### PR TITLE
feat: recency weighting in reranker (v3.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-04-07
+
+### Added
+- Recency weighting in reranker — blends `publishedDate`-based exponential decay score
+  with the cross-encoder relevance score (90-day decay constant, weight 0.15 by default).
+  Surfaces fresher results within relevance-close clusters without overriding large
+  relevance gaps. Configurable via `RERANK_RECENCY_WEIGHT` env var; set to `0` to disable.
+  Skipped automatically when `time_range` is set (pool is already date-filtered).
+
+### Changed
+- Reranker now requests scores for the full result pool rather than only the final topN,
+  enabling post-score re-ordering across all candidates.
+
 ## [3.1.0] - 2026-04-07
 
 ### Added
@@ -91,7 +104,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Result reranking using a local ML model with fallback to raw SearXNG ordering when the reranker is unavailable
 - Category filtering: `general`, `news`, `it`, `science`
 
-[Unreleased]: https://github.com/TadMSTR/searxng-mcp/compare/v3.1.0...HEAD
+[Unreleased]: https://github.com/TadMSTR/searxng-mcp/compare/v3.2.0...HEAD
+[3.2.0]: https://github.com/TadMSTR/searxng-mcp/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/TadMSTR/searxng-mcp/compare/v3.0.2...v3.1.0
 [3.0.2]: https://github.com/TadMSTR/searxng-mcp/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/TadMSTR/searxng-mcp/compare/v3.0.0...v3.0.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-mcp",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "MCP server for SearXNG — private web search for Claude Code",
   "main": "build/src/index.js",
   "type": "module",

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,3 +10,6 @@ export const OLLAMA_URL = process.env.OLLAMA_URL ?? "";
 export const EXPAND_QUERIES_DEFAULT = process.env.EXPAND_QUERIES === "true";
 export const CRAWL4AI_URL = process.env.CRAWL4AI_URL ?? null;
 export const CRAWL4AI_API_TOKEN = process.env.CRAWL4AI_API_TOKEN;
+export const RERANK_RECENCY_WEIGHT = parseFloat(
+  process.env.RERANK_RECENCY_WEIGHT ?? "0.15"
+);

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,14 @@ export const OLLAMA_URL = process.env.OLLAMA_URL ?? "";
 export const EXPAND_QUERIES_DEFAULT = process.env.EXPAND_QUERIES === "true";
 export const CRAWL4AI_URL = process.env.CRAWL4AI_URL ?? null;
 export const CRAWL4AI_API_TOKEN = process.env.CRAWL4AI_API_TOKEN;
-export const RERANK_RECENCY_WEIGHT = parseFloat(
-  process.env.RERANK_RECENCY_WEIGHT ?? "0.15"
-);
+export const RERANK_RECENCY_WEIGHT = (() => {
+  const v = parseFloat(process.env.RERANK_RECENCY_WEIGHT ?? "0.15");
+  if (isNaN(v) || v < 0) {
+    console.warn(`[searxng-mcp] RERANK_RECENCY_WEIGHT="${process.env.RERANK_RECENCY_WEIGHT}" is invalid; recency weighting disabled.`);
+    return 0;
+  }
+  if (v > 1) {
+    console.warn(`[searxng-mcp] RERANK_RECENCY_WEIGHT=${v} exceeds 1.0; recency may dominate relevance scores.`);
+  }
+  return v;
+})();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { registerTools } from "./tools.js";
 
 const server = new McpServer({
   name: "searxng-mcp",
-  version: "3.1.0",
+  version: "3.2.0",
 });
 
 registerTools(server);

--- a/src/reranker.ts
+++ b/src/reranker.ts
@@ -1,10 +1,21 @@
-import { RERANKER_URL } from "./config.js";
+import { RERANKER_URL, RERANK_RECENCY_WEIGHT } from "./config.js";
 import type { SearxResult, RerankResponse } from "./types.js";
+
+/** Exponential decay recency score. Returns 0 for missing/unparseable dates. */
+export function recencyScore(date?: string): number {
+  if (!date) return 0;
+  const ms = Date.parse(date);
+  if (isNaN(ms)) return 0;
+  const ageDays = (Date.now() - ms) / 86_400_000;
+  if (ageDays < 0) return 0; // future dates treated as neutral
+  return Math.exp(-ageDays / 90);
+}
 
 async function rerank(
   query: string,
   results: SearxResult[],
-  topN: number
+  topN: number,
+  applyRecency: boolean
 ): Promise<SearxResult[]> {
   if (results.length === 0) return results;
 
@@ -15,7 +26,10 @@ async function rerank(
   const res = await fetch(`${RERANKER_URL}/v1/rerank`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ query, documents, top_n: topN }),
+    // Request scores for the full pool so the recency re-sort has all candidates.
+    // FlashRank scores all documents regardless of top_n — this is a return-count
+    // change only, not a compute change.
+    body: JSON.stringify({ query, documents, top_n: results.length }),
     signal: AbortSignal.timeout(5000),
   });
 
@@ -24,18 +38,31 @@ async function rerank(
   }
 
   const data = (await res.json()) as RerankResponse;
-  return data.results
+
+  const scored = data.results
     .filter((r) => r.index >= 0 && r.index < results.length)
-    .map((r) => results[r.index]);
+    .map((r) => {
+      const result = results[r.index];
+      const combined =
+        applyRecency && RERANK_RECENCY_WEIGHT > 0
+          ? r.relevance_score + RERANK_RECENCY_WEIGHT * recencyScore(result.publishedDate)
+          : r.relevance_score;
+      return { result, score: combined };
+    });
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, topN).map((s) => s.result);
 }
 
 export async function rerankWithFallback(
   query: string,
   results: SearxResult[],
-  topN: number
+  topN: number,
+  timeRange?: string
 ): Promise<SearxResult[]> {
+  const applyRecency = !timeRange; // skip when caller already filtered by date
   try {
-    return await rerank(query, results, topN);
+    return await rerank(query, results, topN, applyRecency);
   } catch {
     // Reranker unavailable — fall back to SearXNG order
     return results.slice(0, topN);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -53,7 +53,7 @@ export function registerTools(server: McpServer): void {
     },
     async ({ query, num_results, category, time_range, domain_profile, expand }) => {
       const raw = await searxSearch(query, category, num_results, time_range, domain_profile, expand);
-      const ranked = await rerankWithFallback(query, raw, num_results);
+      const ranked = await rerankWithFallback(query, raw, num_results, time_range);
       return { content: [{ type: "text", text: formatResults(ranked) }] };
     }
   );
@@ -89,7 +89,7 @@ export function registerTools(server: McpServer): void {
         return { content: [{ type: "text", text: "No results found." }] };
       }
 
-      const ranked = await rerankWithFallback(query, raw, 5);
+      const ranked = await rerankWithFallback(query, raw, 5, time_range);
       const searchText = formatResults(ranked);
 
       // Divide the 8000-char budget evenly across fetched pages
@@ -161,7 +161,7 @@ export function registerTools(server: McpServer): void {
         return { content: [{ type: "text", text: "No results found." }] };
       }
 
-      const ranked = await rerankWithFallback(query, raw, fetch_count);
+      const ranked = await rerankWithFallback(query, raw, fetch_count, time_range);
       const searchText = formatResults(ranked);
 
       // Fetch top N pages; 4000 chars each (summarizer doesn't need the full 8000)

--- a/tests/reranker.test.ts
+++ b/tests/reranker.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { recencyScore } from "../src/reranker.js";
+
+describe("recencyScore", () => {
+  it("returns 1.0 for today", () => {
+    const today = new Date().toISOString();
+    expect(recencyScore(today)).toBeCloseTo(1.0, 2);
+  });
+
+  it("returns ~0.93 for 1 week ago", () => {
+    const d = new Date(Date.now() - 7 * 86_400_000).toISOString();
+    expect(recencyScore(d)).toBeCloseTo(Math.exp(-7 / 90), 3);
+  });
+
+  it("returns ~0.37 for 90 days ago (1/e decay point)", () => {
+    const d = new Date(Date.now() - 90 * 86_400_000).toISOString();
+    expect(recencyScore(d)).toBeCloseTo(Math.exp(-1), 2);
+  });
+
+  it("returns ~0.06 for 1 year ago", () => {
+    const d = new Date(Date.now() - 365 * 86_400_000).toISOString();
+    expect(recencyScore(d)).toBeCloseTo(Math.exp(-365 / 90), 3);
+  });
+
+  it("returns 0 for undefined", () => {
+    expect(recencyScore(undefined)).toBe(0);
+  });
+
+  it("returns 0 for empty string", () => {
+    expect(recencyScore("")).toBe(0);
+  });
+
+  it("returns 0 for unparseable date", () => {
+    expect(recencyScore("not-a-date")).toBe(0);
+  });
+
+  it("returns 0 for future date", () => {
+    const future = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    expect(recencyScore(future)).toBe(0);
+  });
+
+  it("scores decrease monotonically with age", () => {
+    const week = recencyScore(new Date(Date.now() - 7 * 86_400_000).toISOString());
+    const month = recencyScore(new Date(Date.now() - 30 * 86_400_000).toISOString());
+    const year = recencyScore(new Date(Date.now() - 365 * 86_400_000).toISOString());
+    expect(week).toBeGreaterThan(month);
+    expect(month).toBeGreaterThan(year);
+    expect(year).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Blends `publishedDate`-based exponential decay with the cross-encoder relevance score to surface fresher results within relevance-close clusters.

- Formula: `finalScore = relevanceScore + 0.15 * exp(-ageDays / 90)`
- Skipped automatically when `time_range` is set — pool is already date-filtered
- `RERANK_RECENCY_WEIGHT` env var controls blend strength (default 0.15, set to 0 to disable)
- 9 new tests for `recencyScore()`

Security audit: clean (no findings).