### PR TITLE
chore: polish — CI/CD, badges, security docs, AGENTS.md, Biome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test (Node.js ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20", "22"]
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install pnpm
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm exec tsc --noEmit
+
+      - name: Run tests
+        run: pnpm test
+
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+
+      - name: Install pnpm
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Audit dependencies
+        run: pnpm audit --prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Type check
         run: pnpm exec tsc --noEmit
 
+      - name: Lint
+        run: pnpm lint
+
       - name: Run tests
         run: pnpm test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+
+      - name: Install pnpm
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Package tarball
+        run: pnpm pack
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: package
+          path: "*.tgz"
+
+  create-github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Download package artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: package
+          path: dist/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release create "${TAG_NAME}" \
+            dist/*.tgz \
+            --title "${TAG_NAME}" \
+            --generate-notes \
+            --verify-tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,63 +5,73 @@ promoted: null
 
 # AGENTS.md — searxng-mcp
 
-MCP server that wraps a self-hosted SearXNG instance with optional reranking and full-page fetching via Firecrawl.
+MCP server for private web search via a self-hosted SearXNG instance. Reranks results with a local ML model, fetches full-page content via a three-tier cascade (Firecrawl → Crawl4AI → raw HTTP), and optionally expands queries and synthesizes summaries via Ollama.
 
 ## What it does
 
-Exposes three MCP tools:
+Exposes five MCP tools:
 
-- **`search`** — queries SearXNG, reranks results with a local ML model, returns top N structured results (title, URL, snippet, source engine, date)
-- **`search_and_fetch`** — same as `search` but also fetches and extracts the full text of the top result via Firecrawl
-- **`fetch_url`** — fetches and extracts readable markdown from any public URL via Firecrawl
+- **`search`** — queries SearXNG, reranks results with a local ML model, returns top N structured results
+- **`search_and_fetch`** — same as `search` but also fetches full content of the top result(s) via the fetch cascade
+- **`search_and_summarize`** — search, fetch, then synthesize a summary with citations via Ollama (qwen3:14b)
+- **`fetch_url`** — fetch and extract readable markdown from any public URL; GitHub URLs use the GitHub API
+- **`clear_cache`** — purge the Valkey result cache (search, fetch, or both)
 
 ## Structure
 
 ```
 src/
-  index.ts     # All server logic — tools, SearXNG/Firecrawl/reranker clients, URL safety
-tsconfig.json
-package.json
+  index.ts        # Entry point — creates MCP server, registers tools
+  tools.ts        # Tool definitions (schemas + handlers)
+  search.ts       # SearXNG client
+  fetch.ts        # Fetch cascade (Firecrawl → Crawl4AI → raw HTTP) + GitHub API
+  reranker.ts     # Jina-compatible reranker client + recency weighting
+  ollama.ts       # Ollama client (query expansion + summarization)
+  cache.ts        # Valkey/Redis caching layer
+  domains.ts      # Domain boost/block filtering + profiles
+  config.ts       # Environment variable configuration
+  types.ts        # Shared type definitions
+tests/
+  *.test.ts       # Vitest unit tests (50 tests across 5 files)
 ```
 
 ## Dependencies
 
-Requires three local services:
+Required services:
 
-| Service | Default URL | Purpose |
+| Service | Env var | Purpose |
 |---|---|---|
-| SearXNG | `http://localhost:8081` | Meta-search engine |
-| Firecrawl | `http://localhost:3002` | JS-aware page scraping |
-| Reranker | `http://localhost:8787` | ML relevance reranking |
+| SearXNG | `SEARXNG_URL` | Meta-search engine |
+| Firecrawl | `FIRECRAWL_URL` | JS-aware page scraping (tier 1) |
 
-Reranking is optional — if the reranker is unavailable, results fall back to SearXNG's native order.
+Optional services (server degrades gracefully without these):
+
+| Service | Env var | Purpose |
+|---|---|---|
+| Reranker | `RERANKER_URL` | ML relevance reranking |
+| Crawl4AI | `CRAWL4AI_URL` | Fetch fallback for bot-blocked pages (tier 2) |
+| Valkey/Redis | `VALKEY_URL` | Result caching |
+| Ollama | `OLLAMA_URL` | Query expansion + summarization |
 
 ## Build and run
 
 ```bash
 pnpm install
-pnpm run build       # tsc → build/
-node build/index.js
+pnpm build        # tsc → build/
+node build/src/index.js
 ```
 
 Transport: stdio (MCP standard).
 
-## Wiring into a Claude config
+## Testing
 
-```json
-{
-  "mcpServers": {
-    "searxng": {
-      "command": "node",
-      "args": ["/path/to/searxng-mcp/build/index.js"]
-    }
-  }
-}
+```bash
+pnpm test         # vitest run --typecheck
 ```
 
 ## URL safety
 
-`fetch_url` and `search_and_fetch` block requests to private/internal IP ranges (localhost, RFC1918, link-local). Do not remove this check — it prevents SSRF against internal services.
+`fetch_url` and `search_and_fetch` block requests to private/internal IP ranges (localhost, RFC1918, link-local, IPv6 private). Redirects to internal addresses are also blocked. Do not remove these checks — they prevent SSRF against internal services.
 
 ## Git workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.2.1] - 2026-04-19
+
+### Added
+- GitHub Actions CI workflow — Node.js 20/22 matrix, type-check, Biome lint, Vitest tests, `pnpm audit --prod` (SHA-pinned actions)
+- GitHub Actions release workflow — tag-triggered, builds + tests + `pnpm pack`, creates GitHub Release with tarball attached
+- Biome linter (`biome.json`) — single-binary TypeScript linter and formatter; `pnpm lint` / `pnpm lint:fix` scripts
+- Security section in README — consolidates SSRF/URL safety, redirect protection (v3.1.0 feature, previously undocumented in README), dependency auditing, credential handling, input validation
+
+### Changed
+- `package.json` — added `packageManager` (pnpm@10.30.3), `engines` (node >=20), `files` (clean tarball scope) fields
+- README — Claude Code, CI, and License badges in header; Node.js prerequisite updated from 22+ to 20+; provenance note linking to homelab-agent
+- AGENTS.md — full rewrite to reflect current 5-tool / 9-module architecture (was stale: 3 tools, single-file structure)
+
+### Fixed
+- `src/domains.ts`, `src/reranker.ts`, `src/config.ts`, `src/fetch.ts` — `Number.isNaN` instead of global `isNaN`, template literals, literal key access, unused variable prefix
+
 ## [3.2.0] - 2026-04-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ An MCP server for private web search via a self-hosted [SearXNG](https://github.
 
 Designed for use with Claude Code and LibreChat agents that need web search without sending queries to a third-party search API.
 
+Built with [Claude Code](https://claude.ai/code) using the multi-agent workflow from [homelab-agent](https://github.com/TadMSTR/homelab-agent) — the same platform that uses searxng-mcp in production for AI-assisted research.
+
 ## Tools
 
 | Tool | Description | Key Parameters |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # searxng-mcp
 
+[![Built with Claude Code](https://img.shields.io/badge/Built_with-Claude_Code-6B57FF?logo=claude&logoColor=white)](https://claude.ai/code)
+[![CI](https://github.com/TadMSTR/searxng-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/TadMSTR/searxng-mcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 An MCP server for private web search via a self-hosted [SearXNG](https://github.com/searxng/searxng) instance. Results are reranked by a local ML model, full-page content is fetched via Firecrawl, and an optional Ollama instance provides query expansion and LLM-synthesized summaries.
 
 Designed for use with Claude Code and LibreChat agents that need web search without sending queries to a third-party search API.
@@ -55,7 +59,7 @@ stdio (compatible with Claude Code MCP plugin and LibreChat `stdio` config).
 
 ## Prerequisites
 
-- Node.js 22+
+- Node.js 20+
 - pnpm (or npm)
 - A running [SearXNG](https://github.com/searxng/searxng) instance
 - A running [Firecrawl](https://github.com/mendableai/firecrawl) instance

--- a/README.md
+++ b/README.md
@@ -213,9 +213,27 @@ mcpServers:
 
 Unauthenticated requests are rate-limited to 60/hour. Set `GITHUB_TOKEN` to raise this to 5,000/hour.
 
-## URL Safety
+## Security
+
+### URL safety
 
 The `fetch_url` and `search_and_fetch` tools enforce a URL allowlist — private/internal IP ranges (`10.x`, `192.168.x`, `172.16-31.x`, `localhost`, `127.x`), IPv6 private ranges (`::1`, `fc00::/7`, `fe80::/10`), and non-HTTP protocols are blocked. This prevents the server from being used as an SSRF proxy into your local network.
+
+### Redirect protection
+
+HTTP redirects in raw fetch requests are blocked to prevent SSRF bypass via redirect chains to internal addresses.
+
+### Dependency auditing
+
+CI runs `pnpm audit` on every push. The lockfile (`pnpm-lock.yaml`) is committed for reproducible, auditable builds.
+
+### Credential handling
+
+No credentials are stored or logged by the server. API keys (`FIRECRAWL_API_KEY`, `GITHUB_TOKEN`, `CRAWL4AI_API_TOKEN`) are read from environment variables and used only in outbound requests to their respective services.
+
+### Input validation
+
+Environment variables are validated at startup — `RERANK_RECENCY_WEIGHT` warns on NaN, negative, or >1.0 values. Numeric tool parameters use `z.coerce.number()` with range constraints.
 
 ## License
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "files": {
+    "includes": ["src/**/*.ts", "tests/**/*.ts"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "build": "tsc && chmod 755 build/src/index.js",
     "test": "vitest run --typecheck",
-    "test:watch": "vitest --typecheck"
+    "test:watch": "vitest --typecheck",
+    "lint": "biome check src/ tests/",
+    "lint:fix": "biome check --write src/ tests/"
   },
   "keywords": [
     "searxng",
@@ -17,14 +19,22 @@
   "author": "TadMSTR",
   "license": "MIT",
   "packageManager": "pnpm@10.30.3",
-  "engines": { "node": ">=20" },
-  "files": ["build/src/", "README.md", "LICENSE", "CHANGELOG.md"],
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "build/src/",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.7.0",
     "iovalkey": "^0.3.3",
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.12",
     "@types/node": "^22.13.10",
     "typescript": "^5.8.2",
     "vitest": "^4.1.3"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.7.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "iovalkey": "^0.3.3",
     "zod": "^3.24.2"
   },
@@ -38,5 +38,12 @@
     "@types/node": "^22.13.10",
     "typescript": "^5.8.2",
     "vitest": "^4.1.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "path-to-regexp": ">=8.4.0",
+      "hono": ">=4.12.14",
+      "@hono/node-server": ">=1.19.13"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   ],
   "author": "TadMSTR",
   "license": "MIT",
+  "packageManager": "pnpm@10.30.3",
+  "engines": { "node": ">=20" },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.7.0",
     "iovalkey": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.30.3",
   "engines": { "node": ">=20" },
+  "files": ["build/src/", "README.md", "LICENSE", "CHANGELOG.md"],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.7.0",
     "iovalkey": "^0.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^3.24.2
         version: 3.25.76
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.12
+        version: 2.4.12
       '@types/node':
         specifier: ^22.13.10
         version: 22.19.15
@@ -29,6 +32,63 @@ importers:
         version: 4.1.3(@types/node@22.19.15)(vite@8.0.7(@types/node@22.19.15))
 
 packages:
+
+  '@biomejs/biome@2.4.12':
+    resolution: {integrity: sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.12':
+    resolution: {integrity: sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.12':
+    resolution: {integrity: sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.12':
+    resolution: {integrity: sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.4.12':
+    resolution: {integrity: sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.4.12':
+    resolution: {integrity: sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.4.12':
+    resolution: {integrity: sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.4.12':
+    resolution: {integrity: sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.12':
+    resolution: {integrity: sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
@@ -866,6 +926,41 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@biomejs/biome@2.4.12':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.12
+      '@biomejs/cli-darwin-x64': 2.4.12
+      '@biomejs/cli-linux-arm64': 2.4.12
+      '@biomejs/cli-linux-arm64-musl': 2.4.12
+      '@biomejs/cli-linux-x64': 2.4.12
+      '@biomejs/cli-linux-x64-musl': 2.4.12
+      '@biomejs/cli-win32-arm64': 2.4.12
+      '@biomejs/cli-win32-x64': 2.4.12
+
+  '@biomejs/cli-darwin-arm64@2.4.12':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.12':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.12':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.12':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.12':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.12':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.12':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.12':
+    optional: true
 
   '@emnapi/core@1.9.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  path-to-regexp: '>=8.4.0'
+  hono: '>=4.12.14'
+  '@hono/node-server': '>=1.19.13'
+
 importers:
 
   .:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.7.0
-        version: 1.27.1(zod@3.25.76)
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
       iovalkey:
         specifier: ^0.3.3
         version: 0.3.3
@@ -99,11 +104,11 @@ packages:
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.14'
 
   '@iovalkey/commands@0.1.0':
     resolution: {integrity: sha512-/B9W4qKSSITDii5nkBCHyPkIkAi+ealUtr1oqBJsLxjSRLka4pxun2VvMNSmcwgAMxgXtQfl0qRv7TE+udPJzg==}
@@ -111,8 +116,8 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@modelcontextprotocol/sdk@1.27.1':
-    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -121,8 +126,8 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@napi-rs/wasm-runtime@1.1.2':
-    resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -479,8 +484,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.7:
-    resolution: {integrity: sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -662,8 +667,8 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -679,8 +684,8 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   proxy-addr@2.0.7:
@@ -787,6 +792,10 @@ packages:
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -978,17 +987,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@hono/node-server@1.19.11(hono@4.12.7)':
+  '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
-      hono: 4.12.7
+      hono: 4.12.14
 
   '@iovalkey/commands@0.1.0': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.7)
+      '@hono/node-server': 1.19.14(hono@4.12.14)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -998,7 +1007,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.7
+      hono: 4.12.14
       jose: 6.2.1
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -1008,7 +1017,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
     dependencies:
       '@emnapi/core': 1.9.1
       '@emnapi/runtime': 1.9.1
@@ -1057,7 +1066,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.9.1
       '@emnapi/runtime': 1.9.1
-      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
@@ -1336,7 +1345,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.7: {}
+  hono@4.12.14: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -1473,7 +1482,7 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -1483,7 +1492,7 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  postcss@8.5.8:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -1542,7 +1551,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -1630,6 +1639,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1: {}
@@ -1655,9 +1669,9 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.10
       rolldown: 1.0.0-rc.13
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 22.19.15
       fsevents: 2.3.3

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -7,7 +7,10 @@ let valkey: Valkey | null = null;
 export async function getValkey(): Promise<Valkey | null> {
   if (valkey !== null) return valkey;
   try {
-    const client = new Valkey(VALKEY_URL, { lazyConnect: true, enableReadyCheck: false });
+    const client = new Valkey(VALKEY_URL, {
+      lazyConnect: true,
+      enableReadyCheck: false,
+    });
     client.on("error", () => {
       // Silently disconnect on error — caching is best-effort
       valkey = null;
@@ -20,7 +23,11 @@ export async function getValkey(): Promise<Valkey | null> {
   }
 }
 
-export function searchCacheKey(query: string, category: string, timeRange?: string): string {
+export function searchCacheKey(
+  query: string,
+  category: string,
+  timeRange?: string,
+): string {
   const raw = `${query}|${category}|${timeRange ?? ""}`;
   return `search:${createHash("sha256").update(raw).digest("hex")}`;
 }
@@ -39,7 +46,11 @@ export async function cacheGet(key: string): Promise<string | null> {
   }
 }
 
-export async function cacheSet(key: string, value: string, ttl: number): Promise<void> {
+export async function cacheSet(
+  key: string,
+  value: string,
+  ttl: number,
+): Promise<void> {
   try {
     const client = await getValkey();
     if (!client) return;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,23 +1,35 @@
 export const SEARXNG_URL = process.env.SEARXNG_URL ?? "http://localhost:8081";
-export const FIRECRAWL_URL = process.env.FIRECRAWL_URL ?? "http://localhost:3002";
-export const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY ?? "placeholder-local";
+export const FIRECRAWL_URL =
+  process.env.FIRECRAWL_URL ?? "http://localhost:3002";
+export const FIRECRAWL_API_KEY =
+  process.env.FIRECRAWL_API_KEY ?? "placeholder-local";
 export const RERANKER_URL = process.env.RERANKER_URL ?? "http://localhost:8787";
 export const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 export const VALKEY_URL = process.env.VALKEY_URL ?? "redis://localhost:6381";
-export const CACHE_TTL_SECONDS = parseInt(process.env.CACHE_TTL_SECONDS ?? "3600", 10);
-export const FETCH_CACHE_TTL_SECONDS = parseInt(process.env.FETCH_CACHE_TTL_SECONDS ?? "86400", 10);
+export const CACHE_TTL_SECONDS = parseInt(
+  process.env.CACHE_TTL_SECONDS ?? "3600",
+  10,
+);
+export const FETCH_CACHE_TTL_SECONDS = parseInt(
+  process.env.FETCH_CACHE_TTL_SECONDS ?? "86400",
+  10,
+);
 export const OLLAMA_URL = process.env.OLLAMA_URL ?? "";
 export const EXPAND_QUERIES_DEFAULT = process.env.EXPAND_QUERIES === "true";
 export const CRAWL4AI_URL = process.env.CRAWL4AI_URL ?? null;
 export const CRAWL4AI_API_TOKEN = process.env.CRAWL4AI_API_TOKEN;
 export const RERANK_RECENCY_WEIGHT = (() => {
   const v = parseFloat(process.env.RERANK_RECENCY_WEIGHT ?? "0.15");
-  if (isNaN(v) || v < 0) {
-    console.warn(`[searxng-mcp] RERANK_RECENCY_WEIGHT="${process.env.RERANK_RECENCY_WEIGHT}" is invalid; recency weighting disabled.`);
+  if (Number.isNaN(v) || v < 0) {
+    console.warn(
+      `[searxng-mcp] RERANK_RECENCY_WEIGHT="${process.env.RERANK_RECENCY_WEIGHT}" is invalid; recency weighting disabled.`,
+    );
     return 0;
   }
   if (v > 1) {
-    console.warn(`[searxng-mcp] RERANK_RECENCY_WEIGHT=${v} exceeds 1.0; recency may dominate relevance scores.`);
+    console.warn(
+      `[searxng-mcp] RERANK_RECENCY_WEIGHT=${v} exceeds 1.0; recency may dominate relevance scores.`,
+    );
   }
   return v;
 })();

--- a/src/domains.ts
+++ b/src/domains.ts
@@ -1,9 +1,9 @@
 import { readFileSync, watchFile } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { DomainConfig, SearxResult } from "./types.js";
 
-const BOOST_FACTOR = 1.5;
+const _BOOST_FACTOR = 1.5;
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DOMAINS_PATH = resolve(__dirname, "../../domains.json");
 
@@ -44,11 +44,13 @@ export function urlMatchesDomain(url: string, pattern: string): boolean {
     // Pattern may be "domain.com" or "domain.com/path/prefix"
     if (pattern.includes("/")) {
       const [patDomain, ...patParts] = pattern.split("/");
-      const patPath = "/" + patParts.join("/");
-      return (hostname === patDomain || hostname.endsWith("." + patDomain)) &&
-        pathname.startsWith(patPath);
+      const patPath = `/${patParts.join("/")}`;
+      return (
+        (hostname === patDomain || hostname.endsWith(`.${patDomain}`)) &&
+        pathname.startsWith(patPath)
+      );
     }
-    return hostname === pattern || hostname.endsWith("." + pattern);
+    return hostname === pattern || hostname.endsWith(`.${pattern}`);
   } catch {
     return false;
   }
@@ -56,22 +58,22 @@ export function urlMatchesDomain(url: string, pattern: string): boolean {
 
 export function applyDomainFilters(
   results: SearxResult[],
-  profile?: string
+  profile?: string,
 ): SearxResult[] {
   const blockList = getBlockList(profile);
   const boostList = getBoostList(profile);
 
   // Remove blocked domains
   const filtered = results.filter(
-    (r) => !blockList.some((pat) => urlMatchesDomain(r.url, pat))
+    (r) => !blockList.some((pat) => urlMatchesDomain(r.url, pat)),
   );
 
   // Stable sort: boosted domains float to the top, order within each group preserved
   const boosted = filtered.filter((r) =>
-    boostList.some((pat) => urlMatchesDomain(r.url, pat))
+    boostList.some((pat) => urlMatchesDomain(r.url, pat)),
   );
   const normal = filtered.filter(
-    (r) => !boostList.some((pat) => urlMatchesDomain(r.url, pat))
+    (r) => !boostList.some((pat) => urlMatchesDomain(r.url, pat)),
   );
 
   return [...boosted, ...normal];

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,7 +1,14 @@
-import { FIRECRAWL_URL, FIRECRAWL_API_KEY, GITHUB_TOKEN, CRAWL4AI_URL, CRAWL4AI_API_TOKEN, FETCH_CACHE_TTL_SECONDS } from "./config.js";
-import type { FirecrawlScrapeResponse, GitHubReadmeResponse } from "./types.js";
 import { cacheGet, cacheSet, fetchCacheKey } from "./cache.js";
+import {
+  CRAWL4AI_API_TOKEN,
+  CRAWL4AI_URL,
+  FETCH_CACHE_TTL_SECONDS,
+  FIRECRAWL_API_KEY,
+  FIRECRAWL_URL,
+  GITHUB_TOKEN,
+} from "./config.js";
 import { getBlockList, urlMatchesDomain } from "./domains.js";
+import type { FirecrawlScrapeResponse, GitHubReadmeResponse } from "./types.js";
 
 export function assertPublicUrl(url: string): void {
   const { protocol } = new URL(url);
@@ -31,30 +38,33 @@ export function assertPublicUrl(url: string): void {
 
 async function githubFetch(
   url: string,
-  maxChars = 8000
+  maxChars = 8000,
 ): Promise<{ title: string; url: string; text: string }> {
   const parsed = new URL(url);
   const parts = parsed.pathname.split("/").filter(Boolean);
   // parts: [owner, repo] or [owner, repo, "blob"|"tree", branch, ...path]
 
   const headers: Record<string, string> = {
-    "Accept": "application/vnd.github+json",
+    Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
     "User-Agent": "searxng-mcp",
   };
-  if (GITHUB_TOKEN) headers["Authorization"] = `Bearer ${GITHUB_TOKEN}`;
+  if (GITHUB_TOKEN) headers.Authorization = `Bearer ${GITHUB_TOKEN}`;
 
   if (parts.length >= 4 && parts[2] === "blob") {
     // Rewrite blob URL to raw content
     const [owner, repo, , branch, ...filePath] = parts;
     const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${filePath.join("/")}`;
     const rawHeaders: Record<string, string> = { "User-Agent": "searxng-mcp" };
-    if (GITHUB_TOKEN) rawHeaders["Authorization"] = `Bearer ${GITHUB_TOKEN}`;
+    if (GITHUB_TOKEN) rawHeaders.Authorization = `Bearer ${GITHUB_TOKEN}`;
     const res = await fetch(rawUrl, {
       headers: rawHeaders,
       signal: AbortSignal.timeout(10000),
     });
-    if (!res.ok) throw new Error(`GitHub raw fetch error: ${res.status} ${res.statusText}`);
+    if (!res.ok)
+      throw new Error(
+        `GitHub raw fetch error: ${res.status} ${res.statusText}`,
+      );
     const text = (await res.text()).slice(0, maxChars);
     const fileName = filePath[filePath.length - 1] ?? url;
     return { title: fileName, url: rawUrl, text };
@@ -67,15 +77,18 @@ async function githubFetch(
     headers,
     signal: AbortSignal.timeout(10000),
   });
-  if (!res.ok) throw new Error(`GitHub API error: ${res.status} ${res.statusText}`);
+  if (!res.ok)
+    throw new Error(`GitHub API error: ${res.status} ${res.statusText}`);
   const data = (await res.json()) as GitHubReadmeResponse;
-  const text = Buffer.from(data.content, "base64").toString("utf-8").slice(0, maxChars);
+  const text = Buffer.from(data.content, "base64")
+    .toString("utf-8")
+    .slice(0, maxChars);
   return { title: `${owner}/${repo} — ${data.name}`, url: data.html_url, text };
 }
 
 async function firecrawlScrape(
   url: string,
-  maxChars = 8000
+  maxChars = 8000,
 ): Promise<{ title: string; url: string; text: string }> {
   const res = await fetch(`${FIRECRAWL_URL}/v1/scrape`, {
     method: "POST",
@@ -107,7 +120,7 @@ async function pollCrawl4aiTask(
   taskId: string,
   url: string,
   maxChars: number,
-  signal: AbortSignal
+  signal: AbortSignal,
 ): Promise<{ title: string; url: string; text: string } | null> {
   const deadline = Date.now() + 40_000;
 
@@ -119,7 +132,7 @@ async function pollCrawl4aiTask(
       const resp = await fetch(`${CRAWL4AI_URL}/task/${taskId}`, { signal });
       if (!resp.ok) return null;
 
-      const data = await resp.json() as Record<string, unknown>;
+      const data = (await resp.json()) as Record<string, unknown>;
       if (data.status === "completed") {
         const result = data.result as Record<string, unknown> | null;
         const md = result?.markdown as Record<string, string> | null;
@@ -137,7 +150,7 @@ async function pollCrawl4aiTask(
 
 async function crawl4aiFetch(
   url: string,
-  maxChars = 8000
+  maxChars = 8000,
 ): Promise<{ title: string; url: string; text: string } | null> {
   if (!CRAWL4AI_URL) return null;
 
@@ -145,8 +158,11 @@ async function crawl4aiFetch(
   const timeout = setTimeout(() => controller.abort(), 45_000);
 
   try {
-    const crawlHeaders: Record<string, string> = { "Content-Type": "application/json" };
-    if (CRAWL4AI_API_TOKEN) crawlHeaders["Authorization"] = `Bearer ${CRAWL4AI_API_TOKEN}`;
+    const crawlHeaders: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (CRAWL4AI_API_TOKEN)
+      crawlHeaders.Authorization = `Bearer ${CRAWL4AI_API_TOKEN}`;
     const resp = await fetch(`${CRAWL4AI_URL}/crawl`, {
       method: "POST",
       headers: crawlHeaders,
@@ -155,7 +171,7 @@ async function crawl4aiFetch(
     });
 
     if (!resp.ok) return null;
-    const data = await resp.json() as Record<string, unknown>;
+    const data = (await resp.json()) as Record<string, unknown>;
 
     // Synchronous response — results returned directly
     if (Array.isArray(data.results) && data.results.length > 0) {
@@ -169,7 +185,12 @@ async function crawl4aiFetch(
     // Asynchronous response — poll for completion
     if (typeof data.task_id === "string") {
       if (!/^[a-zA-Z0-9_-]{1,64}$/.test(data.task_id)) return null;
-      return await pollCrawl4aiTask(data.task_id, url, maxChars, controller.signal);
+      return await pollCrawl4aiTask(
+        data.task_id,
+        url,
+        maxChars,
+        controller.signal,
+      );
     }
 
     return null;
@@ -182,7 +203,7 @@ async function crawl4aiFetch(
 
 async function rawFetch(
   url: string,
-  maxChars = 8000
+  maxChars = 8000,
 ): Promise<{ title: string; url: string; text: string }> {
   const res = await fetch(url, {
     headers: { "User-Agent": "Mozilla/5.0 (compatible; searxng-mcp/1.0)" },
@@ -191,9 +212,12 @@ async function rawFetch(
   });
 
   if (res.status >= 300 && res.status < 400) {
-    throw new Error(`Redirect blocked: ${res.status} → ${res.headers.get("location")}`);
+    throw new Error(
+      `Redirect blocked: ${res.status} → ${res.headers.get("location")}`,
+    );
   }
-  if (!res.ok) throw new Error(`Raw fetch error: ${res.status} ${res.statusText}`);
+  if (!res.ok)
+    throw new Error(`Raw fetch error: ${res.status} ${res.statusText}`);
 
   const text = (await res.text()).slice(0, maxChars);
   return { title: url, url, text };
@@ -202,7 +226,7 @@ async function rawFetch(
 export async function fetchPage(
   url: string,
   maxChars = 8000,
-  domainProfile?: string
+  domainProfile?: string,
 ): Promise<{ title: string; url: string; text: string }> {
   assertPublicUrl(url);
 
@@ -244,7 +268,7 @@ export async function fetchPage(
     }
 
     // Tier 3: Raw HTTP fetch
-    result = fetched ?? await rawFetch(url, maxChars);
+    result = fetched ?? (await rawFetch(url, maxChars));
   }
 
   await cacheSet(key, JSON.stringify(result), FETCH_CACHE_TTL_SECONDS);

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -1,5 +1,10 @@
 import { OLLAMA_URL } from "./config.js";
-import type { OllamaGenerateResponse, OllamaChatResponse, Citation, SummaryResult } from "./types.js";
+import type {
+  Citation,
+  OllamaChatResponse,
+  OllamaGenerateResponse,
+  SummaryResult,
+} from "./types.js";
 
 export async function expandQuery(query: string): Promise<string[]> {
   if (!OLLAMA_URL) return [];
@@ -42,7 +47,7 @@ export async function expandQuery(query: string): Promise<string[]> {
 
 export async function summarizePages(
   query: string,
-  pages: Array<{ title: string; url: string; text: string }>
+  pages: Array<{ title: string; url: string; text: string }>,
 ): Promise<SummaryResult> {
   if (!OLLAMA_URL) return { summary: "", citations: [] };
   if (pages.length === 0) {
@@ -51,8 +56,9 @@ export async function summarizePages(
 
   const MAX_CHARS_PER_PAGE = 4000;
   const pageBlocks = pages
-    .map((p, i) =>
-      `[Source ${i + 1}] ${p.title}\nURL: ${p.url}\n\n${p.text.slice(0, MAX_CHARS_PER_PAGE)}`
+    .map(
+      (p, i) =>
+        `[Source ${i + 1}] ${p.title}\nURL: ${p.url}\n\n${p.text.slice(0, MAX_CHARS_PER_PAGE)}`,
     )
     .join("\n\n---\n\n");
 
@@ -85,7 +91,9 @@ export async function summarizePages(
     if (!res.ok) throw new Error(`Ollama error: ${res.status}`);
 
     const data = (await res.json()) as OllamaChatResponse;
-    const raw = (data.message.content.match(/\{[\s\S]*\}/) ?? [data.message.content])[0];
+    const raw = (data.message.content.match(/\{[\s\S]*\}/) ?? [
+      data.message.content,
+    ])[0];
     const parsed = JSON.parse(raw) as SummaryResult;
     return {
       summary: parsed.summary ?? "",

--- a/src/reranker.ts
+++ b/src/reranker.ts
@@ -1,11 +1,11 @@
-import { RERANKER_URL, RERANK_RECENCY_WEIGHT } from "./config.js";
-import type { SearxResult, RerankResponse } from "./types.js";
+import { RERANK_RECENCY_WEIGHT, RERANKER_URL } from "./config.js";
+import type { RerankResponse, SearxResult } from "./types.js";
 
 /** Exponential decay recency score. Returns 0 for missing/unparseable dates. */
 export function recencyScore(date?: string): number {
   if (!date) return 0;
   const ms = Date.parse(date);
-  if (isNaN(ms)) return 0;
+  if (Number.isNaN(ms)) return 0;
   const ageDays = (Date.now() - ms) / 86_400_000;
   if (ageDays < 0) return 0; // future dates treated as neutral
   return Math.exp(-ageDays / 90);
@@ -15,13 +15,11 @@ async function rerank(
   query: string,
   results: SearxResult[],
   topN: number,
-  applyRecency: boolean
+  applyRecency: boolean,
 ): Promise<SearxResult[]> {
   if (results.length === 0) return results;
 
-  const documents = results.map(
-    (r) => `${r.title}. ${r.content ?? ""}`.trim()
-  );
+  const documents = results.map((r) => `${r.title}. ${r.content ?? ""}`.trim());
 
   const res = await fetch(`${RERANKER_URL}/v1/rerank`, {
     method: "POST",
@@ -45,7 +43,8 @@ async function rerank(
       const result = results[r.index];
       const combined =
         applyRecency && RERANK_RECENCY_WEIGHT > 0
-          ? r.relevance_score + RERANK_RECENCY_WEIGHT * recencyScore(result.publishedDate)
+          ? r.relevance_score +
+            RERANK_RECENCY_WEIGHT * recencyScore(result.publishedDate)
           : r.relevance_score;
       return { result, score: combined };
     });
@@ -58,7 +57,7 @@ export async function rerankWithFallback(
   query: string,
   results: SearxResult[],
   topN: number,
-  timeRange?: string
+  timeRange?: string,
 ): Promise<SearxResult[]> {
   const applyRecency = !timeRange; // skip when caller already filtered by date
   try {

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,14 +1,18 @@
-import { SEARXNG_URL, CACHE_TTL_SECONDS, EXPAND_QUERIES_DEFAULT } from "./config.js";
-import type { SearxResult, SearxResponse } from "./types.js";
 import { cacheGet, cacheSet, searchCacheKey } from "./cache.js";
+import {
+  CACHE_TTL_SECONDS,
+  EXPAND_QUERIES_DEFAULT,
+  SEARXNG_URL,
+} from "./config.js";
 import { applyDomainFilters } from "./domains.js";
 import { expandQuery } from "./ollama.js";
+import type { SearxResponse, SearxResult } from "./types.js";
 
 export async function searxSearchSingle(
   query: string,
   category: string,
   fetchCount: number,
-  timeRange?: string
+  timeRange?: string,
 ): Promise<SearxResult[]> {
   const params = new URLSearchParams({
     q: query,
@@ -21,7 +25,8 @@ export async function searxSearchSingle(
   const res = await fetch(`${SEARXNG_URL}/search?${params}`, {
     signal: AbortSignal.timeout(10000),
   });
-  if (!res.ok) throw new Error(`SearXNG error: ${res.status} ${res.statusText}`);
+  if (!res.ok)
+    throw new Error(`SearXNG error: ${res.status} ${res.statusText}`);
 
   const data = (await res.json()) as SearxResponse;
   return data.results.slice(0, fetchCount);
@@ -33,7 +38,7 @@ export async function searxSearch(
   numResults: number,
   timeRange?: string,
   domainProfile?: string,
-  expand?: boolean
+  expand?: boolean,
 ): Promise<SearxResult[]> {
   const shouldExpand = expand ?? EXPAND_QUERIES_DEFAULT;
 
@@ -61,19 +66,27 @@ export async function searxSearch(
     ]);
 
     const variantResults = await Promise.allSettled(
-      variants.map((v) => searxSearchSingle(v, category, fetchCount, timeRange))
+      variants.map((v) =>
+        searxSearchSingle(v, category, fetchCount, timeRange),
+      ),
     );
 
     // Merge: original results first, then variant results; deduplicate by URL
     const seen = new Set<string>();
     const merged: SearxResult[] = [];
     for (const r of originalResults) {
-      if (!seen.has(r.url)) { seen.add(r.url); merged.push(r); }
+      if (!seen.has(r.url)) {
+        seen.add(r.url);
+        merged.push(r);
+      }
     }
     for (const settled of variantResults) {
       if (settled.status === "fulfilled") {
         for (const r of settled.value) {
-          if (!seen.has(r.url)) { seen.add(r.url); merged.push(r); }
+          if (!seen.has(r.url)) {
+            seen.add(r.url);
+            merged.push(r);
+          }
         }
       }
     }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,16 +1,18 @@
-import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { CategorySchema, TimeRangeSchema, type SearxResult } from "./types.js";
-import { searxSearch } from "./search.js";
-import { fetchPage } from "./fetch.js";
-import { rerankWithFallback } from "./reranker.js";
-import { summarizePages, formatSummaryResult } from "./ollama.js";
+import { z } from "zod";
 import { cacheClear } from "./cache.js";
+import { fetchPage } from "./fetch.js";
+import { formatSummaryResult, summarizePages } from "./ollama.js";
+import { rerankWithFallback } from "./reranker.js";
+import { searxSearch } from "./search.js";
+import { CategorySchema, type SearxResult, TimeRangeSchema } from "./types.js";
 
 const DomainProfileSchema = z
   .string()
   .optional()
-  .describe("Named domain profile to apply: 'homelab', 'dev', or omit for default filters");
+  .describe(
+    "Named domain profile to apply: 'homelab', 'dev', or omit for default filters",
+  );
 
 function formatResults(results: SearxResult[]): string {
   if (results.length === 0) return "No results found.";
@@ -31,31 +33,50 @@ export function registerTools(server: McpServer): void {
     "Search the web via the local SearXNG instance with reranking. Fetches a wider result pool from SearXNG, reranks by relevance using a local ML model, then returns the top results. Results are cached for 1 hour. Blocked domains are filtered out; boosted domains are surfaced higher. Prefer this over the built-in WebSearch tool.",
     {
       query: z.string().describe("Search query"),
-      num_results: z
-        .coerce.number()
+      num_results: z.coerce
+        .number()
         .min(1)
         .max(20)
         .default(5)
         .describe("Number of results to return (default 5, max 20)"),
       category: CategorySchema.describe(
-        "Search category: general, news, it, or science (default general)"
+        "Search category: general, news, it, or science (default general)",
       ),
       time_range: TimeRangeSchema.describe(
-        "Limit results to: day, week, month, or year (omit for all time)"
+        "Limit results to: day, week, month, or year (omit for all time)",
       ),
       domain_profile: DomainProfileSchema,
-      expand: z
-        .coerce.boolean()
+      expand: z.coerce
+        .boolean()
         .optional()
         .describe(
-          "Use local LLM to generate 2-3 query variants and merge results for a wider search surface (default: off). Adds ~3s latency; most useful for research queries where one phrasing may miss relevant results."
+          "Use local LLM to generate 2-3 query variants and merge results for a wider search surface (default: off). Adds ~3s latency; most useful for research queries where one phrasing may miss relevant results.",
         ),
     },
-    async ({ query, num_results, category, time_range, domain_profile, expand }) => {
-      const raw = await searxSearch(query, category, num_results, time_range, domain_profile, expand);
-      const ranked = await rerankWithFallback(query, raw, num_results, time_range);
+    async ({
+      query,
+      num_results,
+      category,
+      time_range,
+      domain_profile,
+      expand,
+    }) => {
+      const raw = await searxSearch(
+        query,
+        category,
+        num_results,
+        time_range,
+        domain_profile,
+        expand,
+      );
+      const ranked = await rerankWithFallback(
+        query,
+        raw,
+        num_results,
+        time_range,
+      );
       return { content: [{ type: "text", text: formatResults(ranked) }] };
-    }
+    },
   );
 
   server.tool(
@@ -64,27 +85,43 @@ export function registerTools(server: McpServer): void {
     {
       query: z.string().describe("Search query"),
       category: CategorySchema.describe(
-        "Search category: general, news, it, or science (default general)"
+        "Search category: general, news, it, or science (default general)",
       ),
       time_range: TimeRangeSchema.describe(
-        "Limit results to: day, week, month, or year (omit for all time)"
+        "Limit results to: day, week, month, or year (omit for all time)",
       ),
-      fetch_count: z
-        .coerce.number()
+      fetch_count: z.coerce
+        .number()
         .min(1)
         .max(3)
         .default(1)
-        .describe("Number of top results to fetch full content for (default 1, max 3)"),
+        .describe(
+          "Number of top results to fetch full content for (default 1, max 3)",
+        ),
       domain_profile: DomainProfileSchema,
-      expand: z
-        .coerce.boolean()
+      expand: z.coerce
+        .boolean()
         .optional()
         .describe(
-          "Use local LLM to generate 2-3 query variants and merge results for a wider search surface (default: off). Adds ~3s latency."
+          "Use local LLM to generate 2-3 query variants and merge results for a wider search surface (default: off). Adds ~3s latency.",
         ),
     },
-    async ({ query, category, time_range, fetch_count, domain_profile, expand }) => {
-      const raw = await searxSearch(query, category, 5, time_range, domain_profile, expand);
+    async ({
+      query,
+      category,
+      time_range,
+      fetch_count,
+      domain_profile,
+      expand,
+    }) => {
+      const raw = await searxSearch(
+        query,
+        category,
+        5,
+        time_range,
+        domain_profile,
+        expand,
+      );
       if (raw.length === 0) {
         return { content: [{ type: "text", text: "No results found." }] };
       }
@@ -97,7 +134,7 @@ export function registerTools(server: McpServer): void {
       const toFetch = ranked.slice(0, fetch_count);
 
       const fetched = await Promise.allSettled(
-        toFetch.map((r) => fetchPage(r.url, maxCharsPerPage, domain_profile))
+        toFetch.map((r) => fetchPage(r.url, maxCharsPerPage, domain_profile)),
       );
 
       const fetchedSections = fetched
@@ -106,14 +143,19 @@ export function registerTools(server: McpServer): void {
             const { title, text } = result.value;
             return `\n\n--- Full content: ${title} ---\n${text}`;
           } else {
-            const err = result.reason instanceof Error ? result.reason.message : String(result.reason);
+            const err =
+              result.reason instanceof Error
+                ? result.reason.message
+                : String(result.reason);
             return `\n\n--- Could not fetch result ${i + 1}: ${err} ---`;
           }
         })
         .join("");
 
-      return { content: [{ type: "text", text: searchText + fetchedSections }] };
-    }
+      return {
+        content: [{ type: "text", text: searchText + fetchedSections }],
+      };
+    },
   );
 
   server.tool(
@@ -124,12 +166,16 @@ export function registerTools(server: McpServer): void {
       domain_profile: DomainProfileSchema,
     },
     async ({ url, domain_profile }) => {
-      const { title, url: fetchedUrl, text } = await fetchPage(url, 8000, domain_profile);
+      const {
+        title,
+        url: fetchedUrl,
+        text,
+      } = await fetchPage(url, 8000, domain_profile);
       const output = [`Title: ${title}`, `URL: ${fetchedUrl}`, "", text].join(
-        "\n"
+        "\n",
       );
       return { content: [{ type: "text", text: output }] };
-    }
+    },
   );
 
   server.tool(
@@ -137,42 +183,65 @@ export function registerTools(server: McpServer): void {
     "Search, rerank, fetch top results, then synthesize a summary with citations using a local LLM (qwen3:14b). Returns a structured answer with source attribution. Falls back to raw fetched content if Ollama is unavailable. Best for deep research where you want pre-digested synthesis rather than raw pages.",
     {
       query: z.string().describe("Research query to search for and summarize"),
-      fetch_count: z
-        .coerce.number()
+      fetch_count: z.coerce
+        .number()
         .min(1)
         .max(5)
         .default(3)
-        .describe("Number of top results to fetch and synthesize (default 3, max 5)"),
+        .describe(
+          "Number of top results to fetch and synthesize (default 3, max 5)",
+        ),
       category: CategorySchema.describe(
-        "Search category: general, news, it, or science (default general)"
+        "Search category: general, news, it, or science (default general)",
       ),
       time_range: TimeRangeSchema.describe(
-        "Limit results to: day, week, month, or year (omit for all time)"
+        "Limit results to: day, week, month, or year (omit for all time)",
       ),
       domain_profile: DomainProfileSchema,
-      expand: z
-        .coerce.boolean()
+      expand: z.coerce
+        .boolean()
         .optional()
         .describe("Use query expansion before searching (default: off)"),
     },
-    async ({ query, fetch_count, category, time_range, domain_profile, expand }) => {
-      const raw = await searxSearch(query, category, fetch_count + 2, time_range, domain_profile, expand);
+    async ({
+      query,
+      fetch_count,
+      category,
+      time_range,
+      domain_profile,
+      expand,
+    }) => {
+      const raw = await searxSearch(
+        query,
+        category,
+        fetch_count + 2,
+        time_range,
+        domain_profile,
+        expand,
+      );
       if (raw.length === 0) {
         return { content: [{ type: "text", text: "No results found." }] };
       }
 
-      const ranked = await rerankWithFallback(query, raw, fetch_count, time_range);
+      const ranked = await rerankWithFallback(
+        query,
+        raw,
+        fetch_count,
+        time_range,
+      );
       const searchText = formatResults(ranked);
 
       // Fetch top N pages; 4000 chars each (summarizer doesn't need the full 8000)
       const toFetch = ranked.slice(0, fetch_count);
       const fetched = await Promise.allSettled(
-        toFetch.map((r) => fetchPage(r.url, 4000, domain_profile))
+        toFetch.map((r) => fetchPage(r.url, 4000, domain_profile)),
       );
 
       const successfulPages = fetched
         .map((r) => (r.status === "fulfilled" ? r.value : null))
-        .filter((r): r is { title: string; url: string; text: string } => r !== null);
+        .filter(
+          (r): r is { title: string; url: string; text: string } => r !== null,
+        );
 
       // Summarize — fall back to search_and_fetch output if Ollama fails
       const summaryResult = await summarizePages(query, successfulPages);
@@ -185,17 +254,22 @@ export function registerTools(server: McpServer): void {
               const { title, text } = result.value;
               return `\n\n--- Full content: ${title} ---\n${text}`;
             } else {
-              const err = result.reason instanceof Error ? result.reason.message : String(result.reason);
+              const err =
+                result.reason instanceof Error
+                  ? result.reason.message
+                  : String(result.reason);
               return `\n\n--- Could not fetch result ${i + 1}: ${err} ---`;
             }
           })
           .join("");
-        return { content: [{ type: "text", text: searchText + fetchedSections }] };
+        return {
+          content: [{ type: "text", text: searchText + fetchedSections }],
+        };
       }
 
       const output = formatSummaryResult(summaryResult);
       return { content: [{ type: "text", text: output }] };
-    }
+    },
   );
 
   server.tool(
@@ -205,7 +279,9 @@ export function registerTools(server: McpServer): void {
       target: z
         .enum(["search", "fetch", "all"])
         .default("all")
-        .describe("Which cache to clear: search results, fetched pages, or all (default all)"),
+        .describe(
+          "Which cache to clear: search results, fetched pages, or all (default all)",
+        ),
     },
     async ({ target }) => {
       let cleared = 0;
@@ -216,8 +292,13 @@ export function registerTools(server: McpServer): void {
         cleared += await cacheClear("fetch:*");
       }
       return {
-        content: [{ type: "text", text: `Cleared ${cleared} cache ${cleared === 1 ? "entry" : "entries"}.` }],
+        content: [
+          {
+            type: "text",
+            text: `Cleared ${cleared} cache ${cleared === 1 ? "entry" : "entries"}.`,
+          },
+        ],
       };
-    }
+    },
   );
 }

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { searchCacheKey, fetchCacheKey } from "../src/cache.js";
+import { describe, expect, it } from "vitest";
+import { fetchCacheKey, searchCacheKey } from "../src/cache.js";
 
 describe("searchCacheKey", () => {
   it("produces a consistent key for the same inputs", () => {

--- a/tests/domains.test.ts
+++ b/tests/domains.test.ts
@@ -1,30 +1,42 @@
-import { describe, it, expect } from "vitest";
-import { urlMatchesDomain, applyDomainFilters } from "../src/domains.js";
+import { describe, expect, it } from "vitest";
+import { applyDomainFilters, urlMatchesDomain } from "../src/domains.js";
 import type { SearxResult } from "../src/types.js";
 
 describe("urlMatchesDomain", () => {
   it("matches exact domain", () => {
-    expect(urlMatchesDomain("https://example.com/page", "example.com")).toBe(true);
+    expect(urlMatchesDomain("https://example.com/page", "example.com")).toBe(
+      true,
+    );
   });
 
   it("matches www-prefixed URL against bare domain pattern", () => {
-    expect(urlMatchesDomain("https://www.example.com/page", "example.com")).toBe(true);
+    expect(
+      urlMatchesDomain("https://www.example.com/page", "example.com"),
+    ).toBe(true);
   });
 
   it("matches subdomain against parent domain", () => {
-    expect(urlMatchesDomain("https://sub.example.com/page", "example.com")).toBe(true);
+    expect(
+      urlMatchesDomain("https://sub.example.com/page", "example.com"),
+    ).toBe(true);
   });
 
   it("does not match unrelated domain", () => {
-    expect(urlMatchesDomain("https://other.com/page", "example.com")).toBe(false);
+    expect(urlMatchesDomain("https://other.com/page", "example.com")).toBe(
+      false,
+    );
   });
 
   it("matches domain + path prefix pattern", () => {
-    expect(urlMatchesDomain("https://example.com/docs/guide", "example.com/docs")).toBe(true);
+    expect(
+      urlMatchesDomain("https://example.com/docs/guide", "example.com/docs"),
+    ).toBe(true);
   });
 
   it("does not match when path prefix does not match", () => {
-    expect(urlMatchesDomain("https://example.com/blog/post", "example.com/docs")).toBe(false);
+    expect(
+      urlMatchesDomain("https://example.com/blog/post", "example.com/docs"),
+    ).toBe(false);
   });
 
   it("returns false for invalid URL", () => {
@@ -39,7 +51,10 @@ describe("applyDomainFilters", () => {
   });
 
   it("removes blocked domains", () => {
-    const results = [makeResult("https://blocked.com/page"), makeResult("https://allowed.com/page")];
+    const results = [
+      makeResult("https://blocked.com/page"),
+      makeResult("https://allowed.com/page"),
+    ];
     const filtered = applyDomainFilters(results, undefined);
     // No block/boost lists loaded from disk in tests — all results pass through
     expect(filtered).toHaveLength(2);

--- a/tests/fetch.test.ts
+++ b/tests/fetch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { assertPublicUrl } from "../src/fetch.js";
 
 describe("assertPublicUrl", () => {
@@ -11,31 +11,45 @@ describe("assertPublicUrl", () => {
   });
 
   it("throws on localhost", () => {
-    expect(() => assertPublicUrl("http://localhost/page")).toThrow("Internal/private addresses are not allowed");
+    expect(() => assertPublicUrl("http://localhost/page")).toThrow(
+      "Internal/private addresses are not allowed",
+    );
   });
 
   it("throws on 127.0.0.1", () => {
-    expect(() => assertPublicUrl("http://127.0.0.1/page")).toThrow("Internal/private addresses are not allowed");
+    expect(() => assertPublicUrl("http://127.0.0.1/page")).toThrow(
+      "Internal/private addresses are not allowed",
+    );
   });
 
   it("throws on 0.0.0.0", () => {
-    expect(() => assertPublicUrl("http://0.0.0.0/page")).toThrow("Internal/private addresses are not allowed");
+    expect(() => assertPublicUrl("http://0.0.0.0/page")).toThrow(
+      "Internal/private addresses are not allowed",
+    );
   });
 
   it("throws on 10.x.x.x", () => {
-    expect(() => assertPublicUrl("http://10.0.0.1/page")).toThrow("Internal/private addresses are not allowed");
+    expect(() => assertPublicUrl("http://10.0.0.1/page")).toThrow(
+      "Internal/private addresses are not allowed",
+    );
   });
 
   it("throws on 192.168.x.x", () => {
-    expect(() => assertPublicUrl("http://192.168.1.1/page")).toThrow("Internal/private addresses are not allowed");
+    expect(() => assertPublicUrl("http://192.168.1.1/page")).toThrow(
+      "Internal/private addresses are not allowed",
+    );
   });
 
   it("throws on 172.16.x.x (RFC 1918 range)", () => {
-    expect(() => assertPublicUrl("http://172.16.0.1/page")).toThrow("Internal/private addresses are not allowed");
+    expect(() => assertPublicUrl("http://172.16.0.1/page")).toThrow(
+      "Internal/private addresses are not allowed",
+    );
   });
 
   it("throws on 172.31.x.x (RFC 1918 range boundary)", () => {
-    expect(() => assertPublicUrl("http://172.31.255.255/page")).toThrow("Internal/private addresses are not allowed");
+    expect(() => assertPublicUrl("http://172.31.255.255/page")).toThrow(
+      "Internal/private addresses are not allowed",
+    );
   });
 
   it("accepts 172.15.x.x (just outside RFC 1918 range)", () => {
@@ -43,30 +57,44 @@ describe("assertPublicUrl", () => {
   });
 
   it("throws on host.docker.internal", () => {
-    expect(() => assertPublicUrl("http://host.docker.internal/page")).toThrow("Internal/private addresses are not allowed");
+    expect(() => assertPublicUrl("http://host.docker.internal/page")).toThrow(
+      "Internal/private addresses are not allowed",
+    );
   });
 
   it("throws on ::1 (IPv6 loopback)", () => {
-    expect(() => assertPublicUrl("http://[::1]/page")).toThrow("Internal/private addresses are not allowed");
+    expect(() => assertPublicUrl("http://[::1]/page")).toThrow(
+      "Internal/private addresses are not allowed",
+    );
   });
 
   it("throws on [0:0:0:0:0:0:0:1] (IPv6 full-form loopback, bracket notation)", () => {
-    expect(() => assertPublicUrl("http://[0:0:0:0:0:0:0:1]/page")).toThrow("Internal/private addresses are not allowed");
+    expect(() => assertPublicUrl("http://[0:0:0:0:0:0:0:1]/page")).toThrow(
+      "Internal/private addresses are not allowed",
+    );
   });
 
   it("throws on [fc00::] (IPv6 ULA fc range, bracket notation)", () => {
-    expect(() => assertPublicUrl("http://[fc00::]/page")).toThrow("Internal/private addresses are not allowed");
+    expect(() => assertPublicUrl("http://[fc00::]/page")).toThrow(
+      "Internal/private addresses are not allowed",
+    );
   });
 
   it("throws on [fd00::] (IPv6 ULA fd range, bracket notation)", () => {
-    expect(() => assertPublicUrl("http://[fd00::]/page")).toThrow("Internal/private addresses are not allowed");
+    expect(() => assertPublicUrl("http://[fd00::]/page")).toThrow(
+      "Internal/private addresses are not allowed",
+    );
   });
 
   it("throws on [fe80::] (IPv6 link-local, bracket notation)", () => {
-    expect(() => assertPublicUrl("http://[fe80::]/page")).toThrow("Internal/private addresses are not allowed");
+    expect(() => assertPublicUrl("http://[fe80::]/page")).toThrow(
+      "Internal/private addresses are not allowed",
+    );
   });
 
   it("throws on non-http protocol", () => {
-    expect(() => assertPublicUrl("ftp://example.com/page")).toThrow("Only http/https URLs are supported");
+    expect(() => assertPublicUrl("ftp://example.com/page")).toThrow(
+      "Only http/https URLs are supported",
+    );
   });
 });

--- a/tests/reranker.test.ts
+++ b/tests/reranker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { recencyScore } from "../src/reranker.js";
 
 describe("recencyScore", () => {
@@ -40,9 +40,15 @@ describe("recencyScore", () => {
   });
 
   it("scores decrease monotonically with age", () => {
-    const week = recencyScore(new Date(Date.now() - 7 * 86_400_000).toISOString());
-    const month = recencyScore(new Date(Date.now() - 30 * 86_400_000).toISOString());
-    const year = recencyScore(new Date(Date.now() - 365 * 86_400_000).toISOString());
+    const week = recencyScore(
+      new Date(Date.now() - 7 * 86_400_000).toISOString(),
+    );
+    const month = recencyScore(
+      new Date(Date.now() - 30 * 86_400_000).toISOString(),
+    );
+    const year = recencyScore(
+      new Date(Date.now() - 365 * 86_400_000).toISOString(),
+    );
     expect(week).toBeGreaterThan(month);
     expect(month).toBeGreaterThan(year);
     expect(year).toBeGreaterThan(0);

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { CategorySchema, TimeRangeSchema } from "../src/types.js";
 
 describe("CategorySchema", () => {


### PR DESCRIPTION
## Summary

- **CI workflow** — Node.js 20/22 matrix, type-check, Vitest, `pnpm audit --prod`. SHA-pinned actions.
- **Release workflow** — tag-triggered, builds + tests + `pnpm pack`, creates GitHub Release with tarball.
- **README badges** — Claude Code, CI, License. Node.js prerequisite updated to 20+.
- **Security section** — consolidates SSRF/URL safety, redirect protection (v3.1.0, was missing from README), dependency auditing, credential handling, input validation.
- **Provenance note** — links to homelab-agent with mutual production reference.
- **AGENTS.md** — updated from stale 3-tool/single-file description to current 5-tool/9-module architecture.
- **Biome linter** — single-binary TS linter added to CI; all findings fixed (`useTemplate`, `Number.isNaN`, unused var, import sorting, formatting).
- `package.json` — added `packageManager`, `engines`, `files` fields.
- `core.942842` (1.2GB core dump) deleted from working directory.

No behavior changes to any tool or search logic.

## Test plan

- [ ] CI runs green on branch (type-check + lint + 50 tests + audit on Node 20 and 22)
- [ ] Three badges render in README header
- [ ] Security section visible with all five subsections
- [ ] AGENTS.md lists all 5 tools and 9 source files
- [ ] `pnpm lint` clean locally

🤖 Generated with [Claude Code](https://claude.ai/code)