### PR TITLE
Add OLLAMA_API_KEY support for authenticated Ollama proxy

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ export const FETCH_CACHE_TTL_SECONDS = parseInt(
   10,
 );
 export const OLLAMA_URL = process.env.OLLAMA_URL ?? "";
+export const OLLAMA_API_KEY = process.env.OLLAMA_API_KEY ?? "";
 export const EXPAND_QUERIES_DEFAULT = process.env.EXPAND_QUERIES === "true";
 export const CRAWL4AI_URL = process.env.CRAWL4AI_URL ?? null;
 export const CRAWL4AI_API_TOKEN = process.env.CRAWL4AI_API_TOKEN;

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -1,4 +1,4 @@
-import { OLLAMA_URL } from "./config.js";
+import { OLLAMA_URL, OLLAMA_API_KEY } from "./config.js";
 import type {
   Citation,
   OllamaChatResponse,
@@ -21,7 +21,10 @@ export async function expandQuery(query: string): Promise<string[]> {
   try {
     const res = await fetch(`${OLLAMA_URL}/api/generate`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(OLLAMA_API_KEY && { Authorization: `Bearer ${OLLAMA_API_KEY}` }),
+      },
       body: JSON.stringify({
         model: "qwen3:4b",
         prompt,
@@ -65,7 +68,10 @@ export async function summarizePages(
   try {
     const res = await fetch(`${OLLAMA_URL}/api/chat`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(OLLAMA_API_KEY && { Authorization: `Bearer ${OLLAMA_API_KEY}` }),
+      },
       body: JSON.stringify({
         model: "qwen3:14b",
         messages: [


### PR DESCRIPTION
## Summary

- Adds `OLLAMA_API_KEY` env var support so searxng-mcp can authenticate with the ollama-queue-proxy via `Authorization: Bearer <key>`
- Exported from `src/config.ts`; spread into both `fetch()` calls in `src/ollama.ts` (`expandQuery` and `summarizePages`)
- Backward-compatible: when `OLLAMA_API_KEY` is unset, the spread short-circuits and no Authorization header is sent

## Test plan

- [x] TypeScript build passes (`npm run build`)
- [x] All 50 vitest tests pass with no type errors (`npm test`)
- [x] No new dependencies
- [x] No config file changes (key is env-only)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)