### PR TITLE
feat: v3.6.0 — NATS v3 migration, tier_stats_30d 30-day window, fetch.ts refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,14 @@ src/
   index.ts        # Entry point — creates MCP server, registers tools
   tools.ts        # Tool definitions (schemas + handlers)
   search.ts       # SearXNG client
-  fetch.ts        # Fetch cascade (Firecrawl → Crawl4AI → Readability/raw HTTP) + GitHub API
+  fetch.ts        # Fetch orchestrator: robots gate, tier cascade, caching, post-extract
+  fetch-utils.ts  # Shared primitives: USER_AGENT, assertPublicUrl, readBoundedText, TierResult
+  tiers/          # Tier handlers (one file per tier)
+    firecrawl.ts  # Tier 1: Firecrawl JS-rendering scrape
+    crawl4ai.ts   # Tier 2: Crawl4AI headless fetch + Readability comparison
+    raw.ts        # Tier 3: raw HTTP + Readability; fetchRawHtmlForMetadata for post-extract
+    github.ts     # GitHub blob/README API fetch
+    index.ts      # Barrel re-export
   reranker.ts     # Jina-compatible reranker client + recency weighting
   ollama.ts       # Ollama client (query expansion + summarization)
   cache.ts        # Valkey/Redis caching layer
@@ -27,7 +34,7 @@ src/
   config.ts       # Environment variable configuration
   types.ts        # Shared type definitions
 tests/
-  *.test.ts       # Vitest unit tests (50 tests across 5 files)
+  *.test.ts       # Vitest unit tests (149 tests across 16 files)
 ```
 
 ## Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-05-18
+
+### Changed
+- NATS client migrated from `nats` v2 (deprecated) to `@nats-io/nats-core` + `@nats-io/transport-node` v3. No behavior change; addresses install-time deprecation warning. Lazy-import discipline preserved — packages are not loaded unless `NATS_URL` is set.
+- `tier_stats_30d` now actually implements a 30-day window (was cumulative in v3.5.0). Stale failures no longer haunt domains that have since recovered. Schema bumped to v2; v1 records are discarded on read and rebuild from new fetches (typically <24h of normal traffic). `pnpm dump-domain` output now shows per-tier success rate and days until window reset.
+- Refactored `src/fetch.ts` from 601 lines to 296 by extracting tier-specific handlers into `src/tiers/{firecrawl,crawl4ai,raw,github}.ts`. Shared primitives moved to `src/fetch-utils.ts`. Pure code-move; no behavior change. Eases future per-tier modifications.
+
 ## [3.5.0] - 2026-05-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `tier_stats_30d` now actually implements a 30-day window (was cumulative in v3.5.0). Stale failures no longer haunt domains that have since recovered. Schema bumped to v2; v1 records are discarded on read and rebuild from new fetches (typically <24h of normal traffic). `pnpm dump-domain` output now shows per-tier success rate and days until window reset.
 - Refactored `src/fetch.ts` from 601 lines to 296 by extracting tier-specific handlers into `src/tiers/{firecrawl,crawl4ai,raw,github}.ts`. Shared primitives moved to `src/fetch-utils.ts`. Pure code-move; no behavior change. Eases future per-tier modifications.
 
+### Security
+- `fetchRawHtmlForMetadata` now calls `assertPublicUrl()` before fetching — parity with the SSRF-08 guard already present on `rawFetch`. No behavior change for normal usage; protects against future callers with internal URLs.
+
 ## [3.5.0] - 2026-05-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ Before invoking the fetch cascade, searxng-mcp reads the domain's `tier_stats_30
 
 ### Domain capability database
 
-Every fetch records what searxng-mcp learns about the target domain to Valkey under `domain:<hostname>` (90-day TTL, schema_version 1). Captured per record:
+Every fetch records what searxng-mcp learns about the target domain to Valkey under `domain:<hostname>` (90-day TTL, schema_version 2). Captured per record:
 
-- `tier_stats_30d.{tier1,tier2,tier3}.{attempts, ok, fail, last_fail_reason}` — fetch success rate per tier
+- `tier_stats_30d.{tier1,tier2,tier3}.{attempts, ok, fail, last_fail_reason, window_start_ms}` — fetch success rate per tier over a rolling 30-day window; counters reset when the window expires
 - `capabilities.robots_txt.{present, fetched, allows_us}` — robots.txt presence and whether it permits us
 - `capabilities.llms_full_txt.{present, size_bytes, last_checked}` — whether the domain serves `/llms-full.txt`
 - `capabilities.json_ld_article.{sampled, present, last_sampled_at}` — how often Article-schema JSON-LD is found

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@mozilla/readability": "^0.6.0",
+    "@nats-io/nats-core": "^3.4.0",
+    "@nats-io/transport-node": "^3.4.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.218.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
@@ -46,7 +48,6 @@
     "@opentelemetry/sdk-node": "^0.218.0",
     "iovalkey": "^0.3.3",
     "jsdom": "^29.1.1",
-    "nats": "^2.29.3",
     "robots-parser": "^3.0.1",
     "zod": "^3.24.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tadmstr/searxng-mcp",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "MCP server for SearXNG — private web search for Claude Code",
   "main": "build/src/index.js",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,12 @@ importers:
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
+      '@nats-io/nats-core':
+        specifier: ^3.4.0
+        version: 3.4.0
+      '@nats-io/transport-node':
+        specifier: ^3.4.0
+        version: 3.4.0
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -42,9 +48,6 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
-      nats:
-        specifier: ^2.29.3
-        version: 2.29.3
       robots-parser:
         specifier: ^3.0.1
         version: 3.0.1
@@ -243,6 +246,21 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nats-io/nats-core@3.4.0':
+    resolution: {integrity: sha512-QMDM86EUNm+wudlKC67HLar/KHHQUvJGLfb4jbahje3pUk3K9afeck9fwsxBZF0eUFox6T/TA6m/t+lQqf+QsQ==}
+
+  '@nats-io/nkeys@2.0.3':
+    resolution: {integrity: sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A==}
+    engines: {node: '>=18.0.0'}
+
+  '@nats-io/nuid@3.0.0':
+    resolution: {integrity: sha512-QbXZDrxmYlrn5AD06gYcUTmEHwxn96HBQMIk7XTjDlEcx6FPzVBBPjp4AMRh1lEv6B4iJ6Xb/Uz61JugPXFRQg==}
+    engines: {node: '>= 22.x'}
+
+  '@nats-io/transport-node@3.4.0':
+    resolution: {integrity: sha512-hH7u7ejIBTFEJIZ8rIcMrHJI6wl+HhpO5sVFs1+ppmXa8RuB2+Lh1+UwTzZ5xTNNm1TKcRkYy+2qCV56qp8RxA==}
+    engines: {node: '>= 18.0.0'}
 
   '@opentelemetry/api-logs@0.218.0':
     resolution: {integrity: sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==}
@@ -1054,18 +1072,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nats@2.29.3:
-    resolution: {integrity: sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA==}
-    engines: {node: '>= 14.0.0'}
-    deprecated: Package moved. Use @nats-io/transport-node from https://github.com/nats-io/nats.js
-
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
-
-  nkeys.js@1.1.0:
-    resolution: {integrity: sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==}
-    engines: {node: '>=10.0.0'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1622,6 +1631,23 @@ snapshots:
       '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@nats-io/nats-core@3.4.0':
+    dependencies:
+      '@nats-io/nkeys': 2.0.3
+      '@nats-io/nuid': 3.0.0
+
+  '@nats-io/nkeys@2.0.3':
+    dependencies:
+      tweetnacl: 1.0.3
+
+  '@nats-io/nuid@3.0.0': {}
+
+  '@nats-io/transport-node@3.4.0':
+    dependencies:
+      '@nats-io/nats-core': 3.4.0
+      '@nats-io/nkeys': 2.0.3
+      '@nats-io/nuid': 3.0.0
 
   '@opentelemetry/api-logs@0.218.0':
     dependencies:
@@ -2434,15 +2460,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nats@2.29.3:
-    dependencies:
-      nkeys.js: 1.1.0
-
   negotiator@1.0.0: {}
-
-  nkeys.js@1.1.0:
-    dependencies:
-      tweetnacl: 1.0.3
 
   object-assign@4.1.1: {}
 

--- a/src/cli/dump-domain.ts
+++ b/src/cli/dump-domain.ts
@@ -2,7 +2,21 @@
 // Operator CLI: pretty-print the domain capability record for a hostname.
 // Usage: pnpm dump-domain docs.anthropic.com
 
-import { getDomainRecord, normalizeHostname } from "../domain-db.js";
+import { getDomainRecord, normalizeHostname, type TierStat } from "../domain-db.js";
+
+const WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+function tierSummary(label: string, stat: TierStat): string {
+  const successRate =
+    stat.attempts > 0
+      ? `${Math.round((stat.ok / stat.attempts) * 100)}% ok (${stat.ok}/${stat.attempts})`
+      : "no data";
+  const msLeft = WINDOW_MS - (Date.now() - stat.window_start_ms);
+  const daysLeft = Math.max(0, Math.round(msLeft / 86400000));
+  const windowInfo = `window resets in ~${daysLeft}d`;
+  const failNote = stat.last_fail_reason ? ` | last fail: ${stat.last_fail_reason}` : "";
+  return `  ${label}: ${successRate} | ${windowInfo}${failNote}`;
+}
 
 async function main(): Promise<number> {
   const target = process.argv[2];
@@ -24,6 +38,10 @@ async function main(): Promise<number> {
   }
 
   console.log(JSON.stringify(record, null, 2));
+  console.log("\n--- tier stats (30d window) ---");
+  console.log(tierSummary("tier1 (firecrawl)", record.tier_stats_30d.tier1));
+  console.log(tierSummary("tier2 (crawl4ai) ", record.tier_stats_30d.tier2));
+  console.log(tierSummary("tier3 (raw)      ", record.tier_stats_30d.tier3));
   return 0;
 }
 

--- a/src/cli/dump-domain.ts
+++ b/src/cli/dump-domain.ts
@@ -2,7 +2,11 @@
 // Operator CLI: pretty-print the domain capability record for a hostname.
 // Usage: pnpm dump-domain docs.anthropic.com
 
-import { getDomainRecord, normalizeHostname, type TierStat } from "../domain-db.js";
+import {
+  getDomainRecord,
+  normalizeHostname,
+  type TierStat,
+} from "../domain-db.js";
 
 const WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -14,7 +18,9 @@ function tierSummary(label: string, stat: TierStat): string {
   const msLeft = WINDOW_MS - (Date.now() - stat.window_start_ms);
   const daysLeft = Math.max(0, Math.round(msLeft / 86400000));
   const windowInfo = `window resets in ~${daysLeft}d`;
-  const failNote = stat.last_fail_reason ? ` | last fail: ${stat.last_fail_reason}` : "";
+  const failNote = stat.last_fail_reason
+    ? ` | last fail: ${stat.last_fail_reason}`
+    : "";
   return `  ${label}: ${successRate} | ${windowInfo}${failNote}`;
 }
 

--- a/src/domain-db.ts
+++ b/src/domain-db.ts
@@ -10,7 +10,8 @@
 import { cacheGet, cacheSet } from "./cache.js";
 
 const DOMAIN_RECORD_TTL_SECONDS = 90 * 24 * 60 * 60;
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
+const WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
 export type TierName = "tier1_firecrawl" | "tier2_crawl4ai" | "tier3_rawfetch";
 export type PreferredStrategy = "llms_full_txt" | "tier1" | "tier2" | "tier3";
@@ -20,6 +21,7 @@ export interface TierStat {
   ok: number;
   fail: number;
   last_fail_reason?: string;
+  window_start_ms: number;
 }
 
 export interface DomainCapabilities {
@@ -66,7 +68,7 @@ export interface DomainRecord {
 }
 
 function emptyStat(): TierStat {
-  return { attempts: 0, ok: 0, fail: 0 };
+  return { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() };
 }
 
 function newRecord(domain: string, now: string): DomainRecord {
@@ -184,6 +186,13 @@ export async function recordTierAttempt(
   const slot = TIER_KEY[tier];
   await updateRecord(url, (record) => {
     const stat = record.tier_stats_30d[slot];
+    if (Date.now() - stat.window_start_ms > WINDOW_MS) {
+      stat.attempts = 0;
+      stat.ok = 0;
+      stat.fail = 0;
+      stat.window_start_ms = Date.now();
+      delete stat.last_fail_reason;
+    }
     stat.attempts += 1;
     if (outcome === "hit") {
       stat.ok += 1;

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,7 +1,7 @@
 // NATS event publishing. Fire-and-forget: with no NATS_URL set, this module
-// no-ops and never requires the `nats` package at runtime (type-only imports
-// below are erased by tsc).
-import type { NatsConnection } from "nats";
+// no-ops and never requires the @nats-io/* packages at runtime (type-only
+// imports below are erased by tsc).
+import type { NatsConnection } from "@nats-io/nats-core";
 import { getRequestId } from "./context.js";
 import { getCurrentTraceId } from "./observability.js";
 
@@ -21,7 +21,8 @@ export async function initEvents(): Promise<void> {
   subjectPrefix = process.env.NATS_SUBJECT_PREFIX ?? "searxng";
 
   try {
-    const { connect, credsAuthenticator } = await import("nats");
+    const { connect } = await import("@nats-io/transport-node");
+    const { credsAuthenticator } = await import("@nats-io/nats-core");
     const opts: Record<string, unknown> = {
       servers: url,
       name: "searxng-mcp",

--- a/src/fetch-utils.ts
+++ b/src/fetch-utils.ts
@@ -1,0 +1,63 @@
+// Shared primitives used by both src/fetch.ts (orchestrator) and src/tiers/*.ts
+// (tier handlers). Kept here to avoid circular imports — fetch.ts imports
+// from ./tiers/index.js, so tier files cannot import back from ./fetch.js.
+
+export const USER_AGENT =
+  "searxng-mcp/3.6.0 (+https://github.com/TadMSTR/searxng-mcp; personal research)";
+
+// Hard cap on HTML bytes read into memory per fetch. Anything larger than
+// this is dropped — the metadata extractors aren't useful on multi-megabyte
+// rendered pages anyway, and uncapped reads make the JSDOM constructor a
+// memory-amplification target (IV-14).
+export const RAW_HTML_MAX_BYTES = 2 * 1024 * 1024;
+
+export interface TierResult {
+  title: string;
+  url: string;
+  text: string;
+  html?: string;
+}
+
+export function assertPublicUrl(url: string): void {
+  const { protocol } = new URL(url);
+  // Strip IPv6 brackets so patterns like /^::1$/ match [::1] addresses correctly
+  const hostname = new URL(url).hostname.replace(/^\[|\]$/g, "");
+  if (!/^https?:$/.test(protocol)) {
+    throw new Error(`Only http/https URLs are supported`);
+  }
+  const blocked = [
+    /^localhost$/i,
+    /^127\./,
+    /^0\.0\.0\.0$/,
+    /^10\./,
+    /^192\.168\./,
+    /^172\.(1[6-9]|2[0-9]|3[01])\./,
+    /^host\.docker\.internal$/i,
+    /^fc[0-9a-f]{2}:/i,
+    /^fe[89ab][0-9a-f]:/i,
+    /^::1$/,
+    /^0:0:0:0:0:0:0:1$/,
+    /^fd[0-9a-f]{2}:/i,
+  ];
+  if (blocked.some((r) => r.test(hostname))) {
+    throw new Error(`Internal/private addresses are not allowed`);
+  }
+}
+
+export async function readBoundedText(res: Response): Promise<string> {
+  const reader = res.body?.getReader();
+  if (!reader) return (await res.text()).slice(0, RAW_HTML_MAX_BYTES);
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (total < RAW_HTML_MAX_BYTES) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    total += value.byteLength;
+  }
+  // Drop any in-flight remainder if we hit the cap.
+  reader.cancel().catch(() => {});
+  return Buffer.concat(chunks.map((c) => Buffer.from(c)))
+    .toString("utf-8")
+    .slice(0, RAW_HTML_MAX_BYTES);
+}

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,14 +1,5 @@
-import { Readability } from "@mozilla/readability";
-import { JSDOM } from "jsdom";
 import { cacheGet, cacheSet, fetchCacheKey } from "./cache.js";
-import {
-  CRAWL4AI_API_TOKEN,
-  CRAWL4AI_URL,
-  FETCH_CACHE_TTL_SECONDS,
-  FIRECRAWL_API_KEY,
-  FIRECRAWL_URL,
-  GITHUB_TOKEN,
-} from "./config.js";
+import { FETCH_CACHE_TTL_SECONDS } from "./config.js";
 import {
   recordPostExtractSample,
   recordTierAttempt,
@@ -17,43 +8,23 @@ import {
 import { getBlockList, urlMatchesDomain } from "./domains.js";
 import { events } from "./events.js";
 import { postExtract } from "./extractors/post-extract.js";
-import { preferReadability, runReadability } from "./extractors/readability.js";
+import { assertPublicUrl, type TierResult } from "./fetch-utils.js";
 import { tryLlmsTxtFetch } from "./llms-txt.js";
 import { incCounter, recordHistogram, withSpan } from "./observability.js";
 import { checkRobots } from "./robots.js";
 import { computeTierSkips, type SkipReason, TIER_NAME } from "./routing.js";
-import type {
-  FirecrawlScrapeResponse,
-  GitHubReadmeResponse,
-  TierSlot,
-} from "./types.js";
+import {
+  applyTier2Readability,
+  crawl4aiFetch,
+  fetchRawHtmlForMetadata,
+  firecrawlScrape,
+  githubFetch,
+  rawFetch,
+} from "./tiers/index.js";
+import type { TierSlot } from "./types.js";
 
-export const USER_AGENT =
-  "searxng-mcp/3.5.0 (+https://github.com/TadMSTR/searxng-mcp; personal research)";
-
-// Hard cap on HTML bytes read into memory per fetch. Anything larger than
-// this is dropped — the metadata extractors aren't useful on multi-megabyte
-// rendered pages anyway, and uncapped reads make the JSDOM constructor a
-// memory-amplification target (IV-14).
-const RAW_HTML_MAX_BYTES = 2 * 1024 * 1024;
-
-async function readBoundedText(res: Response): Promise<string> {
-  const reader = res.body?.getReader();
-  if (!reader) return (await res.text()).slice(0, RAW_HTML_MAX_BYTES);
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  while (total < RAW_HTML_MAX_BYTES) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-    total += value.byteLength;
-  }
-  // Drop any in-flight remainder if we hit the cap.
-  reader.cancel().catch(() => {});
-  return Buffer.concat(chunks.map((c) => Buffer.from(c)))
-    .toString("utf-8")
-    .slice(0, RAW_HTML_MAX_BYTES);
-}
+// Re-export for callers that import assertPublicUrl from this module.
+export { assertPublicUrl } from "./fetch-utils.js";
 
 export class RobotsDisallowedError extends Error {
   constructor(url: string) {
@@ -62,289 +33,8 @@ export class RobotsDisallowedError extends Error {
   }
 }
 
-interface TierResult {
-  title: string;
-  url: string;
-  text: string;
-  html?: string;
-}
-
-export function assertPublicUrl(url: string): void {
-  const { protocol } = new URL(url);
-  // Strip IPv6 brackets so patterns like /^::1$/ match [::1] addresses correctly
-  const hostname = new URL(url).hostname.replace(/^\[|\]$/g, "");
-  if (!/^https?:$/.test(protocol)) {
-    throw new Error(`Only http/https URLs are supported`);
-  }
-  const blocked = [
-    /^localhost$/i,
-    /^127\./,
-    /^0\.0\.0\.0$/,
-    /^10\./,
-    /^192\.168\./,
-    /^172\.(1[6-9]|2[0-9]|3[01])\./,
-    /^host\.docker\.internal$/i,
-    /^fc[0-9a-f]{2}:/i,
-    /^fe[89ab][0-9a-f]:/i,
-    /^::1$/,
-    /^0:0:0:0:0:0:0:1$/,
-    /^fd[0-9a-f]{2}:/i,
-  ];
-  if (blocked.some((r) => r.test(hostname))) {
-    throw new Error(`Internal/private addresses are not allowed`);
-  }
-}
-
-async function githubFetch(
-  url: string,
-  maxChars = 8000,
-): Promise<{ title: string; url: string; text: string }> {
-  const parsed = new URL(url);
-  const parts = parsed.pathname.split("/").filter(Boolean);
-  // parts: [owner, repo] or [owner, repo, "blob"|"tree", branch, ...path]
-
-  const headers: Record<string, string> = {
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-    "User-Agent": USER_AGENT,
-  };
-  if (GITHUB_TOKEN) headers.Authorization = `Bearer ${GITHUB_TOKEN}`;
-
-  if (parts.length >= 4 && parts[2] === "blob") {
-    // Rewrite blob URL to raw content
-    const [owner, repo, , branch, ...filePath] = parts;
-    const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${filePath.join("/")}`;
-    const rawHeaders: Record<string, string> = { "User-Agent": USER_AGENT };
-    if (GITHUB_TOKEN) rawHeaders.Authorization = `Bearer ${GITHUB_TOKEN}`;
-    const res = await fetch(rawUrl, {
-      headers: rawHeaders,
-      signal: AbortSignal.timeout(10000),
-    });
-    if (!res.ok)
-      throw new Error(
-        `GitHub raw fetch error: ${res.status} ${res.statusText}`,
-      );
-    const text = (await res.text()).slice(0, maxChars);
-    const fileName = filePath[filePath.length - 1] ?? url;
-    return { title: fileName, url: rawUrl, text };
-  }
-
-  // Repo root or tree — fetch README via GitHub API
-  const [owner, repo] = parts;
-  const apiUrl = `https://api.github.com/repos/${owner}/${repo}/readme`;
-  const res = await fetch(apiUrl, {
-    headers,
-    signal: AbortSignal.timeout(10000),
-  });
-  if (!res.ok)
-    throw new Error(`GitHub API error: ${res.status} ${res.statusText}`);
-  const data = (await res.json()) as GitHubReadmeResponse;
-  const text = Buffer.from(data.content, "base64")
-    .toString("utf-8")
-    .slice(0, maxChars);
-  return { title: `${owner}/${repo} — ${data.name}`, url: data.html_url, text };
-}
-
-async function firecrawlScrape(
-  url: string,
-  maxChars = 8000,
-): Promise<TierResult> {
-  const res = await fetch(`${FIRECRAWL_URL}/v1/scrape`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${FIRECRAWL_API_KEY}`,
-    },
-    body: JSON.stringify({ url, formats: ["markdown", "html"] }),
-    signal: AbortSignal.timeout(15000),
-  });
-
-  if (!res.ok) {
-    throw new Error(`Firecrawl error: ${res.status} ${res.statusText}`);
-  }
-
-  const data = (await res.json()) as FirecrawlScrapeResponse;
-
-  if (!data.success || !data.data) {
-    throw new Error(data.error ?? "Firecrawl returned no data");
-  }
-
-  const title = data.data.metadata?.title ?? url;
-  const text = (data.data.markdown ?? "").slice(0, maxChars);
-  const html = data.data.html;
-
-  return { title, url: data.data.metadata?.sourceURL ?? url, text, html };
-}
-
-async function pollCrawl4aiTask(
-  taskId: string,
-  url: string,
-  maxChars: number,
-  signal: AbortSignal,
-  preferFit = false,
-): Promise<TierResult | null> {
-  const deadline = Date.now() + 40_000;
-
-  while (Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, 2000));
-    if (signal.aborted) return null;
-
-    try {
-      const resp = await fetch(`${CRAWL4AI_URL}/task/${taskId}`, { signal });
-      if (!resp.ok) return null;
-
-      const data = (await resp.json()) as Record<string, unknown>;
-      if (data.status === "completed") {
-        const result = data.result as Record<string, unknown> | null;
-        const md = result?.markdown as Record<string, string> | null;
-        const mdRaw = preferFit
-          ? md?.fit_markdown || md?.raw_markdown
-          : md?.raw_markdown || md?.fit_markdown;
-        const text = (mdRaw ?? "").slice(0, maxChars);
-        const metadata = result?.metadata as Record<string, string> | null;
-        const title = metadata?.title || url;
-        const html =
-          typeof result?.html === "string"
-            ? (result.html as string)
-            : undefined;
-        return text ? { title, url, text, html } : null;
-      }
-      if (data.status === "failed") return null;
-    } catch {
-      return null;
-    }
-  }
-
-  return null;
-}
-
-async function crawl4aiFetch(
-  url: string,
-  maxChars = 8000,
-  preferFit = false,
-): Promise<TierResult | null> {
-  if (!CRAWL4AI_URL) return null;
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 45_000);
-
-  try {
-    const crawlHeaders: Record<string, string> = {
-      "Content-Type": "application/json",
-    };
-    if (CRAWL4AI_API_TOKEN)
-      crawlHeaders.Authorization = `Bearer ${CRAWL4AI_API_TOKEN}`;
-    const resp = await fetch(`${CRAWL4AI_URL}/crawl`, {
-      method: "POST",
-      headers: crawlHeaders,
-      body: JSON.stringify({ urls: [url] }),
-      signal: controller.signal,
-    });
-
-    if (!resp.ok) return null;
-    const data = (await resp.json()) as Record<string, unknown>;
-
-    // Synchronous response — results returned directly
-    if (Array.isArray(data.results) && data.results.length > 0) {
-      const result = data.results[0] as Record<string, unknown>;
-      const md = result.markdown as Record<string, string> | null;
-      const mdRaw = preferFit
-        ? md?.fit_markdown || md?.raw_markdown
-        : md?.raw_markdown || md?.fit_markdown;
-      const text = (mdRaw ?? "").slice(0, maxChars);
-      if (!text) return null;
-      const metadata = result.metadata as Record<string, string> | null;
-      const title = metadata?.title || url;
-      const html =
-        typeof result.html === "string" ? (result.html as string) : undefined;
-      return { title, url, text, html };
-    }
-
-    // Asynchronous response — poll for completion
-    if (typeof data.task_id === "string") {
-      if (!/^[a-zA-Z0-9_-]{1,64}$/.test(data.task_id)) return null;
-      return await pollCrawl4aiTask(
-        data.task_id,
-        url,
-        maxChars,
-        controller.signal,
-        preferFit,
-      );
-    }
-
-    return null;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-export async function rawFetch(
-  url: string,
-  maxChars = 8000,
-): Promise<TierResult> {
-  // Defensive SSRF guard — all current callers go through fetchPage which
-  // also calls this, but rawFetch is exported so the guard protects against
-  // future direct callers (SSRF-08).
-  assertPublicUrl(url);
-
-  const res = await fetch(url, {
-    headers: { "User-Agent": USER_AGENT },
-    redirect: "manual",
-    signal: AbortSignal.timeout(15000),
-  });
-
-  if (res.status >= 300 && res.status < 400) {
-    // Don't echo the Location header into the thrown message — a redirect
-    // to an internal address would surface that address to the MCP caller
-    // (OE-02).
-    throw new Error(`Redirect not followed (${res.status})`);
-  }
-  if (!res.ok)
-    throw new Error(`Raw fetch error: ${res.status} ${res.statusText}`);
-
-  const html = await readBoundedText(res);
-  const dom = new JSDOM(html, { url }); // runScripts not set — script execution disabled
-  const reader = new Readability(dom.window.document);
-  const article = reader.parse();
-
-  const text = (article?.textContent ?? html).slice(0, maxChars);
-  const title = article?.title ?? url;
-  return { title, url, text, html };
-}
-
-function applyTier2Readability(fetched: TierResult, url: string): TierResult {
-  if (!fetched.html) return fetched;
-  const readable = runReadability(fetched.html, url);
-  if (preferReadability(readable, fetched) && readable) {
-    return {
-      ...fetched,
-      title: readable.title ?? fetched.title,
-      text: readable.text,
-    };
-  }
-  return fetched;
-}
-
-async function fetchRawHtmlForMetadata(url: string): Promise<string | null> {
-  // Raw HTTP fetch (no JS rendering) used as the source for JSON-LD and meta
-  // tags. Tier 1/2 puppeteer renders inject payment-widget og:title tags and
-  // can strip JSON-LD scripts; the unrendered HTML is more reliable for
-  // post-extraction. Bounded by RAW_HTML_MAX_BYTES so large pages can't
-  // amplify into a JSDOM-memory hazard (IV-14).
-  try {
-    const res = await fetch(url, {
-      headers: { "User-Agent": USER_AGENT },
-      redirect: "follow",
-      signal: AbortSignal.timeout(8000),
-    });
-    if (!res.ok) return null;
-    return await readBoundedText(res);
-  } catch {
-    return null;
-  }
-}
+// Re-export rawFetch for external callers (e.g. tests).
+export { rawFetch } from "./tiers/index.js";
 
 function applyPostExtract(
   fetched: TierResult,

--- a/src/tiers/crawl4ai.ts
+++ b/src/tiers/crawl4ai.ts
@@ -1,0 +1,126 @@
+import { CRAWL4AI_API_TOKEN, CRAWL4AI_URL } from "../config.js";
+import {
+  preferReadability,
+  runReadability,
+} from "../extractors/readability.js";
+import type { TierResult } from "../fetch-utils.js";
+
+export async function pollCrawl4aiTask(
+  taskId: string,
+  url: string,
+  maxChars: number,
+  signal: AbortSignal,
+  preferFit = false,
+): Promise<TierResult | null> {
+  const deadline = Date.now() + 40_000;
+
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 2000));
+    if (signal.aborted) return null;
+
+    try {
+      const resp = await fetch(`${CRAWL4AI_URL}/task/${taskId}`, { signal });
+      if (!resp.ok) return null;
+
+      const data = (await resp.json()) as Record<string, unknown>;
+      if (data.status === "completed") {
+        const result = data.result as Record<string, unknown> | null;
+        const md = result?.markdown as Record<string, string> | null;
+        const mdRaw = preferFit
+          ? md?.fit_markdown || md?.raw_markdown
+          : md?.raw_markdown || md?.fit_markdown;
+        const text = (mdRaw ?? "").slice(0, maxChars);
+        const metadata = result?.metadata as Record<string, string> | null;
+        const title = metadata?.title || url;
+        const html =
+          typeof result?.html === "string"
+            ? (result.html as string)
+            : undefined;
+        return text ? { title, url, text, html } : null;
+      }
+      if (data.status === "failed") return null;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+export async function crawl4aiFetch(
+  url: string,
+  maxChars = 8000,
+  preferFit = false,
+): Promise<TierResult | null> {
+  if (!CRAWL4AI_URL) return null;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 45_000);
+
+  try {
+    const crawlHeaders: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (CRAWL4AI_API_TOKEN)
+      crawlHeaders.Authorization = `Bearer ${CRAWL4AI_API_TOKEN}`;
+    const resp = await fetch(`${CRAWL4AI_URL}/crawl`, {
+      method: "POST",
+      headers: crawlHeaders,
+      body: JSON.stringify({ urls: [url] }),
+      signal: controller.signal,
+    });
+
+    if (!resp.ok) return null;
+    const data = (await resp.json()) as Record<string, unknown>;
+
+    // Synchronous response — results returned directly
+    if (Array.isArray(data.results) && data.results.length > 0) {
+      const result = data.results[0] as Record<string, unknown>;
+      const md = result.markdown as Record<string, string> | null;
+      const mdRaw = preferFit
+        ? md?.fit_markdown || md?.raw_markdown
+        : md?.raw_markdown || md?.fit_markdown;
+      const text = (mdRaw ?? "").slice(0, maxChars);
+      if (!text) return null;
+      const metadata = result.metadata as Record<string, string> | null;
+      const title = metadata?.title || url;
+      const html =
+        typeof result.html === "string" ? (result.html as string) : undefined;
+      return { title, url, text, html };
+    }
+
+    // Asynchronous response — poll for completion
+    if (typeof data.task_id === "string") {
+      if (!/^[a-zA-Z0-9_-]{1,64}$/.test(data.task_id)) return null;
+      return await pollCrawl4aiTask(
+        data.task_id,
+        url,
+        maxChars,
+        controller.signal,
+        preferFit,
+      );
+    }
+
+    return null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function applyTier2Readability(
+  fetched: TierResult,
+  url: string,
+): TierResult {
+  if (!fetched.html) return fetched;
+  const readable = runReadability(fetched.html, url);
+  if (preferReadability(readable, fetched) && readable) {
+    return {
+      ...fetched,
+      title: readable.title ?? fetched.title,
+      text: readable.text,
+    };
+  }
+  return fetched;
+}

--- a/src/tiers/firecrawl.ts
+++ b/src/tiers/firecrawl.ts
@@ -1,0 +1,34 @@
+import { FIRECRAWL_API_KEY, FIRECRAWL_URL } from "../config.js";
+import type { TierResult } from "../fetch-utils.js";
+import type { FirecrawlScrapeResponse } from "../types.js";
+
+export async function firecrawlScrape(
+  url: string,
+  maxChars = 8000,
+): Promise<TierResult> {
+  const res = await fetch(`${FIRECRAWL_URL}/v1/scrape`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${FIRECRAWL_API_KEY}`,
+    },
+    body: JSON.stringify({ url, formats: ["markdown", "html"] }),
+    signal: AbortSignal.timeout(15000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Firecrawl error: ${res.status} ${res.statusText}`);
+  }
+
+  const data = (await res.json()) as FirecrawlScrapeResponse;
+
+  if (!data.success || !data.data) {
+    throw new Error(data.error ?? "Firecrawl returned no data");
+  }
+
+  const title = data.data.metadata?.title ?? url;
+  const text = (data.data.markdown ?? "").slice(0, maxChars);
+  const html = data.data.html;
+
+  return { title, url: data.data.metadata?.sourceURL ?? url, text, html };
+}

--- a/src/tiers/github.ts
+++ b/src/tiers/github.ts
@@ -1,0 +1,53 @@
+import { GITHUB_TOKEN } from "../config.js";
+import { USER_AGENT } from "../fetch-utils.js";
+import type { GitHubReadmeResponse } from "../types.js";
+
+export async function githubFetch(
+  url: string,
+  maxChars = 8000,
+): Promise<{ title: string; url: string; text: string }> {
+  const parsed = new URL(url);
+  const parts = parsed.pathname.split("/").filter(Boolean);
+  // parts: [owner, repo] or [owner, repo, "blob"|"tree", branch, ...path]
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": USER_AGENT,
+  };
+  if (GITHUB_TOKEN) headers.Authorization = `Bearer ${GITHUB_TOKEN}`;
+
+  if (parts.length >= 4 && parts[2] === "blob") {
+    // Rewrite blob URL to raw content
+    const [owner, repo, , branch, ...filePath] = parts;
+    const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${filePath.join("/")}`;
+    const rawHeaders: Record<string, string> = { "User-Agent": USER_AGENT };
+    if (GITHUB_TOKEN) rawHeaders.Authorization = `Bearer ${GITHUB_TOKEN}`;
+    const res = await fetch(rawUrl, {
+      headers: rawHeaders,
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!res.ok)
+      throw new Error(
+        `GitHub raw fetch error: ${res.status} ${res.statusText}`,
+      );
+    const text = (await res.text()).slice(0, maxChars);
+    const fileName = filePath[filePath.length - 1] ?? url;
+    return { title: fileName, url: rawUrl, text };
+  }
+
+  // Repo root or tree — fetch README via GitHub API
+  const [owner, repo] = parts;
+  const apiUrl = `https://api.github.com/repos/${owner}/${repo}/readme`;
+  const res = await fetch(apiUrl, {
+    headers,
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!res.ok)
+    throw new Error(`GitHub API error: ${res.status} ${res.statusText}`);
+  const data = (await res.json()) as GitHubReadmeResponse;
+  const text = Buffer.from(data.content, "base64")
+    .toString("utf-8")
+    .slice(0, maxChars);
+  return { title: `${owner}/${repo} — ${data.name}`, url: data.html_url, text };
+}

--- a/src/tiers/index.ts
+++ b/src/tiers/index.ts
@@ -1,0 +1,4 @@
+export { applyTier2Readability, crawl4aiFetch } from "./crawl4ai.js";
+export { firecrawlScrape } from "./firecrawl.js";
+export { githubFetch } from "./github.js";
+export { fetchRawHtmlForMetadata, rawFetch } from "./raw.js";

--- a/src/tiers/raw.ts
+++ b/src/tiers/raw.ts
@@ -1,0 +1,63 @@
+import { Readability } from "@mozilla/readability";
+import { JSDOM } from "jsdom";
+import {
+  assertPublicUrl,
+  readBoundedText,
+  type TierResult,
+  USER_AGENT,
+} from "../fetch-utils.js";
+
+export async function rawFetch(
+  url: string,
+  maxChars = 8000,
+): Promise<TierResult> {
+  // Defensive SSRF guard — all current callers go through fetchPage which
+  // also calls this, but rawFetch is exported so the guard protects against
+  // future direct callers (SSRF-08).
+  assertPublicUrl(url);
+
+  const res = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT },
+    redirect: "manual",
+    signal: AbortSignal.timeout(15000),
+  });
+
+  if (res.status >= 300 && res.status < 400) {
+    // Don't echo the Location header into the thrown message — a redirect
+    // to an internal address would surface that address to the MCP caller
+    // (OE-02).
+    throw new Error(`Redirect not followed (${res.status})`);
+  }
+  if (!res.ok)
+    throw new Error(`Raw fetch error: ${res.status} ${res.statusText}`);
+
+  const html = await readBoundedText(res);
+  const dom = new JSDOM(html, { url }); // runScripts not set — script execution disabled
+  const reader = new Readability(dom.window.document);
+  const article = reader.parse();
+
+  const text = (article?.textContent ?? html).slice(0, maxChars);
+  const title = article?.title ?? url;
+  return { title, url, text, html };
+}
+
+export async function fetchRawHtmlForMetadata(
+  url: string,
+): Promise<string | null> {
+  // Raw HTTP fetch (no JS rendering) used as the source for JSON-LD and meta
+  // tags. Tier 1/2 puppeteer renders inject payment-widget og:title tags and
+  // can strip JSON-LD scripts; the unrendered HTML is more reliable for
+  // post-extraction. Bounded by RAW_HTML_MAX_BYTES so large pages can't
+  // amplify into a JSDOM-memory hazard (IV-14).
+  try {
+    const res = await fetch(url, {
+      headers: { "User-Agent": USER_AGENT },
+      redirect: "follow",
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) return null;
+    return await readBoundedText(res);
+  } catch {
+    return null;
+  }
+}

--- a/src/tiers/raw.ts
+++ b/src/tiers/raw.ts
@@ -49,7 +49,10 @@ export async function fetchRawHtmlForMetadata(
   // can strip JSON-LD scripts; the unrendered HTML is more reliable for
   // post-extraction. Bounded by RAW_HTML_MAX_BYTES so large pages can't
   // amplify into a JSDOM-memory hazard (IV-14).
+  // Defensive SSRF guard — function is exported, so protect against future
+  // direct callers with an internal URL (SSRF-08 parity with rawFetch).
   try {
+    assertPublicUrl(url);
     const res = await fetch(url, {
       headers: { "User-Agent": USER_AGENT },
       redirect: "follow",

--- a/tests/domain-db.test.ts
+++ b/tests/domain-db.test.ts
@@ -66,22 +66,23 @@ describe("recordTierAttempt", () => {
     await recordTierAttempt("https://example.com/p", "tier1_firecrawl", "hit");
     const written = lastWrittenRecord();
     expect(written.domain).toBe("example.com");
-    expect(written.schema_version).toBe(1);
+    expect(written.schema_version).toBe(2);
     expect(written.tier_stats_30d.tier1.attempts).toBe(1);
     expect(written.tier_stats_30d.tier1.ok).toBe(1);
+    expect(written.tier_stats_30d.tier1.window_start_ms).toBeGreaterThan(0);
   });
 
   it("updates an existing record incrementally", async () => {
     const seed: DomainRecord = {
-      schema_version: 1,
+      schema_version: 2,
       domain: "example.com",
       first_seen: "2026-05-01T00:00:00Z",
       last_fetch: "2026-05-01T00:00:00Z",
       capabilities: {},
       tier_stats_30d: {
-        tier1: { attempts: 2, ok: 1, fail: 1 },
-        tier2: { attempts: 0, ok: 0, fail: 0 },
-        tier3: { attempts: 0, ok: 0, fail: 0 },
+        tier1: { attempts: 2, ok: 1, fail: 1, window_start_ms: Date.now() },
+        tier2: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
+        tier3: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
       },
     };
     cacheGetMock.mockResolvedValue(JSON.stringify(seed));
@@ -95,6 +96,31 @@ describe("recordTierAttempt", () => {
     expect(written.tier_stats_30d.tier1.attempts).toBe(3);
     expect(written.tier_stats_30d.tier1.fail).toBe(2);
     expect(written.tier_stats_30d.tier1.last_fail_reason).toBe("timeout");
+  });
+
+  it("resets window counters when window_start_ms is older than 30 days", async () => {
+    const oldWindowMs = Date.now() - 31 * 24 * 60 * 60 * 1000;
+    const seed: DomainRecord = {
+      schema_version: 2,
+      domain: "example.com",
+      first_seen: "2026-04-01T00:00:00Z",
+      last_fetch: "2026-04-15T00:00:00Z",
+      capabilities: {},
+      tier_stats_30d: {
+        tier1: { attempts: 50, ok: 5, fail: 45, last_fail_reason: "old_error", window_start_ms: oldWindowMs },
+        tier2: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
+        tier3: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
+      },
+    };
+    cacheGetMock.mockResolvedValue(JSON.stringify(seed));
+    await recordTierAttempt("https://example.com/p", "tier1_firecrawl", "hit");
+    const written = lastWrittenRecord();
+    // Old window expired — counters reset, then this one attempt recorded
+    expect(written.tier_stats_30d.tier1.attempts).toBe(1);
+    expect(written.tier_stats_30d.tier1.ok).toBe(1);
+    expect(written.tier_stats_30d.tier1.fail).toBe(0);
+    expect(written.tier_stats_30d.tier1.last_fail_reason).toBeUndefined();
+    expect(written.tier_stats_30d.tier1.window_start_ms).toBeGreaterThan(oldWindowMs);
   });
 
   it("does not throw on malformed cache content", async () => {
@@ -230,7 +256,7 @@ describe("shouldSkipJsonLdPostExtract", () => {
 
   it("returns false until 5 samples are recorded with zero hits", async () => {
     const seed: DomainRecord = {
-      schema_version: 1,
+      schema_version: 2,
       domain: "example.com",
       first_seen: "2026-05-01T00:00:00Z",
       last_fetch: "2026-05-01T00:00:00Z",
@@ -242,9 +268,9 @@ describe("shouldSkipJsonLdPostExtract", () => {
         },
       },
       tier_stats_30d: {
-        tier1: { attempts: 0, ok: 0, fail: 0 },
-        tier2: { attempts: 0, ok: 0, fail: 0 },
-        tier3: { attempts: 0, ok: 0, fail: 0 },
+        tier1: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
+        tier2: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
+        tier3: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
       },
     };
     cacheGetMock.mockResolvedValue(JSON.stringify(seed));
@@ -255,7 +281,7 @@ describe("shouldSkipJsonLdPostExtract", () => {
 
   it("returns true after 5+ samples with zero JSON-LD hits", async () => {
     const seed: DomainRecord = {
-      schema_version: 1,
+      schema_version: 2,
       domain: "example.com",
       first_seen: "2026-05-01T00:00:00Z",
       last_fetch: "2026-05-01T00:00:00Z",
@@ -267,9 +293,9 @@ describe("shouldSkipJsonLdPostExtract", () => {
         },
       },
       tier_stats_30d: {
-        tier1: { attempts: 0, ok: 0, fail: 0 },
-        tier2: { attempts: 0, ok: 0, fail: 0 },
-        tier3: { attempts: 0, ok: 0, fail: 0 },
+        tier1: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
+        tier2: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
+        tier3: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
       },
     };
     cacheGetMock.mockResolvedValue(JSON.stringify(seed));
@@ -280,7 +306,7 @@ describe("shouldSkipJsonLdPostExtract", () => {
 
   it("returns false once any JSON-LD hit has been seen, regardless of sample count", async () => {
     const seed: DomainRecord = {
-      schema_version: 1,
+      schema_version: 2,
       domain: "example.com",
       first_seen: "2026-05-01T00:00:00Z",
       last_fetch: "2026-05-01T00:00:00Z",
@@ -292,9 +318,9 @@ describe("shouldSkipJsonLdPostExtract", () => {
         },
       },
       tier_stats_30d: {
-        tier1: { attempts: 0, ok: 0, fail: 0 },
-        tier2: { attempts: 0, ok: 0, fail: 0 },
-        tier3: { attempts: 0, ok: 0, fail: 0 },
+        tier1: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
+        tier2: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
+        tier3: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
       },
     };
     cacheGetMock.mockResolvedValue(JSON.stringify(seed));
@@ -317,6 +343,13 @@ describe("getDomainRecord", () => {
   it("returns null on stale schema_version", async () => {
     cacheGetMock.mockResolvedValue(
       JSON.stringify({ schema_version: 0, domain: "example.com" }),
+    );
+    expect(await getDomainRecord("https://example.com")).toBeNull();
+  });
+
+  it("returns null on schema_version 1 (v1 records discarded after v2 bump)", async () => {
+    cacheGetMock.mockResolvedValue(
+      JSON.stringify({ schema_version: 1, domain: "example.com" }),
     );
     expect(await getDomainRecord("https://example.com")).toBeNull();
   });

--- a/tests/domain-db.test.ts
+++ b/tests/domain-db.test.ts
@@ -107,7 +107,13 @@ describe("recordTierAttempt", () => {
       last_fetch: "2026-04-15T00:00:00Z",
       capabilities: {},
       tier_stats_30d: {
-        tier1: { attempts: 50, ok: 5, fail: 45, last_fail_reason: "old_error", window_start_ms: oldWindowMs },
+        tier1: {
+          attempts: 50,
+          ok: 5,
+          fail: 45,
+          last_fail_reason: "old_error",
+          window_start_ms: oldWindowMs,
+        },
         tier2: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
         tier3: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
       },
@@ -120,7 +126,9 @@ describe("recordTierAttempt", () => {
     expect(written.tier_stats_30d.tier1.ok).toBe(1);
     expect(written.tier_stats_30d.tier1.fail).toBe(0);
     expect(written.tier_stats_30d.tier1.last_fail_reason).toBeUndefined();
-    expect(written.tier_stats_30d.tier1.window_start_ms).toBeGreaterThan(oldWindowMs);
+    expect(written.tier_stats_30d.tier1.window_start_ms).toBeGreaterThan(
+      oldWindowMs,
+    );
   });
 
   it("does not throw on malformed cache content", async () => {

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -17,17 +17,23 @@ import { computeTierSkips } from "../src/routing.js";
 const cacheGetMock = vi.mocked(cacheGet);
 const getOpSkipMock = vi.mocked(getOperatorTierSkips);
 
+const NOW = Date.now();
+
+function stat(attempts: number, ok: number, fail: number) {
+  return { attempts, ok, fail, window_start_ms: NOW };
+}
+
 function record(overrides: Partial<DomainRecord>): DomainRecord {
   return {
-    schema_version: 1,
+    schema_version: 2,
     domain: "example.com",
     first_seen: "2026-05-01T00:00:00Z",
     last_fetch: "2026-05-01T00:00:00Z",
     capabilities: {},
     tier_stats_30d: {
-      tier1: { attempts: 0, ok: 0, fail: 0 },
-      tier2: { attempts: 0, ok: 0, fail: 0 },
-      tier3: { attempts: 0, ok: 0, fail: 0 },
+      tier1: stat(0, 0, 0),
+      tier2: stat(0, 0, 0),
+      tier3: stat(0, 0, 0),
     },
     ...overrides,
   };
@@ -47,9 +53,9 @@ describe("computeTierSkips", () => {
       JSON.stringify(
         record({
           tier_stats_30d: {
-            tier1: { attempts: 5, ok: 0, fail: 5 },
-            tier2: { attempts: 0, ok: 0, fail: 0 },
-            tier3: { attempts: 0, ok: 0, fail: 0 },
+            tier1: stat(5, 0, 5),
+            tier2: stat(0, 0, 0),
+            tier3: stat(0, 0, 0),
           },
         }),
       ),
@@ -63,9 +69,9 @@ describe("computeTierSkips", () => {
       JSON.stringify(
         record({
           tier_stats_30d: {
-            tier1: { attempts: 20, ok: 4, fail: 16 },
-            tier2: { attempts: 0, ok: 0, fail: 0 },
-            tier3: { attempts: 0, ok: 0, fail: 0 },
+            tier1: stat(20, 4, 16),
+            tier2: stat(0, 0, 0),
+            tier3: stat(0, 0, 0),
           },
         }),
       ),
@@ -79,9 +85,9 @@ describe("computeTierSkips", () => {
       JSON.stringify(
         record({
           tier_stats_30d: {
-            tier1: { attempts: 20, ok: 6, fail: 14 },
-            tier2: { attempts: 0, ok: 0, fail: 0 },
-            tier3: { attempts: 0, ok: 0, fail: 0 },
+            tier1: stat(20, 6, 14),
+            tier2: stat(0, 0, 0),
+            tier3: stat(0, 0, 0),
           },
         }),
       ),
@@ -95,9 +101,9 @@ describe("computeTierSkips", () => {
       JSON.stringify(
         record({
           tier_stats_30d: {
-            tier1: { attempts: 50, ok: 1, fail: 49 },
-            tier2: { attempts: 50, ok: 5, fail: 45 },
-            tier3: { attempts: 0, ok: 0, fail: 0 },
+            tier1: stat(50, 1, 49),
+            tier2: stat(50, 5, 45),
+            tier3: stat(0, 0, 0),
           },
         }),
       ),
@@ -121,9 +127,9 @@ describe("computeTierSkips", () => {
       JSON.stringify(
         record({
           tier_stats_30d: {
-            tier1: { attempts: 20, ok: 1, fail: 19 },
-            tier2: { attempts: 0, ok: 0, fail: 0 },
-            tier3: { attempts: 0, ok: 0, fail: 0 },
+            tier1: stat(20, 1, 19),
+            tier2: stat(0, 0, 0),
+            tier3: stat(0, 0, 0),
           },
         }),
       ),
@@ -138,9 +144,9 @@ describe("computeTierSkips", () => {
       JSON.stringify(
         record({
           tier_stats_30d: {
-            tier1: { attempts: 20, ok: 1, fail: 19 },
-            tier2: { attempts: 0, ok: 0, fail: 0 },
-            tier3: { attempts: 0, ok: 0, fail: 0 },
+            tier1: stat(20, 1, 19),
+            tier2: stat(0, 0, 0),
+            tier3: stat(0, 0, 0),
           },
         }),
       ),


### PR DESCRIPTION
## Summary

- **Phase 1:** Migrate NATS client from deprecated `nats` v2 to `@nats-io/nats-core` + `@nats-io/transport-node` v3; lazy-load pattern preserved
- **Phase 2:** `tier_stats_30d` now implements a real 30-day rolling window via `window_start_ms` reset strategy; domain-db schema bumped to v2 (v1 records discarded on read)
- **Phase 3:** `src/fetch.ts` refactored from 601 → 296 lines by extracting tier handlers into `src/tiers/{firecrawl,crawl4ai,raw,github}.ts` and shared primitives into `src/fetch-utils.ts`
- **Security (L1):** `fetchRawHtmlForMetadata` gains co-located `assertPublicUrl` guard matching its sibling `rawFetch`

## Test plan

- [x] 149 tests across 16 files — all passing
- [x] `pnpm build` clean (tsc)
- [x] `pnpm audit` clean
- [x] Security audit completed (1 finding — resolved)
- [x] Biome lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)