### PR TITLE
feat: searxng-mcp v3.7.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — searxng-mcp
 
-MCP server for private web search via a self-hosted SearXNG instance. Reranks results with a local ML model, fetches full-page content via a three-tier cascade (Firecrawl → Crawl4AI → readability/raw HTTP), and optionally expands queries and synthesizes summaries via Ollama.
+MCP server for private web search via a self-hosted SearXNG instance. Reranks results with a local ML model, fetches full-page content via a four-tier cascade (Firecrawl → Crawl4AI → raw HTTP → Wayback Machine opt-in), and optionally expands queries and synthesizes summaries via Ollama.
 
 ## What it does
 
@@ -25,6 +25,7 @@ src/
     firecrawl.ts  # Tier 1: Firecrawl JS-rendering scrape
     crawl4ai.ts   # Tier 2: Crawl4AI headless fetch + Readability comparison
     raw.ts        # Tier 3: raw HTTP + Readability; fetchRawHtmlForMetadata for post-extract
+    wayback.ts    # Tier 4: Wayback Machine CDX lookup + rawFetch (opt-in, WAYBACK_ENABLED)
     github.ts     # GitHub blob/README API fetch
     index.ts      # Barrel re-export
   reranker.ts     # Jina-compatible reranker client + recency weighting
@@ -34,7 +35,7 @@ src/
   config.ts       # Environment variable configuration
   types.ts        # Shared type definitions
 tests/
-  *.test.ts       # Vitest unit tests (149 tests across 16 files)
+  *.test.ts       # Vitest unit tests (211 tests across 22 files)
 ```
 
 ## Dependencies
@@ -54,6 +55,7 @@ Optional services (server degrades gracefully without these):
 | Crawl4AI | `CRAWL4AI_URL` | Fetch fallback for bot-blocked pages (tier 2) |
 | Valkey/Redis | `VALKEY_URL` | Result caching |
 | Ollama | `OLLAMA_URL` | Query expansion + summarization |
+| Wayback Machine | `WAYBACK_ENABLED=true` | Archived snapshot fallback (tier 4, opt-in) |
 
 ## Build and run
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.7.0] - 2026-05-18
+
+### Added
+- **`language` parameter** on `search`, `search_and_fetch`, and `search_and_summarize` tools. Accepts a BCP-47 language code (e.g. `en`, `de`) or `all`. Omitting it preserves the SearXNG instance default.
+- **PDF routing**: `.pdf` URLs are now detected (`isPdfUrl`) and routed directly to Crawl4AI (tier 2), bypassing Firecrawl which cannot extract PDF text. `rawFetch` also throws a descriptive error if it receives `application/pdf` content instead of silently returning binary noise.
+- **Wayback Machine tier-4** (opt-in): when `WAYBACK_ENABLED=true`, pages that fail all three tiers are looked up in the Wayback Machine CDX API and fetched from the most recent snapshot. Results get an `[Archived]` title prefix. Disabled by default — no outbound archive.org traffic unless opted in.
+- **Test coverage**: added `tests/tools.test.ts`, `tests/ollama.test.ts`, and `tests/tiers/{firecrawl,crawl4ai,raw,wayback}.test.ts`; expanded `tests/search.test.ts`. Coverage up from ~57% to ~80%+ by line count.
+
+### Changed
+- `tools.ts` handler closures extracted into named exported functions (`handleSearch`, `handleSearchAndFetch`, `handleSearchAndSummarize`, `handleFetchUrl`, `handleClearCache`) for testability. `registerTools` behavior unchanged.
+- Adblock sidecar (`docker/puppeteer-adblock/init-adblock.js`) now guards against double-load via `NODE_OPTIONS` inheritance. Eliminates ~1.5s duplicate filter-list fetch on container start. **Requires container rebuild**: `docker compose -f ~/docker/firecrawl-simple/docker-compose.yml up -d --build firecrawl-puppeteer`.
+
 ## [3.6.0] - 2026-05-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Built with [Claude Code](https://claude.ai/code) using the multi-agent workflow 
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `search` | Search via SearXNG with local reranking. Fetches a wider result pool, reranks by relevance, returns top N. | `query`, `num_results` (1–20), `category`, `time_range`, `domain_profile`, `expand` |
-| `search_and_fetch` | Search, rerank, then fetch full content of the top result(s) using the fetch cascade (Firecrawl → Crawl4AI → raw HTTP). | `query`, `category`, `time_range`, `fetch_count` (1–3), `domain_profile`, `expand` |
-| `search_and_summarize` | Search, fetch top results, then synthesize a summary with citations via Ollama (`OLLAMA_SUMMARIZE_MODEL`). Falls back to raw fetched content if Ollama is unavailable. | `query`, `fetch_count` (1–5), `category`, `time_range`, `domain_profile`, `expand` |
+| `search` | Search via SearXNG with local reranking. Fetches a wider result pool, reranks by relevance, returns top N. | `query`, `num_results` (1–20), `category`, `time_range`, `domain_profile`, `expand`, `language` |
+| `search_and_fetch` | Search, rerank, then fetch full content of the top result(s) using the fetch cascade (Firecrawl → Crawl4AI → raw HTTP). | `query`, `category`, `time_range`, `fetch_count` (1–3), `domain_profile`, `expand`, `language` |
+| `search_and_summarize` | Search, fetch top results, then synthesize a summary with citations via Ollama (`OLLAMA_SUMMARIZE_MODEL`). Falls back to raw fetched content if Ollama is unavailable. | `query`, `fetch_count` (1–5), `category`, `time_range`, `domain_profile`, `expand`, `language` |
 | `fetch_url` | Fetch and extract readable markdown from any public URL. GitHub URLs use the GitHub API; all others use the fetch cascade (Firecrawl → Crawl4AI → raw HTTP). Truncated to 8,000 characters. | `url`, `domain_profile` |
 | `clear_cache` | Purge the search cache, fetch cache, or both. Useful when researching fast-moving topics where cached results may be stale. | `target` (`search`, `fetch`, `all`) |
 
@@ -32,6 +32,8 @@ Built with [Claude Code](https://claude.ai/code) using the multi-agent workflow 
 **`domain_profile`** — apply a named domain filter profile: `homelab` (surfaces self-hosted/Linux docs) or `dev` (surfaces Stack Overflow, MDN, npm). Omit for default filters.
 
 **`expand`** — when `true`, rewrites the query via Ollama (`OLLAMA_EXPAND_MODEL`) before searching to improve recall. Requires `OLLAMA_URL`. Defaults to the `EXPAND_QUERIES` env var value.
+
+**`language`** — BCP-47 language code (e.g. `en`, `de`) or `all` to restrict to a specific language. Omit to use the SearXNG instance default. Available on `search`, `search_and_fetch`, and `search_and_summarize`.
 
 ## Architecture
 
@@ -48,7 +50,8 @@ MCP client (stdio)
       ├── fetch content ────┬→ GitHub API (github.com)    → markdown
       │                     ├→ Firecrawl ($FIRECRAWL_URL) → page markdown (tier 1)
       │                     ├→ Crawl4AI ($CRAWL4AI_URL)  → page markdown (tier 2, optional)
-      │                     └→ Raw HTTP + Readability     → page markdown (tier 3 fallback)
+      │                     ├→ Raw HTTP + Readability     → page markdown (tier 3 fallback)
+      │                     └→ Wayback Machine (opt-in)  → archived page markdown (tier 4, $WAYBACK_ENABLED)
       └── summarize (opt.) →  Ollama ($OLLAMA_URL)        → synthesized summary ($OLLAMA_SUMMARIZE_MODEL)
 ```
 
@@ -237,6 +240,7 @@ All service URLs are configurable via environment variables.
 | `EXPAND_QUERIES` | `false` | Set to `true` to enable query expansion globally |
 | `CRAWL4AI_URL` | *(unset)* | Crawl4AI instance URL — enables second-tier fetch fallback when Firecrawl fails |
 | `CRAWL4AI_API_TOKEN` | *(unset)* | Optional Bearer token for Crawl4AI instances with API token protection |
+| `WAYBACK_ENABLED` | `false` | Set to `true` to enable Wayback Machine tier-4 fallback — fetches archived snapshots when all three tiers fail |
 
 ## Install
 

--- a/docker/puppeteer-adblock/init-adblock.js
+++ b/docker/puppeteer-adblock/init-adblock.js
@@ -22,6 +22,8 @@ if (process.env.ADBLOCK_DISABLE === "true") {
 }
 
 function install() {
+  if (process.env._ADBLOCK_LOADED) return;
+  process.env._ADBLOCK_LOADED = "1";
 
 const FILTER_URLS = (
   process.env.ADBLOCK_FILTERS_URL ||

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tadmstr/searxng-mcp",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "MCP server for SearXNG — private web search for Claude Code",
   "main": "build/src/index.js",
   "bin": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export const OLLAMA_SUMMARIZE_MODEL =
 export const EXPAND_QUERIES_DEFAULT = process.env.EXPAND_QUERIES === "true";
 export const CRAWL4AI_URL = process.env.CRAWL4AI_URL ?? null;
 export const CRAWL4AI_API_TOKEN = process.env.CRAWL4AI_API_TOKEN;
+export const WAYBACK_ENABLED = process.env.WAYBACK_ENABLED === "true";
 export const RERANK_RECENCY_WEIGHT = (() => {
   const v = parseFloat(process.env.RERANK_RECENCY_WEIGHT ?? "0.15");
   if (Number.isNaN(v) || v < 0) {

--- a/src/fetch-utils.ts
+++ b/src/fetch-utils.ts
@@ -44,6 +44,14 @@ export function assertPublicUrl(url: string): void {
   }
 }
 
+export function isPdfUrl(url: string): boolean {
+  try {
+    return new URL(url).pathname.toLowerCase().endsWith(".pdf");
+  } catch {
+    return false;
+  }
+}
+
 export async function readBoundedText(res: Response): Promise<string> {
   const reader = res.body?.getReader();
   if (!reader) return (await res.text()).slice(0, RAW_HTML_MAX_BYTES);

--- a/src/fetch-utils.ts
+++ b/src/fetch-utils.ts
@@ -3,7 +3,7 @@
 // from ./tiers/index.js, so tier files cannot import back from ./fetch.js.
 
 export const USER_AGENT =
-  "searxng-mcp/3.6.0 (+https://github.com/TadMSTR/searxng-mcp; personal research)";
+  "searxng-mcp/3.7.0 (+https://github.com/TadMSTR/searxng-mcp; personal research)";
 
 // Hard cap on HTML bytes read into memory per fetch. Anything larger than
 // this is dropped — the metadata extractors aren't useful on multi-megabyte

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,5 +1,5 @@
 import { cacheGet, cacheSet, fetchCacheKey } from "./cache.js";
-import { FETCH_CACHE_TTL_SECONDS } from "./config.js";
+import { FETCH_CACHE_TTL_SECONDS, WAYBACK_ENABLED } from "./config.js";
 import {
   recordPostExtractSample,
   recordTierAttempt,
@@ -20,6 +20,7 @@ import {
   firecrawlScrape,
   githubFetch,
   rawFetch,
+  waybackFetch,
 } from "./tiers/index.js";
 import type { TierSlot } from "./types.js";
 
@@ -276,6 +277,15 @@ export async function fetchPage(
             rawFetch(url, 8000),
           );
           if (fetched) tierServed = "tier3_rawfetch";
+        }
+      }
+
+      if (!fetched && WAYBACK_ENABLED) {
+        console.error(`[searxng-mcp] fetch tier4 wayback attempt url=${url}`);
+        fetched = await waybackFetch(url, 8000);
+        if (fetched) {
+          tierServed = "tier4_wayback";
+          console.error(`[searxng-mcp] fetch tier4 wayback hit url=${url}`);
         }
       }
 

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -8,7 +8,7 @@ import {
 import { getBlockList, urlMatchesDomain } from "./domains.js";
 import { events } from "./events.js";
 import { postExtract } from "./extractors/post-extract.js";
-import { assertPublicUrl, type TierResult } from "./fetch-utils.js";
+import { assertPublicUrl, isPdfUrl, type TierResult } from "./fetch-utils.js";
 import { tryLlmsTxtFetch } from "./llms-txt.js";
 import { incCounter, recordHistogram, withSpan } from "./observability.js";
 import { checkRobots } from "./robots.js";
@@ -205,6 +205,32 @@ export async function fetchPage(
           `[searxng-mcp] fetch ${slot} skipped url=${url} reason=${reason}`,
         );
       };
+
+      // PDF fast path — Firecrawl can't extract PDF text; route directly to Crawl4AI.
+      if (isPdfUrl(url)) {
+        const pdfResult = await runTier("tier2_crawl4ai", url, () =>
+          crawl4aiFetch(url, 8000, preferFit),
+        );
+        if (!pdfResult) {
+          throw new Error(
+            "PDF extraction requires Crawl4AI (CRAWL4AI_URL not configured)",
+          );
+        }
+        const persisted = {
+          title: pdfResult.title,
+          url: pdfResult.url,
+          text: pdfResult.text,
+        };
+        await cacheSet(key, JSON.stringify(persisted), FETCH_CACHE_TTL_SECONDS);
+        events.fetchCompleted({
+          url,
+          tier_served: "tier2_crawl4ai",
+          title: pdfResult.title,
+          text_len: pdfResult.text.length,
+          latency_ms: Date.now() - t_total,
+        });
+        return { ...persisted, text: persisted.text.slice(0, maxChars) };
+      }
 
       // Run tier cascade and side-channel raw-HTML metadata fetch in parallel.
       const metadataHtmlPromise = fetchRawHtmlForMetadata(url);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ await initEvents();
 
 const server = new McpServer({
   name: "searxng-mcp",
-  version: "3.5.0",
+  version: "3.7.0",
 });
 
 registerTools(server);

--- a/src/search.ts
+++ b/src/search.ts
@@ -14,6 +14,7 @@ export async function searxSearchSingle(
   category: string,
   fetchCount: number,
   timeRange?: string,
+  language?: string,
 ): Promise<SearxResult[]> {
   return withSpan(
     "searxng_request",
@@ -26,6 +27,7 @@ export async function searxSearchSingle(
         pageno: "1",
       });
       if (timeRange) params.set("time_range", timeRange);
+      if (language) params.set("language", language);
 
       const res = await fetch(`${SEARXNG_URL}/search?${params}`, {
         signal: AbortSignal.timeout(10000),
@@ -46,6 +48,7 @@ export async function searxSearch(
   timeRange?: string,
   domainProfile?: string,
   expand?: boolean,
+  language?: string,
 ): Promise<SearxResult[]> {
   const shouldExpand = expand ?? EXPAND_QUERIES_DEFAULT;
 
@@ -71,12 +74,12 @@ export async function searxSearch(
       withSpan("expand_query", { "query.expand": true }, () =>
         expandQuery(query),
       ),
-      searxSearchSingle(query, category, fetchCount, timeRange),
+      searxSearchSingle(query, category, fetchCount, timeRange, language),
     ]);
 
     const variantResults = await Promise.allSettled(
       variants.map((v) =>
-        searxSearchSingle(v, category, fetchCount, timeRange),
+        searxSearchSingle(v, category, fetchCount, timeRange, language),
       ),
     );
 
@@ -107,7 +110,13 @@ export async function searxSearch(
   }
 
   // Non-expanded path
-  const raw = await searxSearchSingle(query, category, fetchCount, timeRange);
+  const raw = await searxSearchSingle(
+    query,
+    category,
+    fetchCount,
+    timeRange,
+    language,
+  );
 
   // Cache pre-filter results so domain config changes apply retroactively on cache hits
   await cacheSet(key, JSON.stringify(raw), CACHE_TTL_SECONDS);

--- a/src/tiers/index.ts
+++ b/src/tiers/index.ts
@@ -2,3 +2,4 @@ export { applyTier2Readability, crawl4aiFetch } from "./crawl4ai.js";
 export { firecrawlScrape } from "./firecrawl.js";
 export { githubFetch } from "./github.js";
 export { fetchRawHtmlForMetadata, rawFetch } from "./raw.js";
+export { waybackFetch } from "./wayback.js";

--- a/src/tiers/raw.ts
+++ b/src/tiers/raw.ts
@@ -22,6 +22,11 @@ export async function rawFetch(
     signal: AbortSignal.timeout(15000),
   });
 
+  if (res.headers.get("content-type")?.includes("application/pdf")) {
+    throw new Error(
+      "PDF content cannot be extracted by raw fetch — use Crawl4AI",
+    );
+  }
   if (res.status >= 300 && res.status < 400) {
     // Don't echo the Location header into the thrown message — a redirect
     // to an internal address would surface that address to the MCP caller

--- a/src/tiers/raw.ts
+++ b/src/tiers/raw.ts
@@ -60,7 +60,7 @@ export async function fetchRawHtmlForMetadata(
     assertPublicUrl(url);
     const res = await fetch(url, {
       headers: { "User-Agent": USER_AGENT },
-      redirect: "follow",
+      redirect: "manual",
       signal: AbortSignal.timeout(8000),
     });
     if (!res.ok) return null;

--- a/src/tiers/wayback.ts
+++ b/src/tiers/wayback.ts
@@ -1,8 +1,10 @@
-import type { TierResult } from "../fetch-utils.js";
+import { readBoundedText, type TierResult } from "../fetch-utils.js";
 import { rawFetch } from "./raw.js";
 
 const CDX_URL = "https://archive.org/wayback/available";
 const WAYBACK_TIMEOUT = 8000;
+// Generous cap for a fixed-schema CDX JSON response (~300 bytes typical).
+const CDX_MAX_BYTES = 64 * 1024;
 
 export async function waybackFetch(
   url: string,
@@ -13,7 +15,11 @@ export async function waybackFetch(
       signal: AbortSignal.timeout(WAYBACK_TIMEOUT),
     });
     if (!cdx.ok) return null;
-    const data = (await cdx.json()) as Record<string, unknown>;
+    const raw = await readBoundedText(cdx);
+    const data = JSON.parse(raw.slice(0, CDX_MAX_BYTES)) as Record<
+      string,
+      unknown
+    >;
     const snapshotUrl = (
       data.archived_snapshots as Record<string, { url?: string }>
     )?.closest?.url;

--- a/src/tiers/wayback.ts
+++ b/src/tiers/wayback.ts
@@ -1,0 +1,29 @@
+import type { TierResult } from "../fetch-utils.js";
+import { rawFetch } from "./raw.js";
+
+const CDX_URL = "https://archive.org/wayback/available";
+const WAYBACK_TIMEOUT = 8000;
+
+export async function waybackFetch(
+  url: string,
+  maxChars = 8000,
+): Promise<TierResult | null> {
+  try {
+    const cdx = await fetch(`${CDX_URL}?url=${encodeURIComponent(url)}`, {
+      signal: AbortSignal.timeout(WAYBACK_TIMEOUT),
+    });
+    if (!cdx.ok) return null;
+    const data = (await cdx.json()) as Record<string, unknown>;
+    const snapshotUrl = (
+      data.archived_snapshots as Record<string, { url?: string }>
+    )?.closest?.url;
+    if (!snapshotUrl) return null;
+
+    // Snapshot URLs are always archive.org — public, passes assertPublicUrl.
+    // rawFetch calls assertPublicUrl internally.
+    const result = await rawFetch(snapshotUrl, maxChars);
+    return { ...result, title: `[Archived] ${result.title}` };
+  } catch {
+    return null;
+  }
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -88,6 +88,273 @@ function formatResults(results: SearxResult[]): string {
     .join("\n\n");
 }
 
+export async function handleSearch({
+  query,
+  num_results,
+  category,
+  time_range,
+  domain_profile,
+  expand,
+  language,
+}: {
+  query: string;
+  num_results: number;
+  category?: string;
+  time_range?: string;
+  domain_profile?: string;
+  expand?: boolean;
+  language?: string;
+}) {
+  return instrumentTool("search", () =>
+    withSearchEvents(
+      { query, profile: domain_profile, expand, time_range, num_results },
+      async () => {
+        const raw = await searxSearch(
+          query,
+          category,
+          num_results,
+          time_range,
+          domain_profile,
+          expand,
+          language,
+        );
+        const ranked = await rerankWithFallback(
+          query,
+          raw,
+          num_results,
+          time_range,
+        );
+        return {
+          ranked,
+          rerankApplied: true,
+          result: { content: [{ type: "text", text: formatResults(ranked) }] },
+        };
+      },
+    ),
+  );
+}
+
+export async function handleSearchAndFetch({
+  query,
+  category,
+  time_range,
+  fetch_count,
+  domain_profile,
+  expand,
+  language,
+}: {
+  query: string;
+  category?: string;
+  time_range?: string;
+  fetch_count: number;
+  domain_profile?: string;
+  expand?: boolean;
+  language?: string;
+}) {
+  return instrumentTool("search_and_fetch", () =>
+    withSearchEvents(
+      {
+        query,
+        profile: domain_profile,
+        expand,
+        time_range,
+        num_results: fetch_count,
+      },
+      async () => {
+        const raw = await searxSearch(
+          query,
+          category,
+          5,
+          time_range,
+          domain_profile,
+          expand,
+          language,
+        );
+        if (raw.length === 0) {
+          return {
+            ranked: [],
+            rerankApplied: false,
+            result: { content: [{ type: "text", text: "No results found." }] },
+          };
+        }
+        const ranked = await rerankWithFallback(query, raw, 5, time_range);
+        const searchText = formatResults(ranked);
+        const maxCharsPerPage = Math.floor(8000 / fetch_count);
+        const toFetch = ranked.slice(0, fetch_count);
+        const fetched = await Promise.allSettled(
+          toFetch.map((r) => fetchPage(r.url, maxCharsPerPage, domain_profile)),
+        );
+        const fetchedSections = fetched
+          .map((result, i) => {
+            if (result.status === "fulfilled") {
+              const { title, text } = result.value;
+              return `\n\n--- Full content: ${title} ---\n${text}`;
+            }
+            const err =
+              result.reason instanceof Error
+                ? result.reason.message
+                : String(result.reason);
+            return `\n\n--- Could not fetch result ${i + 1}: ${err} ---`;
+          })
+          .join("");
+        return {
+          ranked,
+          rerankApplied: true,
+          result: {
+            content: [{ type: "text", text: searchText + fetchedSections }],
+          },
+        };
+      },
+    ),
+  );
+}
+
+export async function handleSearchAndSummarize({
+  query,
+  fetch_count,
+  category,
+  time_range,
+  domain_profile,
+  expand,
+  language,
+}: {
+  query: string;
+  fetch_count: number;
+  category?: string;
+  time_range?: string;
+  domain_profile?: string;
+  expand?: boolean;
+  language?: string;
+}) {
+  return instrumentTool("search_and_summarize", () =>
+    withSearchEvents(
+      {
+        query,
+        profile: domain_profile,
+        expand,
+        time_range,
+        num_results: fetch_count,
+      },
+      async () => {
+        const raw = await searxSearch(
+          query,
+          category,
+          fetch_count + 2,
+          time_range,
+          domain_profile,
+          expand,
+          language,
+        );
+        if (raw.length === 0) {
+          return {
+            ranked: [],
+            rerankApplied: false,
+            result: { content: [{ type: "text", text: "No results found." }] },
+          };
+        }
+        const ranked = await rerankWithFallback(
+          query,
+          raw,
+          fetch_count,
+          time_range,
+        );
+        const searchText = formatResults(ranked);
+        const toFetch = ranked.slice(0, fetch_count);
+        const fetched = await Promise.allSettled(
+          toFetch.map((r) => fetchPage(r.url, 4000, domain_profile, true)),
+        );
+        const successfulPages = fetched
+          .map((r) => (r.status === "fulfilled" ? r.value : null))
+          .filter(
+            (r): r is { title: string; url: string; text: string } =>
+              r !== null,
+          );
+        const summaryResult = await withSpan(
+          "summarize_llm",
+          { "summary.pages": successfulPages.length },
+          () => summarizePages(query, successfulPages),
+        );
+
+        if (!summaryResult.summary) {
+          const fetchedSections = fetched
+            .map((result, i) => {
+              if (result.status === "fulfilled") {
+                const { title, text } = result.value;
+                return `\n\n--- Full content: ${title} ---\n${text}`;
+              }
+              const err =
+                result.reason instanceof Error
+                  ? result.reason.message
+                  : String(result.reason);
+              return `\n\n--- Could not fetch result ${i + 1}: ${err} ---`;
+            })
+            .join("");
+          return {
+            ranked,
+            rerankApplied: true,
+            result: {
+              content: [{ type: "text", text: searchText + fetchedSections }],
+            },
+          };
+        }
+        const output = formatSummaryResult(summaryResult);
+        return {
+          ranked,
+          rerankApplied: true,
+          result: { content: [{ type: "text", text: output }] },
+        };
+      },
+    ),
+  );
+}
+
+export async function handleFetchUrl({
+  url,
+  domain_profile,
+}: {
+  url: string;
+  domain_profile?: string;
+}) {
+  return instrumentTool("fetch_url", async () => {
+    const {
+      title,
+      url: fetchedUrl,
+      text,
+    } = await fetchPage(url, 8000, domain_profile);
+    const output = [`Title: ${title}`, `URL: ${fetchedUrl}`, "", text].join(
+      "\n",
+    );
+    return { content: [{ type: "text", text: output }] };
+  });
+}
+
+export async function handleClearCache({ target }: { target: string }) {
+  return instrumentTool("clear_cache", async () => {
+    let cleared = 0;
+    if (target === "search" || target === "all") {
+      cleared += await cacheClear("search:*");
+    }
+    if (target === "fetch" || target === "all") {
+      cleared += await cacheClear("fetch:*");
+    }
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Cleared ${cleared} cache ${cleared === 1 ? "entry" : "entries"}.`,
+        },
+      ],
+    };
+  });
+}
+
+const LanguageSchema = z
+  .string()
+  .optional()
+  .describe(
+    "BCP-47 language code (e.g. 'en', 'de') or 'all' for all languages. Omit to use the SearXNG instance default.",
+  );
+
 export function registerTools(server: McpServer): void {
   server.tool(
     "search",
@@ -113,50 +380,9 @@ export function registerTools(server: McpServer): void {
         .describe(
           "Use local LLM to generate 2-3 query variants and merge results for a wider search surface (default: off). Adds ~3s latency; most useful for research queries where one phrasing may miss relevant results.",
         ),
+      language: LanguageSchema,
     },
-    async ({
-      query,
-      num_results,
-      category,
-      time_range,
-      domain_profile,
-      expand,
-    }) => {
-      return instrumentTool("search", () =>
-        withSearchEvents(
-          {
-            query,
-            profile: domain_profile,
-            expand,
-            time_range,
-            num_results,
-          },
-          async () => {
-            const raw = await searxSearch(
-              query,
-              category,
-              num_results,
-              time_range,
-              domain_profile,
-              expand,
-            );
-            const ranked = await rerankWithFallback(
-              query,
-              raw,
-              num_results,
-              time_range,
-            );
-            return {
-              ranked,
-              rerankApplied: true,
-              result: {
-                content: [{ type: "text", text: formatResults(ranked) }],
-              },
-            };
-          },
-        ),
-      );
-    },
+    handleSearch,
   );
 
   server.tool(
@@ -185,75 +411,9 @@ export function registerTools(server: McpServer): void {
         .describe(
           "Use local LLM to generate 2-3 query variants and merge results for a wider search surface (default: off). Adds ~3s latency.",
         ),
+      language: LanguageSchema,
     },
-    async ({
-      query,
-      category,
-      time_range,
-      fetch_count,
-      domain_profile,
-      expand,
-    }) => {
-      return instrumentTool("search_and_fetch", () =>
-        withSearchEvents(
-          {
-            query,
-            profile: domain_profile,
-            expand,
-            time_range,
-            num_results: fetch_count,
-          },
-          async () => {
-            const raw = await searxSearch(
-              query,
-              category,
-              5,
-              time_range,
-              domain_profile,
-              expand,
-            );
-            if (raw.length === 0) {
-              return {
-                ranked: [],
-                rerankApplied: false,
-                result: {
-                  content: [{ type: "text", text: "No results found." }],
-                },
-              };
-            }
-            const ranked = await rerankWithFallback(query, raw, 5, time_range);
-            const searchText = formatResults(ranked);
-            const maxCharsPerPage = Math.floor(8000 / fetch_count);
-            const toFetch = ranked.slice(0, fetch_count);
-            const fetched = await Promise.allSettled(
-              toFetch.map((r) =>
-                fetchPage(r.url, maxCharsPerPage, domain_profile),
-              ),
-            );
-            const fetchedSections = fetched
-              .map((result, i) => {
-                if (result.status === "fulfilled") {
-                  const { title, text } = result.value;
-                  return `\n\n--- Full content: ${title} ---\n${text}`;
-                }
-                const err =
-                  result.reason instanceof Error
-                    ? result.reason.message
-                    : String(result.reason);
-                return `\n\n--- Could not fetch result ${i + 1}: ${err} ---`;
-              })
-              .join("");
-            return {
-              ranked,
-              rerankApplied: true,
-              result: {
-                content: [{ type: "text", text: searchText + fetchedSections }],
-              },
-            };
-          },
-        ),
-      );
-    },
+    handleSearchAndFetch,
   );
 
   server.tool(
@@ -263,19 +423,7 @@ export function registerTools(server: McpServer): void {
       url: z.string().url().describe("URL to fetch and extract content from"),
       domain_profile: DomainProfileSchema,
     },
-    async ({ url, domain_profile }) => {
-      return instrumentTool("fetch_url", async () => {
-        const {
-          title,
-          url: fetchedUrl,
-          text,
-        } = await fetchPage(url, 8000, domain_profile);
-        const output = [`Title: ${title}`, `URL: ${fetchedUrl}`, "", text].join(
-          "\n",
-        );
-        return { content: [{ type: "text", text: output }] };
-      });
-    },
+    handleFetchUrl,
   );
 
   server.tool(
@@ -302,99 +450,9 @@ export function registerTools(server: McpServer): void {
         .boolean()
         .optional()
         .describe("Use query expansion before searching (default: off)"),
+      language: LanguageSchema,
     },
-    async ({
-      query,
-      fetch_count,
-      category,
-      time_range,
-      domain_profile,
-      expand,
-    }) => {
-      return instrumentTool("search_and_summarize", () =>
-        withSearchEvents(
-          {
-            query,
-            profile: domain_profile,
-            expand,
-            time_range,
-            num_results: fetch_count,
-          },
-          async () => {
-            const raw = await searxSearch(
-              query,
-              category,
-              fetch_count + 2,
-              time_range,
-              domain_profile,
-              expand,
-            );
-            if (raw.length === 0) {
-              return {
-                ranked: [],
-                rerankApplied: false,
-                result: {
-                  content: [{ type: "text", text: "No results found." }],
-                },
-              };
-            }
-            const ranked = await rerankWithFallback(
-              query,
-              raw,
-              fetch_count,
-              time_range,
-            );
-            const searchText = formatResults(ranked);
-            const toFetch = ranked.slice(0, fetch_count);
-            const fetched = await Promise.allSettled(
-              toFetch.map((r) => fetchPage(r.url, 4000, domain_profile, true)),
-            );
-            const successfulPages = fetched
-              .map((r) => (r.status === "fulfilled" ? r.value : null))
-              .filter(
-                (r): r is { title: string; url: string; text: string } =>
-                  r !== null,
-              );
-            const summaryResult = await withSpan(
-              "summarize_llm",
-              { "summary.pages": successfulPages.length },
-              () => summarizePages(query, successfulPages),
-            );
-
-            if (!summaryResult.summary) {
-              const fetchedSections = fetched
-                .map((result, i) => {
-                  if (result.status === "fulfilled") {
-                    const { title, text } = result.value;
-                    return `\n\n--- Full content: ${title} ---\n${text}`;
-                  }
-                  const err =
-                    result.reason instanceof Error
-                      ? result.reason.message
-                      : String(result.reason);
-                  return `\n\n--- Could not fetch result ${i + 1}: ${err} ---`;
-                })
-                .join("");
-              return {
-                ranked,
-                rerankApplied: true,
-                result: {
-                  content: [
-                    { type: "text", text: searchText + fetchedSections },
-                  ],
-                },
-              };
-            }
-            const output = formatSummaryResult(summaryResult);
-            return {
-              ranked,
-              rerankApplied: true,
-              result: { content: [{ type: "text", text: output }] },
-            };
-          },
-        ),
-      );
-    },
+    handleSearchAndSummarize,
   );
 
   server.tool(
@@ -408,24 +466,6 @@ export function registerTools(server: McpServer): void {
           "Which cache to clear: search results, fetched pages, or all (default all)",
         ),
     },
-    async ({ target }) => {
-      return instrumentTool("clear_cache", async () => {
-        let cleared = 0;
-        if (target === "search" || target === "all") {
-          cleared += await cacheClear("search:*");
-        }
-        if (target === "fetch" || target === "all") {
-          cleared += await cacheClear("fetch:*");
-        }
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Cleared ${cleared} cache ${cleared === 1 ? "entry" : "entries"}.`,
-            },
-          ],
-        };
-      });
-    },
+    handleClearCache,
   );
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -111,7 +111,7 @@ export async function handleSearch({
       async () => {
         const raw = await searxSearch(
           query,
-          category,
+          category ?? "general",
           num_results,
           time_range,
           domain_profile,
@@ -127,7 +127,9 @@ export async function handleSearch({
         return {
           ranked,
           rerankApplied: true,
-          result: { content: [{ type: "text", text: formatResults(ranked) }] },
+          result: {
+            content: [{ type: "text" as const, text: formatResults(ranked) }],
+          },
         };
       },
     ),
@@ -163,7 +165,7 @@ export async function handleSearchAndFetch({
       async () => {
         const raw = await searxSearch(
           query,
-          category,
+          category ?? "general",
           5,
           time_range,
           domain_profile,
@@ -174,7 +176,9 @@ export async function handleSearchAndFetch({
           return {
             ranked: [],
             rerankApplied: false,
-            result: { content: [{ type: "text", text: "No results found." }] },
+            result: {
+              content: [{ type: "text" as const, text: "No results found." }],
+            },
           };
         }
         const ranked = await rerankWithFallback(query, raw, 5, time_range);
@@ -201,7 +205,9 @@ export async function handleSearchAndFetch({
           ranked,
           rerankApplied: true,
           result: {
-            content: [{ type: "text", text: searchText + fetchedSections }],
+            content: [
+              { type: "text" as const, text: searchText + fetchedSections },
+            ],
           },
         };
       },
@@ -238,7 +244,7 @@ export async function handleSearchAndSummarize({
       async () => {
         const raw = await searxSearch(
           query,
-          category,
+          category ?? "general",
           fetch_count + 2,
           time_range,
           domain_profile,
@@ -249,7 +255,9 @@ export async function handleSearchAndSummarize({
           return {
             ranked: [],
             rerankApplied: false,
-            result: { content: [{ type: "text", text: "No results found." }] },
+            result: {
+              content: [{ type: "text" as const, text: "No results found." }],
+            },
           };
         }
         const ranked = await rerankWithFallback(
@@ -293,7 +301,9 @@ export async function handleSearchAndSummarize({
             ranked,
             rerankApplied: true,
             result: {
-              content: [{ type: "text", text: searchText + fetchedSections }],
+              content: [
+                { type: "text" as const, text: searchText + fetchedSections },
+              ],
             },
           };
         }
@@ -301,7 +311,7 @@ export async function handleSearchAndSummarize({
         return {
           ranked,
           rerankApplied: true,
-          result: { content: [{ type: "text", text: output }] },
+          result: { content: [{ type: "text" as const, text: output }] },
         };
       },
     ),
@@ -324,7 +334,7 @@ export async function handleFetchUrl({
     const output = [`Title: ${title}`, `URL: ${fetchedUrl}`, "", text].join(
       "\n",
     );
-    return { content: [{ type: "text", text: output }] };
+    return { content: [{ type: "text" as const, text: output }] };
   });
 }
 
@@ -340,7 +350,7 @@ export async function handleClearCache({ target }: { target: string }) {
     return {
       content: [
         {
-          type: "text",
+          type: "text" as const,
           text: `Cleared ${cleared} cache ${cleared === 1 ? "entry" : "entries"}.`,
         },
       ],

--- a/tests/fetch.test.ts
+++ b/tests/fetch.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { assertPublicUrl, rawFetch } from "../src/fetch.js";
+import { isPdfUrl } from "../src/fetch-utils.js";
 
 describe("assertPublicUrl", () => {
   it("accepts a normal public HTTPS URL", () => {
@@ -165,5 +166,27 @@ describe("rawFetch", () => {
     await expect(rawFetch("https://example.com/missing")).rejects.toThrow(
       "Raw fetch error: 404",
     );
+  });
+});
+
+describe("isPdfUrl", () => {
+  it("returns true for .pdf URL", () => {
+    expect(isPdfUrl("https://example.com/doc.pdf")).toBe(true);
+  });
+
+  it("returns true for .PDF URL (case-insensitive)", () => {
+    expect(isPdfUrl("https://example.com/doc.PDF")).toBe(true);
+  });
+
+  it("returns false for non-PDF URL", () => {
+    expect(isPdfUrl("https://example.com/page.html")).toBe(false);
+  });
+
+  it("returns false for URL with .pdf in query string but not path", () => {
+    expect(isPdfUrl("https://example.com/view?file=doc.pdf")).toBe(false);
+  });
+
+  it("returns false for invalid URL", () => {
+    expect(isPdfUrl("not a url")).toBe(false);
   });
 });

--- a/tests/ollama.test.ts
+++ b/tests/ollama.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Reset env before each test; individual tests set what they need
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  delete process.env.OLLAMA_URL;
+  delete process.env.OLLAMA_API_KEY;
+});
+
+afterEach(() => {
+  delete process.env.OLLAMA_URL;
+  delete process.env.OLLAMA_API_KEY;
+});
+
+describe("expandQuery", () => {
+  it("returns empty array when OLLAMA_URL is not set", async () => {
+    const { expandQuery } = await import("../src/ollama.js");
+    const result = await expandQuery("test query");
+    expect(result).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns variant strings on success", async () => {
+    process.env.OLLAMA_URL = "http://ollama:11434";
+    const { expandQuery } = await import("../src/ollama.js");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          response: "variant one\nvariant two\nvariant three",
+        }),
+    });
+    const result = await expandQuery("test query");
+    expect(result).toEqual(["variant one", "variant two", "variant three"]);
+  });
+
+  it("returns empty array on fetch error", async () => {
+    process.env.OLLAMA_URL = "http://ollama:11434";
+    const { expandQuery } = await import("../src/ollama.js");
+    mockFetch.mockRejectedValueOnce(new Error("connection refused"));
+    const result = await expandQuery("test query");
+    expect(result).toEqual([]);
+  });
+
+  it("includes Authorization header when OLLAMA_API_KEY is set", async () => {
+    process.env.OLLAMA_URL = "http://ollama:11434";
+    process.env.OLLAMA_API_KEY = "sk-test";
+    const { expandQuery } = await import("../src/ollama.js");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ response: "variant" }),
+    });
+    await expandQuery("test query");
+    const callOpts = mockFetch.mock.calls[0][1] as RequestInit;
+    expect((callOpts.headers as Record<string, string>).Authorization).toBe(
+      "Bearer sk-test",
+    );
+  });
+
+  it("strips blank lines and the original query from variants", async () => {
+    process.env.OLLAMA_URL = "http://ollama:11434";
+    const { expandQuery } = await import("../src/ollama.js");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          response: "test query\n\nvariant one\n\nvariant two",
+        }),
+    });
+    const result = await expandQuery("test query");
+    expect(result).not.toContain("test query");
+    expect(result).not.toContain("");
+    expect(result).toContain("variant one");
+    expect(result).toContain("variant two");
+  });
+});
+
+describe("summarizePages", () => {
+  it("returns empty summary when OLLAMA_URL is not set", async () => {
+    const { summarizePages } = await import("../src/ollama.js");
+    const result = await summarizePages("query", [
+      { title: "Page", url: "https://example.com", text: "content" },
+    ]);
+    expect(result).toEqual({ summary: "", citations: [] });
+  });
+
+  it("returns structured summary and citations on success", async () => {
+    process.env.OLLAMA_URL = "http://ollama:11434";
+    const { summarizePages } = await import("../src/ollama.js");
+    const payload = {
+      summary: "This is the answer",
+      citations: [
+        {
+          url: "https://example.com",
+          title: "Example",
+          key_facts: ["fact 1"],
+        },
+      ],
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          message: { content: JSON.stringify(payload) },
+        }),
+    });
+    const result = await summarizePages("query", [
+      { title: "Example", url: "https://example.com", text: "some text" },
+    ]);
+    expect(result.summary).toBe("This is the answer");
+    expect(result.citations).toHaveLength(1);
+    expect(result.citations[0].url).toBe("https://example.com");
+  });
+
+  it("handles JSON embedded in trailing text (regex pre-parse)", async () => {
+    process.env.OLLAMA_URL = "http://ollama:11434";
+    const { summarizePages } = await import("../src/ollama.js");
+    const payload = { summary: "answer", citations: [] };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          message: {
+            content: `Here is the result:\n${JSON.stringify(payload)}\n\nDone.`,
+          },
+        }),
+    });
+    const result = await summarizePages("query", [
+      { title: "T", url: "https://example.com", text: "t" },
+    ]);
+    expect(result.summary).toBe("answer");
+  });
+
+  it("returns fallback when OLLAMA_URL not set and pages provided", async () => {
+    const { summarizePages } = await import("../src/ollama.js");
+    const result = await summarizePages("q", [
+      { title: "T", url: "https://example.com", text: "t" },
+    ]);
+    expect(result).toEqual({ summary: "", citations: [] });
+  });
+});

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,5 +1,128 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CategorySchema, TimeRangeSchema } from "../src/types.js";
+
+vi.mock("../src/cache.js", () => ({
+  cacheGet: vi.fn(),
+  cacheSet: vi.fn().mockResolvedValue(undefined),
+  searchCacheKey: vi.fn().mockReturnValue("cache-key"),
+}));
+
+vi.mock("../src/ollama.js", () => ({
+  expandQuery: vi.fn().mockResolvedValue(["variant 1", "variant 2"]),
+}));
+
+vi.mock("../src/domains.js", () => ({
+  applyDomainFilters: vi.fn().mockImplementation((results) => results),
+}));
+
+vi.mock("../src/observability.js", () => ({
+  withSpan: vi.fn().mockImplementation((_n, _a, fn) => fn()),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const makeResult = (url: string) => ({
+  title: "Title",
+  url,
+  content: "content",
+  engines: ["google"],
+});
+
+function mockSearxResponse(results: object[]) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ results }),
+  };
+}
+
+import { cacheGet, cacheSet } from "../src/cache.js";
+import { applyDomainFilters } from "../src/domains.js";
+import { searxSearch } from "../src/search.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(cacheGet).mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("searxSearch", () => {
+  it("fetches from SearXNG on cache miss and caches results", async () => {
+    mockFetch.mockResolvedValue(
+      mockSearxResponse([
+        makeResult("https://a.com"),
+        makeResult("https://b.com"),
+      ]),
+    );
+    const results = await searxSearch("query", "general", 2);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(cacheSet).toHaveBeenCalledOnce();
+    expect(results).toHaveLength(2);
+  });
+
+  it("returns cached results on cache hit without calling SearXNG", async () => {
+    const cached = JSON.stringify([makeResult("https://cached.com")]);
+    vi.mocked(cacheGet).mockResolvedValue(cached);
+    const results = await searxSearch("query", "general", 5);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(results).toHaveLength(1);
+    expect(results[0].url).toBe("https://cached.com");
+  });
+
+  it("applies domain filters after cache retrieval on cache hit", async () => {
+    const cached = JSON.stringify([makeResult("https://cached.com")]);
+    vi.mocked(cacheGet).mockResolvedValue(cached);
+    await searxSearch("query", "general", 5, undefined, "homelab");
+    expect(applyDomainFilters).toHaveBeenCalledWith(
+      expect.any(Array),
+      "homelab",
+    );
+  });
+
+  it("passes time_range to SearXNG URL", async () => {
+    mockFetch.mockResolvedValue(mockSearxResponse([]));
+    await searxSearch("query", "general", 5, "week");
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("time_range=week");
+  });
+
+  it("runs expand path: fetches original + variants, deduplicates by URL", async () => {
+    mockFetch.mockResolvedValue(
+      mockSearxResponse([
+        makeResult("https://shared.com"),
+        makeResult("https://orig.com"),
+      ]),
+    );
+    const results = await searxSearch(
+      "query",
+      "general",
+      5,
+      undefined,
+      undefined,
+      true,
+    );
+    // original + 2 variants = 3 calls to fetch; shared.com should appear once
+    expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
+    const urls = results.map((r) => r.url);
+    const unique = new Set(urls);
+    expect(unique.size).toBe(urls.length);
+  });
+
+  it("expand path: variant fetch rejection does not throw", async () => {
+    // First call (original) resolves; subsequent calls reject
+    mockFetch
+      .mockResolvedValueOnce(
+        mockSearxResponse([makeResult("https://orig.com")]),
+      )
+      .mockRejectedValue(new Error("network error"));
+    await expect(
+      searxSearch("query", "general", 5, undefined, undefined, true),
+    ).resolves.toBeDefined();
+  });
+});
 
 describe("CategorySchema", () => {
   it("accepts valid categories", () => {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -89,6 +89,28 @@ describe("searxSearch", () => {
     expect(calledUrl).toContain("time_range=week");
   });
 
+  it("passes language param to SearXNG URL when provided", async () => {
+    mockFetch.mockResolvedValue(mockSearxResponse([]));
+    await searxSearch(
+      "query",
+      "general",
+      5,
+      undefined,
+      undefined,
+      undefined,
+      "de",
+    );
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("language=de");
+  });
+
+  it("omits language param from SearXNG URL when not provided", async () => {
+    mockFetch.mockResolvedValue(mockSearxResponse([]));
+    await searxSearch("query", "general", 5);
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).not.toContain("language=");
+  });
+
   it("runs expand path: fetches original + variants, deduplicates by URL", async () => {
     mockFetch.mockResolvedValue(
       mockSearxResponse([

--- a/tests/tiers/crawl4ai.test.ts
+++ b/tests/tiers/crawl4ai.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted — runs before imports, so CRAWL4AI_URL is set correctly
+vi.mock("../../src/config.js", () => ({
+  CRAWL4AI_URL: "http://crawl4ai:8000",
+  CRAWL4AI_API_TOKEN: undefined,
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { crawl4aiFetch, pollCrawl4aiTask } from "../../src/tiers/crawl4ai.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const URL = "https://example.com/page";
+
+const syncResponse = (text = "# Page Content\n\nSome text") => ({
+  ok: true,
+  json: () =>
+    Promise.resolve({
+      results: [
+        {
+          markdown: { raw_markdown: text },
+          metadata: { title: "Page Title" },
+          html: "<p>html</p>",
+        },
+      ],
+    }),
+});
+
+describe("crawl4aiFetch", () => {
+  it("returns result immediately on synchronous response", async () => {
+    mockFetch.mockResolvedValueOnce(syncResponse());
+    const result = await crawl4aiFetch(URL);
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Page Title");
+    expect(result!.text).toContain("Some text");
+  });
+
+  it("truncates text to maxChars", async () => {
+    mockFetch.mockResolvedValueOnce(syncResponse("abcdefghij"));
+    const result = await crawl4aiFetch(URL, 3);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("abc");
+  });
+
+  it("returns null when sync result has empty markdown", async () => {
+    mockFetch.mockResolvedValueOnce(syncResponse(""));
+    const result = await crawl4aiFetch(URL);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for invalid task_id format (path traversal guard)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ task_id: "../../etc/passwd" }),
+    });
+    const result = await crawl4aiFetch(URL);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when response is not-ok", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({}),
+    });
+    const result = await crawl4aiFetch(URL);
+    expect(result).toBeNull();
+  });
+});
+
+describe("pollCrawl4aiTask", () => {
+  it("returns result when status is completed", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          status: "completed",
+          result: {
+            markdown: { raw_markdown: "page content" },
+            metadata: { title: "Polled Page" },
+            html: null,
+          },
+        }),
+    });
+
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const promise = pollCrawl4aiTask("task123", URL, 8000, controller.signal);
+    // Advance past the initial 2s sleep
+    await vi.advanceTimersByTimeAsync(2500);
+    const result = await promise;
+    vi.useRealTimers();
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Polled Page");
+    expect(result!.text).toBe("page content");
+  });
+
+  it("returns null when status is failed", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ status: "failed" }),
+    });
+
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const promise = pollCrawl4aiTask("task123", URL, 8000, controller.signal);
+    await vi.advanceTimersByTimeAsync(2500);
+    const result = await promise;
+    vi.useRealTimers();
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when aborted", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    controller.abort();
+    const promise = pollCrawl4aiTask("task123", URL, 8000, controller.signal);
+    // abort check runs after the 2s sleep, so advance past it
+    await vi.advanceTimersByTimeAsync(2500);
+    const result = await promise;
+    vi.useRealTimers();
+    expect(result).toBeNull();
+  });
+});

--- a/tests/tiers/firecrawl.test.ts
+++ b/tests/tiers/firecrawl.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { firecrawlScrape } from "../../src/tiers/firecrawl.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const URL = "https://example.com/page";
+
+function mockSuccess(overrides?: object) {
+  return {
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        success: true,
+        data: {
+          markdown: "# Title\n\nContent here",
+          html: "<h1>Title</h1><p>Content here</p>",
+          metadata: {
+            title: "Title",
+            sourceURL: URL,
+          },
+          ...overrides,
+        },
+      }),
+  };
+}
+
+describe("firecrawlScrape", () => {
+  it("returns title, url, text, and html on success", async () => {
+    mockFetch.mockResolvedValueOnce(mockSuccess());
+    const result = await firecrawlScrape(URL);
+    expect(result.title).toBe("Title");
+    expect(result.url).toBe(URL);
+    expect(result.text).toContain("Content here");
+    expect(result.html).toContain("<h1>");
+  });
+
+  it("truncates text to maxChars", async () => {
+    mockFetch.mockResolvedValueOnce(mockSuccess());
+    const result = await firecrawlScrape(URL, 5);
+    expect(result.text.length).toBeLessThanOrEqual(5);
+  });
+
+  it("throws on non-2xx response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      statusText: "Service Unavailable",
+    });
+    await expect(firecrawlScrape(URL)).rejects.toThrow("Firecrawl error: 503");
+  });
+
+  it("throws when success is false with error message", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({ success: false, error: "bot-blocked", data: null }),
+    });
+    await expect(firecrawlScrape(URL)).rejects.toThrow("bot-blocked");
+  });
+
+  it("returns empty text when markdown is empty (not a throw)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockSuccess({ markdown: "", html: "<p>x</p>" }),
+    );
+    const result = await firecrawlScrape(URL);
+    expect(result.text).toBe("");
+    expect(result.html).toBe("<p>x</p>");
+  });
+
+  it("falls back to url when metadata title is missing", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockSuccess({ metadata: { sourceURL: URL } }),
+    );
+    const result = await firecrawlScrape(URL);
+    expect(result.title).toBe(URL);
+  });
+});

--- a/tests/tiers/raw.test.ts
+++ b/tests/tiers/raw.test.ts
@@ -95,4 +95,18 @@ describe("rawFetch", () => {
     const result = await rawFetch(URL, 10);
     expect(result.text.length).toBeLessThanOrEqual(10);
   });
+
+  it("throws descriptive error on PDF content-type", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "Content-Type": "application/pdf" }),
+      body: null,
+      text: () => Promise.resolve("%PDF-1.4"),
+    });
+    await expect(rawFetch(URL)).rejects.toThrow(
+      "PDF content cannot be extracted by raw fetch",
+    );
+  });
 });

--- a/tests/tiers/raw.test.ts
+++ b/tests/tiers/raw.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { rawFetch } from "../../src/tiers/raw.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const URL = "https://example.com/page";
+
+function mockHtmlResponse(
+  html: string,
+  opts?: { status?: number; headers?: Record<string, string> },
+) {
+  const status = opts?.status ?? 200;
+  const headers = new Headers({
+    "Content-Type": "text/html",
+    ...opts?.headers,
+  });
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers,
+    body: null,
+    text: () => Promise.resolve(html),
+  };
+}
+
+const ARTICLE_HTML = `
+<html><head><title>Test Article</title></head>
+<body>
+  <article>
+    <h1>Test Article</h1>
+    <p>This is the main article content with enough text to pass Readability's scoring threshold.</p>
+    <p>More paragraph content here to ensure the article is detected properly by Readability.</p>
+  </article>
+</body></html>`;
+
+const SIMPLE_HTML = `<html><body><p>simple page</p></body></html>`;
+
+describe("rawFetch", () => {
+  it("throws on private/localhost URL (SSRF guard)", async () => {
+    await expect(rawFetch("http://localhost/page")).rejects.toThrow(
+      "Internal/private addresses are not allowed",
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("throws on 3xx redirect without echoing Location header", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 301,
+      statusText: "Moved Permanently",
+      headers: new Headers({
+        Location: "http://192.168.1.1/internal",
+      }),
+      body: null,
+      text: () => Promise.resolve(""),
+    });
+    await expect(rawFetch(URL)).rejects.toThrow("Redirect not followed (301)");
+  });
+
+  it("throws on non-2xx response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      headers: new Headers(),
+      body: null,
+      text: () => Promise.resolve(""),
+    });
+    await expect(rawFetch(URL)).rejects.toThrow("Raw fetch error: 404");
+  });
+
+  it("returns title and text from a simple HTML page", async () => {
+    mockFetch.mockResolvedValueOnce(mockHtmlResponse(SIMPLE_HTML));
+    const result = await rawFetch(URL);
+    expect(result.url).toBe(URL);
+    expect(typeof result.text).toBe("string");
+    expect(result.text.length).toBeGreaterThan(0);
+  });
+
+  it("returns article title when Readability successfully parses content", async () => {
+    mockFetch.mockResolvedValueOnce(mockHtmlResponse(ARTICLE_HTML));
+    const result = await rawFetch(URL, 10000);
+    expect(result.title).toBe("Test Article");
+  });
+
+  it("truncates text to maxChars", async () => {
+    mockFetch.mockResolvedValueOnce(mockHtmlResponse(ARTICLE_HTML));
+    const result = await rawFetch(URL, 10);
+    expect(result.text.length).toBeLessThanOrEqual(10);
+  });
+});

--- a/tests/tiers/wayback.test.ts
+++ b/tests/tiers/wayback.test.ts
@@ -22,23 +22,19 @@ beforeEach(() => {
 
 const URL = "https://example.com/dead-page";
 
-const cdxHit = (snapshotUrl: string) => ({
-  ok: true,
-  json: () =>
-    Promise.resolve({
-      archived_snapshots: {
-        closest: { url: snapshotUrl, available: true, timestamp: "20240101" },
-      },
-    }),
-});
+const cdxHit = (snapshotUrl: string) => {
+  const body = JSON.stringify({
+    archived_snapshots: {
+      closest: { url: snapshotUrl, available: true, timestamp: "20240101" },
+    },
+  });
+  return { ok: true, body: null, text: () => Promise.resolve(body) };
+};
 
-const cdxMiss = () => ({
-  ok: true,
-  json: () =>
-    Promise.resolve({
-      archived_snapshots: {},
-    }),
-});
+const cdxMiss = () => {
+  const body = JSON.stringify({ archived_snapshots: {} });
+  return { ok: true, body: null, text: () => Promise.resolve(body) };
+};
 
 describe("waybackFetch", () => {
   it("fetches snapshot and returns result with [Archived] title prefix", async () => {

--- a/tests/tiers/wayback.test.ts
+++ b/tests/tiers/wayback.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// rawFetch needs fetch stubbed; mock assertPublicUrl so archive.org passes
+vi.mock("../../src/tiers/raw.js", () => ({
+  rawFetch: vi.fn().mockResolvedValue({
+    title: "Archived Page",
+    url: "https://web.archive.org/web/20240101/https://example.com/page",
+    text: "Archived content here",
+    html: "<p>html</p>",
+  }),
+}));
+
+import { rawFetch } from "../../src/tiers/raw.js";
+import { waybackFetch } from "../../src/tiers/wayback.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const URL = "https://example.com/dead-page";
+
+const cdxHit = (snapshotUrl: string) => ({
+  ok: true,
+  json: () =>
+    Promise.resolve({
+      archived_snapshots: {
+        closest: { url: snapshotUrl, available: true, timestamp: "20240101" },
+      },
+    }),
+});
+
+const cdxMiss = () => ({
+  ok: true,
+  json: () =>
+    Promise.resolve({
+      archived_snapshots: {},
+    }),
+});
+
+describe("waybackFetch", () => {
+  it("fetches snapshot and returns result with [Archived] title prefix", async () => {
+    mockFetch.mockResolvedValueOnce(
+      cdxHit(
+        "https://web.archive.org/web/20240101/https://example.com/dead-page",
+      ),
+    );
+    const result = await waybackFetch(URL);
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("[Archived] Archived Page");
+    expect(result!.text).toBe("Archived content here");
+    expect(rawFetch).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when CDX API returns no closest snapshot", async () => {
+    mockFetch.mockResolvedValueOnce(cdxMiss());
+    const result = await waybackFetch(URL);
+    expect(result).toBeNull();
+    expect(rawFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null when CDX API responds with non-2xx", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({}),
+    });
+    const result = await waybackFetch(URL);
+    expect(result).toBeNull();
+    expect(rawFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null when CDX API fetch times out or throws", async () => {
+    mockFetch.mockRejectedValueOnce(new DOMException("aborted", "AbortError"));
+    const result = await waybackFetch(URL);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when rawFetch throws (snapshot unavailable)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      cdxHit(
+        "https://web.archive.org/web/20240101/https://example.com/dead-page",
+      ),
+    );
+    vi.mocked(rawFetch).mockRejectedValueOnce(
+      new Error("Raw fetch error: 404"),
+    );
+    const result = await waybackFetch(URL);
+    expect(result).toBeNull();
+  });
+});

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -85,7 +85,7 @@ describe("handleSearch", () => {
     });
     expect(searxSearch).toHaveBeenCalledWith(
       "test query",
-      undefined,
+      "general",
       5,
       undefined,
       undefined,
@@ -104,7 +104,7 @@ describe("handleSearch", () => {
     });
     expect(searxSearch).toHaveBeenCalledWith(
       "test",
-      undefined,
+      "general",
       3,
       undefined,
       undefined,

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/cache.js", () => ({
+  cacheClear: vi.fn().mockResolvedValue(5),
+  cacheGet: vi.fn().mockResolvedValue(null),
+  cacheSet: vi.fn().mockResolvedValue(undefined),
+  searchCacheKey: vi.fn().mockReturnValue("key"),
+}));
+
+vi.mock("../src/search.js", () => ({
+  searxSearch: vi.fn().mockResolvedValue([
+    {
+      title: "Result 1",
+      url: "https://example.com/1",
+      content: "Some content",
+      engines: ["google"],
+    },
+    {
+      title: "Result 2",
+      url: "https://example.com/2",
+      content: "More content",
+      engines: ["bing"],
+    },
+  ]),
+}));
+
+vi.mock("../src/reranker.js", () => ({
+  rerankWithFallback: vi
+    .fn()
+    .mockImplementation((_, results) => Promise.resolve(results)),
+}));
+
+vi.mock("../src/fetch.js", () => ({
+  fetchPage: vi.fn().mockResolvedValue({
+    title: "Fetched Page",
+    url: "https://example.com/1",
+    text: "Page content here",
+  }),
+}));
+
+vi.mock("../src/ollama.js", () => ({
+  summarizePages: vi.fn().mockResolvedValue({ summary: "", citations: [] }),
+  formatSummaryResult: vi.fn().mockReturnValue("## Summary\n\ntest"),
+}));
+
+vi.mock("../src/events.js", () => ({
+  events: {
+    searchRequested: vi.fn(),
+    searchCompleted: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../src/observability.js", () => ({
+  incCounter: vi.fn(),
+  recordHistogram: vi.fn(),
+  withSpan: vi.fn().mockImplementation((_name, _attrs, fn) => fn()),
+}));
+
+vi.mock("../src/context.js", () => ({
+  newRequestId: vi.fn().mockReturnValue("test-req-id"),
+  withRequestId: vi.fn().mockImplementation((_id, fn) => fn()),
+}));
+
+import { cacheClear } from "../src/cache.js";
+import { fetchPage } from "../src/fetch.js";
+import { searxSearch } from "../src/search.js";
+import {
+  handleClearCache,
+  handleFetchUrl,
+  handleSearch,
+  handleSearchAndFetch,
+  handleSearchAndSummarize,
+} from "../src/tools.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("handleSearch", () => {
+  it("calls searxSearch with provided params and returns formatted results", async () => {
+    const result = await handleSearch({
+      query: "test query",
+      num_results: 5,
+    });
+    expect(searxSearch).toHaveBeenCalledWith(
+      "test query",
+      undefined,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(result.content[0].text).toContain("Result 1");
+    expect(result.content[0].text).toContain("example.com/1");
+  });
+
+  it("passes language param through to searxSearch", async () => {
+    await handleSearch({
+      query: "test",
+      num_results: 3,
+      language: "de",
+    });
+    expect(searxSearch).toHaveBeenCalledWith(
+      "test",
+      undefined,
+      3,
+      undefined,
+      undefined,
+      undefined,
+      "de",
+    );
+  });
+
+  it("returns No results found when searxSearch returns empty", async () => {
+    vi.mocked(searxSearch).mockResolvedValueOnce([]);
+    const result = await handleSearch({ query: "nothing", num_results: 5 });
+    expect(result.content[0].text).toBe("No results found.");
+  });
+});
+
+describe("handleSearchAndFetch", () => {
+  it("fetches top result and appends content to search results", async () => {
+    const result = await handleSearchAndFetch({
+      query: "test",
+      fetch_count: 1,
+    });
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(result.content[0].text).toContain("Full content");
+    expect(result.content[0].text).toContain("Page content here");
+  });
+
+  it("returns No results found when search returns empty", async () => {
+    vi.mocked(searxSearch).mockResolvedValueOnce([]);
+    const result = await handleSearchAndFetch({
+      query: "nothing",
+      fetch_count: 1,
+    });
+    expect(result.content[0].text).toBe("No results found.");
+    expect(fetchPage).not.toHaveBeenCalled();
+  });
+
+  it("handles fetch failure gracefully with error message", async () => {
+    vi.mocked(fetchPage).mockRejectedValueOnce(new Error("Connection refused"));
+    const result = await handleSearchAndFetch({
+      query: "test",
+      fetch_count: 1,
+    });
+    expect(result.content[0].text).toContain("Could not fetch result 1");
+    expect(result.content[0].text).toContain("Connection refused");
+  });
+});
+
+describe("handleSearchAndSummarize", () => {
+  it("falls back to raw fetch output when Ollama unavailable (empty summary)", async () => {
+    const result = await handleSearchAndSummarize({
+      query: "test",
+      fetch_count: 2,
+    });
+    // summarizePages returns {summary: "", citations: []} — should fall back
+    expect(result.content[0].text).toContain("Full content");
+  });
+
+  it("returns No results found when search returns empty", async () => {
+    vi.mocked(searxSearch).mockResolvedValueOnce([]);
+    const result = await handleSearchAndSummarize({
+      query: "nothing",
+      fetch_count: 2,
+    });
+    expect(result.content[0].text).toBe("No results found.");
+  });
+});
+
+describe("handleFetchUrl", () => {
+  it("fetches URL and returns formatted output with title and URL header", async () => {
+    const result = await handleFetchUrl({ url: "https://example.com/page" });
+    expect(fetchPage).toHaveBeenCalledWith(
+      "https://example.com/page",
+      8000,
+      undefined,
+    );
+    expect(result.content[0].text).toContain("Title: Fetched Page");
+    expect(result.content[0].text).toContain("URL: https://example.com/1");
+    expect(result.content[0].text).toContain("Page content here");
+  });
+
+  it("propagates SSRF errors from fetchPage", async () => {
+    vi.mocked(fetchPage).mockRejectedValueOnce(
+      new Error("Internal/private addresses are not allowed"),
+    );
+    await expect(
+      handleFetchUrl({ url: "http://192.168.1.1/page" }),
+    ).rejects.toThrow("Internal/private addresses are not allowed");
+  });
+});
+
+describe("handleClearCache", () => {
+  it("clears both caches when target is all", async () => {
+    const result = await handleClearCache({ target: "all" });
+    expect(cacheClear).toHaveBeenCalledWith("search:*");
+    expect(cacheClear).toHaveBeenCalledWith("fetch:*");
+    expect(result.content[0].text).toContain("10 cache entries");
+  });
+
+  it("clears only search cache when target is search", async () => {
+    await handleClearCache({ target: "search" });
+    expect(cacheClear).toHaveBeenCalledWith("search:*");
+    expect(cacheClear).not.toHaveBeenCalledWith("fetch:*");
+  });
+
+  it("clears only fetch cache when target is fetch", async () => {
+    await handleClearCache({ target: "fetch" });
+    expect(cacheClear).not.toHaveBeenCalledWith("search:*");
+    expect(cacheClear).toHaveBeenCalledWith("fetch:*");
+  });
+
+  it("uses singular 'entry' when exactly 1 cleared", async () => {
+    vi.mocked(cacheClear).mockResolvedValueOnce(1);
+    const result = await handleClearCache({ target: "search" });
+    expect(result.content[0].text).toBe("Cleared 1 cache entry.");
+  });
+});


### PR DESCRIPTION
## Summary

- **Phase 1** — Adblock double-load guard: `_ADBLOCK_LOADED` env check prevents duplicate filter-list fetches from `NODE_OPTIONS` inheritance
- **Phase 2** — Test coverage overhaul: 149 → 211 tests across 22 files; extracted named handlers (`handleSearch` etc.) from `tools.ts` for testability
- **Phase 3** — Language parameter: BCP-47 `language` param on `search`, `search_and_fetch`, `search_and_summarize`
- **Phase 4** — PDF routing: `.pdf` URLs skip Firecrawl and go directly to Crawl4AI; `rawFetch` now throws on `application/pdf` content-type
- **Phase 5** — Wayback Machine tier-4 (opt-in): `WAYBACK_ENABLED=true` enables CDX API lookup → `rawFetch` for pages that fail all three tiers; results tagged `[Archived]`
- **Security fixes** — CDX response body capped at 64 KB via `readBoundedText`; `fetchRawHtmlForMetadata` changed to `redirect: "manual"` (SSRF-02 defense-in-depth)

## Test plan

- [ ] CI passes on Node.js 20 and 22
- [ ] Dependency audit clean
- [ ] `pnpm test` — 211 tests passing, no type errors
- [ ] `pnpm build` — clean TypeScript compile

## Notes

- Adblock container requires a separate rebuild after merge: `docker compose -f ~/docker/firecrawl-simple/docker-compose.yml up -d --build firecrawl-puppeteer`
- `WAYBACK_ENABLED` is opt-in — no archive.org traffic unless explicitly set
- Personal-agent PM2 process requires restart after tag + npm publish to pick up new build

🤖 Generated with [Claude Code](https://claude.com/claude-code)