### PR TITLE
feat(polish): CACHE_URL generalization, onboarding docs, code quality fixes, adblock hardening

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Something is not working correctly
+labels: bug
+---
+
+## Description
+
+A clear description of what is wrong.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include error messages or logs if available.
+
+## Environment
+
+- searxng-mcp version:
+- Node.js version (`node --version`):
+- Optional services enabled (check all that apply):
+  - [ ] Firecrawl
+  - [ ] Crawl4AI
+  - [ ] Ollama
+  - [ ] Reranker
+  - [ ] Kiwix
+  - [ ] Wayback Machine (`WAYBACK_ENABLED=true`)
+  - [ ] NATS
+  - [ ] OpenTelemetry

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest a new capability or improvement
+labels: enhancement
+---
+
+## Problem
+
+What problem does this solve, or what use case does it enable?
+
+## Proposed solution
+
+Describe what you would like to happen.
+
+## Alternatives considered
+
+Other approaches you considered and why you prefer this one.

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ build/
 core.*
 *.core
 .env
+*.env
 run.sh
 package-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Optional services (server degrades gracefully without these):
 |---|---|---|
 | Reranker | `RERANKER_URL` | ML relevance reranking |
 | Crawl4AI | `CRAWL4AI_URL` | Fetch fallback for bot-blocked pages (tier 2) |
-| Valkey/Redis | `VALKEY_URL` | Result caching |
+| Valkey/Redis/Dragonfly | `CACHE_URL` | Result caching (also accepts `VALKEY_URL` or `REDIS_URL`) |
 | Ollama | `OLLAMA_URL` | Query expansion + summarization |
 | Wayback Machine | `WAYBACK_ENABLED=true` | Archived snapshot fallback (tier 4, opt-in) |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- `CACHE_URL` is now the canonical cache backend env var; `VALKEY_URL` and `REDIS_URL` are accepted as backward-compatible aliases. Works with Redis, Valkey, and Dragonfly.
+
 ## [3.8.0] - 2026-06-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.9.0] - 2026-06-05
+
+### Added
+- **Onboarding docs** — `docker-compose.example.yml` (minimal cache-only stack) and `docker-compose.full.yml` (all optional services: Firecrawl, Crawl4AI, Ollama, Reranker, Kiwix, NATS) added for quick setup.
+- **`CONTRIBUTING.md`** — prerequisites, setup, test/lint/typecheck, commit conventions, PR process.
+- **GitHub issue templates** — bug report and feature request templates under `.github/ISSUE_TEMPLATE/`.
+- **Adblock sidecar docs** — `docker/puppeteer-adblock/README.md` documents the patch mechanism, failure modes, build/use instructions, and SHA pin update procedure.
+
 ### Changed
-- `CACHE_URL` is now the canonical cache backend env var; `VALKEY_URL` and `REDIS_URL` are accepted as backward-compatible aliases. Works with Redis, Valkey, and Dragonfly.
+- **`CACHE_URL`** is now the canonical cache backend env var; `VALKEY_URL` and `REDIS_URL` are accepted as backward-compatible aliases. Works with Redis, Valkey, and Dragonfly.
+- **Wayback Machine tier** — fetched content is now prefixed with `> [via Wayback Machine, archived YYYY-MM-DD]` provenance header. Archive date is parsed from the CDX API timestamp.
+- **llms-full.txt cache** — full document body is now stored in Valkey (TTL: `FETCH_CACHE_TTL_SECONDS`) to survive process restarts. In-process L1 cache capped at 10MB.
+- **Domain record writes** — replaced in-process per-hostname Promise queue with atomic WATCH/MULTI/EXEC via `cacheAtomicUpdate`. Correct under multiple process instances sharing the same Valkey backend.
+- **Adblock sidecar** — logs wrapped `puppeteer-service` version on startup.
+
+### Fixed
+- `assertPublicUrl` (`src/fetch-utils.ts`) — added inline comment documenting that `http://` is intentionally permitted.
+- `_clearWriteLocksForTests` test stub removed from production export (`src/domain-db.ts`).
+
+### Security
+- `src/tiers/wayback.ts` — `closest.url` from CDX API now validated to `https://web.archive.org/` origin before fetch (F-01).
 
 ## [3.8.0] - 2026-06-05
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to searxng-mcp
+
+## Prerequisites
+
+- Node.js 20+
+- pnpm 10.30.3+
+
+## Setup
+
+```bash
+git clone https://github.com/TadMSTR/searxng-mcp.git
+cd searxng-mcp
+pnpm install
+pnpm build
+```
+
+## Running tests
+
+```bash
+pnpm test
+```
+
+## Linting
+
+```bash
+pnpm lint        # Biome — check and report
+pnpm lint:fix    # Biome — auto-fix
+```
+
+## Type check
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+## Running locally
+
+The minimum required env var is `SEARXNG_URL` pointing at any SearXNG instance.
+All other services are optional — the server degrades gracefully when they are absent.
+
+```bash
+SEARXNG_URL=http://localhost:8081 node build/src/index.js
+```
+
+To run against a local SearXNG instance quickly:
+
+```bash
+docker run -d -p 8081:8080 searxng/searxng
+SEARXNG_URL=http://localhost:8081 node build/src/index.js
+```
+
+See `docker-compose.example.yml` for a minimal stack including a cache backend,
+and `docker-compose.full.yml` for the full topology.
+
+## Commit conventions
+
+Use a `type/scope` prefix:
+
+| Type | When |
+|------|------|
+| `feat` | New capability |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `chore` | Build, deps, tooling |
+| `security` | Security fix |
+| `refactor` | Code restructure, no behavior change |
+| `test` | Test additions or fixes |
+
+Examples: `feat(kiwix): add zim routing`, `fix(domain-db): atomic write race`
+
+## PR process
+
+1. Fork and create a branch (`feat/<slug>` or `fix/<slug>`)
+2. Make your changes — `pnpm build && pnpm test && pnpm lint` must all pass
+3. Open a PR against `main`
+4. CI runs automatically; merge requires CI green

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Built with [Claude Code](https://claude.ai/code) using the multi-agent workflow 
 MCP client (stdio)
       │
       ▼
-  searxng-mcp ──────────────→ Valkey ($VALKEY_URL)        → result cache (search 1h, fetch 24h)
+  searxng-mcp ──────────────→ cache ($CACHE_URL)           → result cache (search 1h, fetch 24h)
       │
       ├── expand (optional) →  Ollama ($OLLAMA_URL)        → rewritten query (qwen3:4b)
       ├── search ───────────→ SearXNG ($SEARXNG_URL)      → raw results
@@ -334,7 +334,7 @@ All service URLs are configurable via environment variables.
 | `OLLAMA_API_KEY` | *(unset)* | Bearer token for authenticated Ollama proxies — adds `Authorization: Bearer <key>` header when set |
 | `OLLAMA_EXPAND_MODEL` | `qwen3:4b` | Model used by query expansion (`expand` parameter). Override without rebuilding. |
 | `OLLAMA_SUMMARIZE_MODEL` | `qwen3:14b` | Model used by `search_and_summarize`. Override without rebuilding. |
-| `VALKEY_URL` | `redis://localhost:6381` | Redis-compatible URL — enables result caching. Server degrades gracefully if unavailable. |
+| `CACHE_URL` | `redis://localhost:6381` | Redis-compatible URL — enables result caching. Also accepts `VALKEY_URL` or `REDIS_URL` as aliases. Works with Redis, Valkey, and Dragonfly. Server degrades gracefully if unavailable. |
 | `CACHE_TTL_SECONDS` | `3600` | Search result cache TTL in seconds |
 | `FETCH_CACHE_TTL_SECONDS` | `86400` | Fetched page cache TTL in seconds |
 | `EXPAND_QUERIES` | `false` | Set to `true` to enable query expansion globally |
@@ -383,7 +383,7 @@ claude mcp add-json searxng --scope user '{
     "FIRECRAWL_URL": "http://localhost:3002",
     "RERANKER_URL": "http://localhost:8787",
     "OLLAMA_URL": "http://localhost:11434",
-    "VALKEY_URL": "redis://localhost:6379",
+    "CACHE_URL": "redis://localhost:6379",
     "CACHE_TTL_SECONDS": "3600",
     "FETCH_CACHE_TTL_SECONDS": "86400",
     "EXPAND_QUERIES": "false",
@@ -407,7 +407,7 @@ This writes to `~/.claude.json`. Do not add searxng to `~/.claude/settings.json`
         "FIRECRAWL_URL": "http://localhost:3002",
         "RERANKER_URL": "http://localhost:8787",
         "OLLAMA_URL": "http://localhost:11434",
-        "VALKEY_URL": "redis://localhost:6379",
+        "CACHE_URL": "redis://localhost:6379",
         "CRAWL4AI_URL": "http://localhost:11235"
       }
     }
@@ -429,7 +429,7 @@ mcpServers:
       FIRECRAWL_URL: http://localhost:3002
       RERANKER_URL: http://localhost:8787
       OLLAMA_URL: http://localhost:11434
-      VALKEY_URL: redis://localhost:6379
+      CACHE_URL: redis://localhost:6379
       CRAWL4AI_URL: http://localhost:11235
 ```
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,49 @@
+# searxng-mcp minimal stack
+#
+# Required: a running SearXNG instance (see SEARXNG_URL below).
+# This file wires only the cache backend — the minimum needed for
+# searxng-mcp to function beyond a bare in-memory session.
+#
+# For a full topology (Firecrawl, Crawl4AI, Ollama, Kiwix, NATS),
+# see docker-compose.full.yml.
+
+services:
+  cache:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    # Alternatives (drop-in compatible):
+    #   image: redis:7-alpine
+    #   image: valkey/valkey:8-alpine
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:6381:6379"
+    command: ["--maxmemory=512mb", "--save_schedule="]
+    ulimits:
+      memlock: -1
+
+# ── MCP client configuration ──────────────────────────────────────────────────
+#
+# Add the following env block to your MCP client config.
+# Only SEARXNG_URL and CACHE_URL are required; everything else is optional.
+#
+#   SEARXNG_URL           http://localhost:8081    # Required: your SearXNG instance
+#   CACHE_URL             redis://localhost:6381   # Cache backend (Redis/Valkey/Dragonfly)
+#
+# Optional env vars:
+#   FIRECRAWL_URL         http://localhost:3002    # Tier-1 JS-render fetch
+#   FIRECRAWL_API_KEY     placeholder-local        # Firecrawl API key
+#   CRAWL4AI_URL          http://localhost:11235   # Tier-2 fetch fallback
+#   CRAWL4AI_API_TOKEN                             # Crawl4AI bearer token (if protected)
+#   RERANKER_URL          http://localhost:8787    # ML reranking (cross-encoder)
+#   OLLAMA_URL            http://localhost:11434   # Query expansion + summarization
+#   OLLAMA_API_KEY                                 # Bearer token for authenticated Ollama proxies
+#   OLLAMA_EXPAND_MODEL   qwen3:4b                 # Model for query expansion
+#   OLLAMA_SUMMARIZE_MODEL qwen3:14b               # Model for search_and_summarize
+#   EXPAND_QUERIES        false                    # Set true to expand queries globally
+#   KIWIX_URL             http://localhost:8292    # Kiwix fast path (Wikipedia/SO/Arch Wiki)
+#   WAYBACK_ENABLED       false                    # Set true to enable Wayback Machine tier-4
+#   GITHUB_TOKEN                                   # GitHub PAT — raises rate limit to 5k/h
+#   CACHE_TTL_SECONDS     3600                     # Search result cache TTL
+#   FETCH_CACHE_TTL_SECONDS 86400                  # Fetched page cache TTL
+#   NATS_URL                                       # NATS server for event publishing
+#   OTEL_EXPORTER_OTLP_ENDPOINT                   # OpenTelemetry endpoint
+#   RERANK_RECENCY_WEIGHT 0.15                     # Recency bias in reranking (0-1)

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -9,7 +9,7 @@
 
 services:
   cache:
-    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest # SECURITY[accepted]: latest tag — example file; pin for production
     # Alternatives (drop-in compatible):
     #   image: redis:7-alpine
     #   image: valkey/valkey:8-alpine

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -15,7 +15,7 @@
 services:
   # ── Cache backend (Redis-compatible) ────────────────────────────────────────
   cache:
-    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest # SECURITY[accepted]: latest tag — example file; pin for production
     # Alternatives (drop-in compatible):
     #   image: redis:7-alpine
     #   image: valkey/valkey:8-alpine
@@ -30,7 +30,7 @@ services:
   # Firecrawl requires its own Redis instance and the playwright-service sidecar.
   # See https://docs.firecrawl.dev/self-hosting for full setup.
   firecrawl-api:
-    image: ghcr.io/mendableai/firecrawl:latest
+    image: ghcr.io/mendableai/firecrawl:latest # SECURITY[accepted]: latest tag — example file; pin for production
     restart: unless-stopped
     environment:
       REDIS_URL: redis://firecrawl-redis:6379
@@ -59,7 +59,7 @@ services:
 
   # ── Crawl4AI (tier-2 fetch fallback) ────────────────────────────────────────
   crawl4ai:
-    image: unclecode/crawl4ai:latest
+    image: unclecode/crawl4ai:latest # SECURITY[accepted]: latest tag — example file; pin for production
     restart: unless-stopped
     ports:
       - "127.0.0.1:11235:11235"
@@ -71,7 +71,7 @@ services:
   # Required models: qwen3:4b (expand), qwen3:14b (summarize)
   # Pull after start: docker exec ollama ollama pull qwen3:4b && docker exec ollama ollama pull qwen3:14b
   ollama:
-    image: ollama/ollama:latest
+    image: ollama/ollama:latest # SECURITY[accepted]: latest tag — example file; pin for production
     restart: unless-stopped
     ports:
       - "127.0.0.1:11434:11434"
@@ -92,7 +92,7 @@ services:
   #   - Infinity with a cross-encoder model: https://github.com/michaelfeil/infinity
   #   - Any OpenAI-compatible reranker API at port 8787
   reranker:
-    image: michaelf34/infinity:latest
+    image: michaelf34/infinity:latest # SECURITY[accepted]: latest tag — example file; pin for production
     restart: unless-stopped
     ports:
       - "127.0.0.1:8787:7997"
@@ -105,7 +105,7 @@ services:
   # ── Kiwix (offline Wikipedia / Stack Overflow / Arch Wiki) ──────────────────
   # Requires ZIM files in ./kiwix-data/ — see https://download.kiwix.org/
   kiwix:
-    image: ghcr.io/kiwix/kiwix-serve:latest
+    image: ghcr.io/kiwix/kiwix-serve:latest # SECURITY[accepted]: latest tag — example file; pin for production
     restart: unless-stopped
     ports:
       - "127.0.0.1:8292:8080"

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -1,0 +1,151 @@
+# searxng-mcp full stack
+#
+# Wires all optional services: cache, Firecrawl + adblock sidecar, Crawl4AI,
+# Ollama, Kiwix, and NATS. Requires SearXNG running externally (see SEARXNG_URL).
+#
+# Prerequisites:
+#   - Kiwix: download ZIM files to ./kiwix-data/ before starting kiwix service.
+#     See https://download.kiwix.org/ — recommended: wikipedia_en_all_maxi,
+#     stackoverflow_en_all, archlinux_en_all
+#   - Ollama: pull required models after first start:
+#       docker exec ollama ollama pull qwen3:4b
+#       docker exec ollama ollama pull qwen3:14b
+#   - NATS: update NATS_CREDS path if using credential-based auth.
+
+services:
+  # ── Cache backend (Redis-compatible) ────────────────────────────────────────
+  cache:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    # Alternatives (drop-in compatible):
+    #   image: redis:7-alpine
+    #   image: valkey/valkey:8-alpine
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:6381:6379"
+    command: ["--maxmemory=2gb", "--save_schedule="]
+    ulimits:
+      memlock: -1
+
+  # ── Firecrawl (tier-1 JS-render fetch) ──────────────────────────────────────
+  # Firecrawl requires its own Redis instance and the playwright-service sidecar.
+  # See https://docs.firecrawl.dev/self-hosting for full setup.
+  firecrawl-api:
+    image: ghcr.io/mendableai/firecrawl:latest
+    restart: unless-stopped
+    environment:
+      REDIS_URL: redis://firecrawl-redis:6379
+      PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-puppeteer:3000
+      USE_DB_AUTHENTICATION: "false"
+    ports:
+      - "127.0.0.1:3002:3002"
+    depends_on:
+      - firecrawl-redis
+      - firecrawl-puppeteer
+
+  firecrawl-redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+
+  firecrawl-puppeteer:
+    # Custom build: trieve/puppeteer-service-ts + @ghostery/adblocker-puppeteer
+    # See docker/puppeteer-adblock/README.md for details.
+    build:
+      context: ./docker/puppeteer-adblock
+    restart: unless-stopped
+    environment:
+      ADBLOCK_FILTERS_URL: "https://easylist.to/easylist/easylist.txt,https://easylist.to/easylist/easyprivacy.txt"
+      ADBLOCK_REFRESH_HOURS: "168"
+      # Set ADBLOCK_DISABLE=true to disable adblocking for debugging.
+
+  # ── Crawl4AI (tier-2 fetch fallback) ────────────────────────────────────────
+  crawl4ai:
+    image: unclecode/crawl4ai:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:11235:11235"
+    environment:
+      CRAWL4AI_API_TOKEN: ""  # Set to protect your instance
+    shm_size: "1gb"
+
+  # ── Ollama (query expansion + summarization) ─────────────────────────────────
+  # Required models: qwen3:4b (expand), qwen3:14b (summarize)
+  # Pull after start: docker exec ollama ollama pull qwen3:4b && docker exec ollama ollama pull qwen3:14b
+  ollama:
+    image: ollama/ollama:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    # GPU support (NVIDIA):
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+
+  # ── Reranker (ML cross-encoder reranking) ────────────────────────────────────
+  # Options:
+  #   - Jina Reranker: docker pull jinaai/jina-reranker-v2-base-multilingual
+  #   - Infinity with a cross-encoder model: https://github.com/michaelfeil/infinity
+  #   - Any OpenAI-compatible reranker API at port 8787
+  reranker:
+    image: michaelf34/infinity:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8787:7997"
+    command:
+      - v2
+      - --model-id
+      - cross-encoder/ms-marco-MiniLM-L-6-v2
+    # GPU support: add deploy.resources.reservations.devices as above
+
+  # ── Kiwix (offline Wikipedia / Stack Overflow / Arch Wiki) ──────────────────
+  # Requires ZIM files in ./kiwix-data/ — see https://download.kiwix.org/
+  kiwix:
+    image: ghcr.io/kiwix/kiwix-serve:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8292:8080"
+    volumes:
+      - ./kiwix-data:/data
+    command: /data/*.zim
+
+  # ── NATS (event publishing) ──────────────────────────────────────────────────
+  # Optional: set NATS_URL=nats://localhost:4222 in searxng-mcp env to enable.
+  nats:
+    image: nats:2-alpine
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:4222:4222"
+    command: ["-js"]
+    # For credential-based auth, mount a config file:
+    # volumes:
+    #   - ./nats.conf:/etc/nats/nats.conf:ro
+    # command: ["-c", "/etc/nats/nats.conf"]
+
+volumes:
+  ollama-data:
+
+# ── MCP client configuration ──────────────────────────────────────────────────
+#
+# Full env block for your MCP client config (all services wired):
+#
+#   SEARXNG_URL             http://localhost:8081
+#   CACHE_URL               redis://localhost:6381
+#   FIRECRAWL_URL           http://localhost:3002
+#   FIRECRAWL_API_KEY       placeholder-local
+#   CRAWL4AI_URL            http://localhost:11235
+#   RERANKER_URL            http://localhost:8787
+#   OLLAMA_URL              http://localhost:11434
+#   OLLAMA_EXPAND_MODEL     qwen3:4b
+#   OLLAMA_SUMMARIZE_MODEL  qwen3:14b
+#   EXPAND_QUERIES          false
+#   KIWIX_URL               http://localhost:8292
+#   WAYBACK_ENABLED         false
+#   NATS_URL                nats://localhost:4222
+#   CACHE_TTL_SECONDS       3600
+#   FETCH_CACHE_TTL_SECONDS 86400
+#   RERANK_RECENCY_WEIGHT   0.15

--- a/docker/puppeteer-adblock/README.md
+++ b/docker/puppeteer-adblock/README.md
@@ -1,0 +1,97 @@
+# puppeteer-adblock
+
+Docker image that layers `@ghostery/adblocker-puppeteer` (EasyList + EasyPrivacy)
+onto the upstream `trieve/puppeteer-service-ts` image used by Firecrawl, without
+forking the upstream source.
+
+## What it does
+
+Firecrawl uses [trieve/puppeteer-service-ts](https://github.com/devflowinc/trieve/tree/main/puppeteer-service-ts)
+as its headless Chrome service. That image ships `puppeteer-extra-plugin-adblocker`
+with no filter lists configured, which provides no meaningful blocking in practice.
+
+This image adds `@ghostery/adblocker-puppeteer` with EasyList + EasyPrivacy,
+loaded at startup via `init-adblock.js`. The result: ads and trackers are blocked
+at the network request level inside every page Firecrawl renders, improving
+extraction quality for ad-heavy pages.
+
+## How the monkey-patch works
+
+`init-adblock.js` is loaded via `NODE_OPTIONS=--require` before `api.ts` starts.
+It patches `Module.prototype.require` to intercept any `require('puppeteer')` or
+`require('puppeteer-extra')` call. When detected, it wraps `browser.launch()` so
+that every `Browser` returned has its `newPage()` and `createBrowserContext()`
+methods patched to call `blocker.enableBlockingInPage(page)` on each new page.
+
+No fork of `api.ts` is needed. The patch composes with `puppeteer-extra` plugins
+already installed by the upstream image.
+
+## Known failure modes
+
+| Failure | Effect | Detection |
+|---------|--------|-----------|
+| Upstream changes its `require('puppeteer')` path | Patch does not apply; pages are unblocked | No `[adblock] wrapping puppeteer-service` log line at startup |
+| Filter list fetch fails at startup | Silent continue — pages are unblocked until the next refresh | `[adblock] initial load failed:` log line at startup |
+| Node version mismatch | `require` hook may not intercept correctly | Check base image Node version vs the version expected by `@ghostery/adblocker-puppeteer` |
+| Base image SHA256 drift | Build may pull a different image than pinned | Rebuild fails or logs an unexpected `puppeteer-service` version |
+
+## Build and use
+
+```bash
+# Build from the searxng-mcp repo root
+docker build -t puppeteer-adblock ./docker/puppeteer-adblock
+
+# Or via docker compose (rebuilds only if Dockerfile/init-adblock.js changed)
+docker compose -f ~/docker/firecrawl-simple/docker-compose.yml \
+  up -d --build firecrawl-puppeteer
+```
+
+Point Firecrawl's `PLAYWRIGHT_MICROSERVICE_URL` at this container:
+
+```yaml
+firecrawl-puppeteer:
+  build:
+    context: ./docker/puppeteer-adblock
+  environment:
+    ADBLOCK_FILTERS_URL: "https://easylist.to/easylist/easylist.txt,..."
+    ADBLOCK_REFRESH_HOURS: "168"
+```
+
+## Verifying adblock is active
+
+Check container logs on startup:
+
+```
+[adblock] wrapping puppeteer-service 0.0.6
+[adblock] loading filter lists: https://easylist.to/easylist/easylist.txt, ...
+[adblock] loaded 2 list(s) in 1234ms
+```
+
+The first line confirms the patch applied. If you see `(version unknown)`, the
+upstream moved `/app/package.json` — update the path in `init-adblock.js`.
+
+## Updating the base image pin
+
+The Dockerfile pins the base image by SHA256 digest (security check DC-01).
+To update the pin to a new tag:
+
+```bash
+# Get the current digest for a tag
+docker buildx imagetools inspect trieve/puppeteer-service-ts:<tag> \
+  --format '{{json .Manifest}}' | jq -r '.digest'
+
+# Or via docker pull + inspect
+docker pull trieve/puppeteer-service-ts:<tag>
+docker inspect trieve/puppeteer-service-ts:<tag> \
+  --format '{{index .RepoDigests 0}}'
+```
+
+Update the `FROM` line in `Dockerfile` with the new digest.
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ADBLOCK_DISABLE` | `false` | Set to `true` to disable adblocking entirely |
+| `ADBLOCK_FILTERS_URL` | EasyList + EasyPrivacy | Comma-separated filter list URLs |
+| `ADBLOCK_REFRESH_HOURS` | `168` | How often to rebuild filter lists (hours) |

--- a/docker/puppeteer-adblock/init-adblock.js
+++ b/docker/puppeteer-adblock/init-adblock.js
@@ -22,7 +22,10 @@ if (process.env.ADBLOCK_DISABLE === "true") {
 }
 
 function install() {
-  if (process.env._ADBLOCK_LOADED) return;
+  if (process.env._ADBLOCK_LOADED) {
+    console.warn("[adblock] _ADBLOCK_LOADED already set — skipping install (adblocking may be inactive)");
+    return;
+  }
   process.env._ADBLOCK_LOADED = "1";
 
   try {

--- a/docker/puppeteer-adblock/init-adblock.js
+++ b/docker/puppeteer-adblock/init-adblock.js
@@ -25,6 +25,13 @@ function install() {
   if (process.env._ADBLOCK_LOADED) return;
   process.env._ADBLOCK_LOADED = "1";
 
+  try {
+    const pkg = require("/app/package.json");
+    console.log(`[adblock] wrapping puppeteer-service ${pkg.version}`);
+  } catch {
+    console.log("[adblock] wrapping puppeteer-service (version unknown)");
+  }
+
 const FILTER_URLS = (
   process.env.ADBLOCK_FILTERS_URL ||
   "https://easylist.to/easylist/easylist.txt,https://easylist.to/easylist/easyprivacy.txt"

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -103,6 +103,8 @@ export async function cacheAtomicUpdate(
       if (results !== null) return; // transaction committed
       // results === null: key modified between WATCH and EXEC — retry
     } catch {
+      // SECURITY[accepted]: exits retry on first exception (transient errors consume full budget).
+      // Intentional best-effort design — domain-db writes are fire-and-forget. Audit: 2026-06-05/searxng-mcp-polish-2026-06.
       return; // best-effort — never throw
     }
   }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { Redis as Valkey } from "iovalkey";
-import { VALKEY_URL } from "./config.js";
+import { CACHE_URL } from "./config.js";
 import { events } from "./events.js";
 import { incCounter } from "./observability.js";
 
@@ -14,7 +14,7 @@ let valkey: Valkey | null = null;
 export async function getValkey(): Promise<Valkey | null> {
   if (valkey !== null) return valkey;
   try {
-    const client = new Valkey(VALKEY_URL, {
+    const client = new Valkey(CACHE_URL, {
       lazyConnect: true,
       enableReadyCheck: false,
     });
@@ -77,6 +77,34 @@ export async function cacheSet(
     await client.set(key, value, "EX", ttl);
   } catch {
     // Best-effort — never throw
+  }
+}
+
+// Atomic read-modify-write using WATCH/MULTI/EXEC (optimistic locking).
+// `mutateFn` receives the current raw value (or null) and returns the new value.
+// Retries up to `maxRetries` times on concurrent-modification conflicts.
+// Best-effort: returns without throwing on any error or Valkey unavailability.
+export async function cacheAtomicUpdate(
+  key: string,
+  ttl: number,
+  mutateFn: (raw: string | null) => string,
+  maxRetries = 3,
+): Promise<void> {
+  const client = await getValkey();
+  if (!client) return;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      await client.watch(key);
+      const raw = await client.get(key);
+      const updated = mutateFn(raw);
+      const pipeline = client.multi();
+      pipeline.set(key, updated, "EX", ttl);
+      const results = await pipeline.exec();
+      if (results !== null) return; // transaction committed
+      // results === null: key modified between WATCH and EXEC — retry
+    } catch {
+      return; // best-effort — never throw
+    }
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,11 @@ export const FIRECRAWL_API_KEY =
   process.env.FIRECRAWL_API_KEY ?? "placeholder-local";
 export const RERANKER_URL = process.env.RERANKER_URL ?? "http://localhost:8787";
 export const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-export const VALKEY_URL = process.env.VALKEY_URL ?? "redis://localhost:6381";
+export const CACHE_URL =
+  process.env.CACHE_URL ??
+  process.env.VALKEY_URL ??
+  process.env.REDIS_URL ??
+  "redis://localhost:6381";
 export const CACHE_TTL_SECONDS = parseInt(
   process.env.CACHE_TTL_SECONDS ?? "3600",
   10,

--- a/src/domain-db.ts
+++ b/src/domain-db.ts
@@ -7,7 +7,7 @@
 // Writes are best-effort and fire-and-forget: a failure here must never
 // surface to the caller of fetchPage.
 
-import { cacheGet, cacheSet } from "./cache.js";
+import { cacheAtomicUpdate, cacheGet } from "./cache.js";
 
 const DOMAIN_RECORD_TTL_SECONDS = 90 * 24 * 60 * 60;
 const SCHEMA_VERSION = 2;
@@ -116,60 +116,43 @@ export async function getDomainRecord(
   }
 }
 
-async function writeRecord(record: DomainRecord): Promise<void> {
-  await cacheSet(
-    domainKey(record.domain),
-    JSON.stringify(record),
-    DOMAIN_RECORD_TTL_SECONDS,
-  );
-}
-
-// Per-hostname write queue. Multiple recorders (tier-attempt, robots probe,
-// post-extract sample, llms.txt probe) can run concurrently for the same
-// fetch; without serialization their read-modify-write cycles race and the
-// last writer overwrites the others' changes. Chaining new writes onto the
-// previous promise gives sequential, in-order updates per hostname while
-// keeping different hostnames fully parallel.
-const writeLocks = new Map<string, Promise<void>>();
-
-async function performUpdate(
-  hostname: string,
-  mutate: (r: DomainRecord) => void,
-): Promise<void> {
-  const now = new Date().toISOString();
-  try {
-    const existing = await getDomainRecord(hostname);
-    const record = existing ?? newRecord(hostname, now);
-    mutate(record);
-    record.last_fetch = now;
-    await writeRecord(record);
-  } catch {
-    // best-effort — never throw from a DB hook
-  }
-}
-
+// Atomic read-modify-write: uses WATCH/MULTI/EXEC via cacheAtomicUpdate.
+// Replaces the former in-process per-hostname Promise queue, which only
+// serialized within a single process. WATCH/MULTI/EXEC handles concurrent
+// writers across multiple processes as well.
 function updateRecord(
   hostnameOrUrl: string,
   mutate: (r: DomainRecord) => void,
 ): Promise<void> {
   const hostname = normalizeHostname(hostnameOrUrl);
   if (!hostname) return Promise.resolve();
-  const prev = writeLocks.get(hostname) ?? Promise.resolve();
-  const next = prev.then(() => performUpdate(hostname, mutate));
-  writeLocks.set(
-    hostname,
-    next.finally(() => {
-      // Clear the lock entry once this update settles, but only if no
-      // newer update has chained on (which would have overwritten it).
-      if (writeLocks.get(hostname) === next) writeLocks.delete(hostname);
-    }),
-  );
-  return next;
+  const key = domainKey(hostname);
+  const now = new Date().toISOString();
+  return cacheAtomicUpdate(key, DOMAIN_RECORD_TTL_SECONDS, (raw) => {
+    let record: DomainRecord;
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as DomainRecord;
+        record =
+          parsed.schema_version === SCHEMA_VERSION
+            ? parsed
+            : newRecord(hostname, now);
+      } catch {
+        record = newRecord(hostname, now);
+      }
+    } else {
+      record = newRecord(hostname, now);
+    }
+    mutate(record);
+    record.last_fetch = now;
+    return JSON.stringify(record);
+  });
 }
 
-export function _clearWriteLocksForTests(): void {
-  writeLocks.clear();
-}
+// No-op stub — retained for test compatibility.
+// The in-process write queue was replaced by Valkey WATCH/MULTI/EXEC; there
+// is no longer any in-process state to clear between tests.
+export function _clearWriteLocksForTests(): void {}
 
 const TIER_KEY: Record<TierName, "tier1" | "tier2" | "tier3"> = {
   tier1_firecrawl: "tier1",

--- a/src/domain-db.ts
+++ b/src/domain-db.ts
@@ -149,11 +149,6 @@ function updateRecord(
   });
 }
 
-// No-op stub — retained for test compatibility.
-// The in-process write queue was replaced by Valkey WATCH/MULTI/EXEC; there
-// is no longer any in-process state to clear between tests.
-export function _clearWriteLocksForTests(): void {}
-
 const TIER_KEY: Record<TierName, "tier1" | "tier2" | "tier3"> = {
   tier1_firecrawl: "tier1",
   tier2_crawl4ai: "tier2",

--- a/src/fetch-utils.ts
+++ b/src/fetch-utils.ts
@@ -22,6 +22,9 @@ export function assertPublicUrl(url: string): void {
   const { protocol } = new URL(url);
   // Strip IPv6 brackets so patterns like /^::1$/ match [::1] addresses correctly
   const hostname = new URL(url).hostname.replace(/^\[|\]$/g, "");
+  // http:// is intentionally permitted: Wayback Machine snapshots, some legacy sites,
+  // and local service integrations (Kiwix, Firecrawl) may use non-TLS URLs.
+  // Private/RFC-1918 addresses are blocked below regardless of scheme.
   if (!/^https?:$/.test(protocol)) {
     throw new Error(`Only http/https URLs are supported`);
   }

--- a/src/llms-txt.ts
+++ b/src/llms-txt.ts
@@ -13,6 +13,8 @@ const USER_AGENT =
   "searxng-mcp/3.8.0 (+https://github.com/TadMSTR/searxng-mcp; personal research)";
 
 // 10MB cap across all domains for the in-process L1 body cache.
+// Note: enforced using body.length (UTF-16 char count). For non-ASCII content,
+// actual heap usage may be ~2× this value; llms-full.txt is almost exclusively ASCII.
 const L1_MAX_BYTES = 10 * 1024 * 1024;
 
 interface CachedLlmsFull {

--- a/src/llms-txt.ts
+++ b/src/llms-txt.ts
@@ -1,4 +1,5 @@
 import { cacheGet, cacheSet } from "./cache.js";
+import { FETCH_CACHE_TTL_SECONDS } from "./config.js";
 import { recordLlmsFullProbe } from "./domain-db.js";
 import { getLlmsTxtAllowlist } from "./domains.js";
 
@@ -9,7 +10,10 @@ const FETCH_TIMEOUT_MS = 30_000;
 const MIN_SIZE_BYTES = 1_024;
 const MAX_SIZE_BYTES = 200 * 1024 * 1024;
 const USER_AGENT =
-  "searxng-mcp/3.7.0 (+https://github.com/TadMSTR/searxng-mcp; personal research)";
+  "searxng-mcp/3.8.0 (+https://github.com/TadMSTR/searxng-mcp; personal research)";
+
+// 10MB cap across all domains for the in-process L1 body cache.
+const L1_MAX_BYTES = 10 * 1024 * 1024;
 
 interface CachedLlmsFull {
   status: "present" | "absent";
@@ -17,15 +21,38 @@ interface CachedLlmsFull {
   fetched: string;
 }
 
-// In-process cache for the parsed body. Valkey would have to serialize the
-// full file (anthropic's is ~76 MB) on every read — keeping the body in
-// memory for the process lifetime is cheaper and scales fine for the small
-// number of whitelisted docs domains. Valkey still records the present/absent
-// flag so a fresh process can skip the probe on a domain known to be absent.
+// In-process L1 cache: avoids redundant large Valkey reads within a session.
+// Valkey is the authoritative body store; L1 is a hot-read layer only.
 const bodyCache = new Map<string, { body: string; expiresAt: number }>();
+let bodyCacheTotalBytes = 0;
+
+function l1Set(origin: string, body: string, ttlMs: number): void {
+  const existing = bodyCache.get(origin);
+  if (existing) {
+    bodyCacheTotalBytes -= existing.body.length;
+    bodyCache.delete(origin);
+  }
+  // Evict oldest entries until there is room for the new body.
+  while (
+    bodyCacheTotalBytes + body.length > L1_MAX_BYTES &&
+    bodyCache.size > 0
+  ) {
+    const oldest = bodyCache.keys().next().value;
+    if (!oldest) break;
+    const entry = bodyCache.get(oldest);
+    if (entry) bodyCacheTotalBytes -= entry.body.length;
+    bodyCache.delete(oldest);
+  }
+  // Only insert if the body fits (a single very large doc may exceed the cap).
+  if (bodyCacheTotalBytes + body.length <= L1_MAX_BYTES) {
+    bodyCache.set(origin, { body, expiresAt: Date.now() + ttlMs });
+    bodyCacheTotalBytes += body.length;
+  }
+}
 
 export function _clearBodyCacheForTests(): void {
   bodyCache.clear();
+  bodyCacheTotalBytes = 0;
 }
 
 export function isLlmsTxtDomain(url: string, allowlist?: string[]): boolean {
@@ -40,8 +67,12 @@ export function isLlmsTxtDomain(url: string, allowlist?: string[]): boolean {
   return list.some((pat) => hostname === pat || hostname.endsWith(`.${pat}`));
 }
 
-function llmsCacheKey(origin: string): string {
+function llmsProbeCacheKey(origin: string): string {
   return `llms:${origin}:full`;
+}
+
+function llmsBodyCacheKey(origin: string): string {
+  return `llms:${origin}:body`;
 }
 
 async function fetchLlmsFullTxt(origin: string): Promise<CachedLlmsFull> {
@@ -65,41 +96,52 @@ async function fetchLlmsFullTxt(origin: string): Promise<CachedLlmsFull> {
 }
 
 async function getLlmsFullTxt(origin: string): Promise<CachedLlmsFull> {
-  // In-process body cache hit?
+  // L1 hit?
   const local = bodyCache.get(origin);
   if (local && local.expiresAt > Date.now()) {
     return { status: "present", body: local.body, fetched: "" };
   }
 
-  // Valkey only stores the present/absent flag, never the body.
-  const key = llmsCacheKey(origin);
-  const cached = await cacheGet(key);
-  if (cached) {
+  // Valkey body hit? Body is stored separately under llms:<origin>:body.
+  const bodyKey = llmsBodyCacheKey(origin);
+  const cachedBody = await cacheGet(bodyKey);
+  if (cachedBody) {
+    l1Set(origin, cachedBody, PROBE_PRESENT_TTL_MS);
+    return { status: "present", body: cachedBody, fetched: "" };
+  }
+
+  // Probe flag: if we know the domain is absent, skip the network fetch.
+  const flagKey = llmsProbeCacheKey(origin);
+  const cachedFlag = await cacheGet(flagKey);
+  if (cachedFlag) {
     try {
-      const meta = JSON.parse(cached) as CachedLlmsFull;
+      const meta = JSON.parse(cachedFlag) as CachedLlmsFull;
       if (meta.status === "absent") return meta;
-      // status: present but no in-process body — fall through to refetch.
+      // status: present but body evicted from Valkey — fall through to refetch.
     } catch {
       // corrupt cache entry — refetch
     }
   }
 
   const fresh = await fetchLlmsFullTxt(origin);
-  const ttl =
+  const probeTtl =
     fresh.status === "present"
       ? PROBE_PRESENT_TTL_SECONDS
       : PROBE_ABSENT_TTL_SECONDS;
+
+  // Store probe flag (present/absent, no body).
   await cacheSet(
-    key,
+    flagKey,
     JSON.stringify({ status: fresh.status, fetched: fresh.fetched }),
-    ttl,
+    probeTtl,
   );
+
+  // Store body in Valkey and warm L1.
   if (fresh.status === "present" && fresh.body) {
-    bodyCache.set(origin, {
-      body: fresh.body,
-      expiresAt: Date.now() + PROBE_PRESENT_TTL_MS,
-    });
+    await cacheSet(bodyKey, fresh.body, FETCH_CACHE_TTL_SECONDS);
+    l1Set(origin, fresh.body, PROBE_PRESENT_TTL_MS);
   }
+
   recordLlmsFullProbe(
     origin,
     fresh.status === "present",

--- a/src/tiers/wayback.ts
+++ b/src/tiers/wayback.ts
@@ -27,6 +27,9 @@ export async function waybackFetch(
       >
     )?.closest;
     if (!closest?.url) return null;
+    // Enforce that the CDX response points to archive.org — defensive check in case
+    // of API compromise or unexpected response shape.
+    if (!closest.url.startsWith("https://web.archive.org/")) return null;
 
     const archiveDate = closest.timestamp
       ? `${closest.timestamp.slice(0, 4)}-${closest.timestamp.slice(4, 6)}-${closest.timestamp.slice(6, 8)}`

--- a/src/tiers/wayback.ts
+++ b/src/tiers/wayback.ts
@@ -20,15 +20,27 @@ export async function waybackFetch(
       string,
       unknown
     >;
-    const snapshotUrl = (
-      data.archived_snapshots as Record<string, { url?: string }>
-    )?.closest?.url;
-    if (!snapshotUrl) return null;
+    const closest = (
+      data.archived_snapshots as Record<
+        string,
+        { url?: string; timestamp?: string }
+      >
+    )?.closest;
+    if (!closest?.url) return null;
+
+    const archiveDate = closest.timestamp
+      ? `${closest.timestamp.slice(0, 4)}-${closest.timestamp.slice(4, 6)}-${closest.timestamp.slice(6, 8)}`
+      : "unknown date";
+    const provenance = `> [via Wayback Machine, archived ${archiveDate}]\n\n`;
 
     // Snapshot URLs are always archive.org — public, passes assertPublicUrl.
     // rawFetch calls assertPublicUrl internally.
-    const result = await rawFetch(snapshotUrl, maxChars);
-    return { ...result, title: `[Archived] ${result.title}` };
+    const result = await rawFetch(closest.url, maxChars);
+    return {
+      ...result,
+      title: `[Archived] ${result.title}`,
+      text: provenance + result.text,
+    };
   } catch {
     return null;
   }

--- a/tests/domain-db.test.ts
+++ b/tests/domain-db.test.ts
@@ -3,9 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../src/cache.js", () => ({
   cacheGet: vi.fn(),
   cacheSet: vi.fn(),
+  cacheAtomicUpdate: vi.fn(),
 }));
 
-import { cacheGet, cacheSet } from "../src/cache.js";
+import { cacheAtomicUpdate, cacheGet } from "../src/cache.js";
 import {
   _clearWriteLocksForTests,
   type DomainRecord,
@@ -19,11 +20,23 @@ import {
 } from "../src/domain-db.js";
 
 const cacheGetMock = vi.mocked(cacheGet);
-const cacheSetMock = vi.mocked(cacheSet);
+const cacheAtomicUpdateMock = vi.mocked(cacheAtomicUpdate);
 
-function lastWrittenRecord(): DomainRecord {
-  const lastCall = cacheSetMock.mock.calls[cacheSetMock.mock.calls.length - 1];
-  return JSON.parse(lastCall[1] as string) as DomainRecord;
+// Simulate an atomic update: call mutateFn with the current stored value and
+// capture the result. Mimics the WATCH/MULTI/EXEC contract in tests.
+function setupAtomicMock(initial: string | null = null): {
+  getStored: () => string | null;
+} {
+  let stored: string | null = initial;
+  cacheAtomicUpdateMock.mockImplementation(async (_key, _ttl, mutateFn) => {
+    stored = mutateFn(stored);
+  });
+  return { getStored: () => stored };
+}
+
+function lastWrittenRecord(stored: string | null): DomainRecord {
+  if (!stored) throw new Error("No record written");
+  return JSON.parse(stored) as DomainRecord;
 }
 
 describe("normalizeHostname", () => {
@@ -55,16 +68,16 @@ describe("normalizeHostname", () => {
 describe("recordTierAttempt", () => {
   beforeEach(() => {
     cacheGetMock.mockReset();
-    cacheSetMock.mockReset();
+    cacheAtomicUpdateMock.mockReset();
     _clearWriteLocksForTests();
   });
 
   afterEach(() => vi.restoreAllMocks());
 
   it("creates a new record on the first call", async () => {
-    cacheGetMock.mockResolvedValue(null);
+    const { getStored } = setupAtomicMock(null);
     await recordTierAttempt("https://example.com/p", "tier1_firecrawl", "hit");
-    const written = lastWrittenRecord();
+    const written = lastWrittenRecord(getStored());
     expect(written.domain).toBe("example.com");
     expect(written.schema_version).toBe(2);
     expect(written.tier_stats_30d.tier1.attempts).toBe(1);
@@ -85,14 +98,14 @@ describe("recordTierAttempt", () => {
         tier3: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
       },
     };
-    cacheGetMock.mockResolvedValue(JSON.stringify(seed));
+    const { getStored } = setupAtomicMock(JSON.stringify(seed));
     await recordTierAttempt(
       "https://example.com/p",
       "tier1_firecrawl",
       "error",
       "timeout",
     );
-    const written = lastWrittenRecord();
+    const written = lastWrittenRecord(getStored());
     expect(written.tier_stats_30d.tier1.attempts).toBe(3);
     expect(written.tier_stats_30d.tier1.fail).toBe(2);
     expect(written.tier_stats_30d.tier1.last_fail_reason).toBe("timeout");
@@ -118,9 +131,9 @@ describe("recordTierAttempt", () => {
         tier3: { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
       },
     };
-    cacheGetMock.mockResolvedValue(JSON.stringify(seed));
+    const { getStored } = setupAtomicMock(JSON.stringify(seed));
     await recordTierAttempt("https://example.com/p", "tier1_firecrawl", "hit");
-    const written = lastWrittenRecord();
+    const written = lastWrittenRecord(getStored());
     // Old window expired — counters reset, then this one attempt recorded
     expect(written.tier_stats_30d.tier1.attempts).toBe(1);
     expect(written.tier_stats_30d.tier1.ok).toBe(1);
@@ -132,33 +145,33 @@ describe("recordTierAttempt", () => {
   });
 
   it("does not throw on malformed cache content", async () => {
-    cacheGetMock.mockResolvedValue("{not json");
+    const { getStored } = setupAtomicMock("{not json");
     await expect(
       recordTierAttempt("https://example.com/p", "tier2_crawl4ai", "hit"),
     ).resolves.toBeUndefined();
     // A fresh record should be created and written.
-    expect(cacheSetMock).toHaveBeenCalled();
+    expect(cacheAtomicUpdateMock).toHaveBeenCalled();
+    expect(getStored()).not.toBeNull();
   });
 
   it("treats normalized hostnames as the same record", async () => {
-    cacheGetMock.mockResolvedValue(null);
+    setupAtomicMock(null);
     await recordTierAttempt(
       "https://www.Example.com/p",
       "tier1_firecrawl",
       "hit",
     );
-    const key = cacheSetMock.mock.calls[0][0] as string;
+    const key = cacheAtomicUpdateMock.mock.calls[0][0] as string;
     expect(key).toBe("domain:example.com");
   });
 
   it("serializes concurrent writes for the same hostname (no read-modify-write race)", async () => {
     // Simulate the in-fetch race: tier attempt, robots probe, and post-extract
-    // sample all fire concurrently for one URL. With proper serialization the
-    // final record reflects all three updates.
+    // sample all fire concurrently for one URL. With atomic writes the final
+    // record must reflect all three updates.
     let stored: string | null = null;
-    cacheGetMock.mockImplementation(async () => stored);
-    cacheSetMock.mockImplementation(async (_k, v) => {
-      stored = v as string;
+    cacheAtomicUpdateMock.mockImplementation(async (_key, _ttl, mutateFn) => {
+      stored = mutateFn(stored);
     });
 
     await Promise.all([
@@ -182,23 +195,23 @@ describe("recordTierAttempt", () => {
 describe("recordLlmsFullProbe", () => {
   beforeEach(() => {
     cacheGetMock.mockReset();
-    cacheSetMock.mockReset();
+    cacheAtomicUpdateMock.mockReset();
     _clearWriteLocksForTests();
   });
 
   it("sets preferred_strategy to llms_full_txt on a present probe", async () => {
-    cacheGetMock.mockResolvedValue(null);
+    const { getStored } = setupAtomicMock(null);
     await recordLlmsFullProbe("https://docs.anthropic.com", true, 76_123_708);
-    const written = lastWrittenRecord();
+    const written = lastWrittenRecord(getStored());
     expect(written.capabilities.llms_full_txt?.present).toBe(true);
     expect(written.capabilities.llms_full_txt?.size_bytes).toBe(76_123_708);
     expect(written.preferred_strategy).toBe("llms_full_txt");
   });
 
   it("records absence without changing preferred_strategy", async () => {
-    cacheGetMock.mockResolvedValue(null);
+    const { getStored } = setupAtomicMock(null);
     await recordLlmsFullProbe("https://docs.openai.com", false);
-    const written = lastWrittenRecord();
+    const written = lastWrittenRecord(getStored());
     expect(written.capabilities.llms_full_txt?.present).toBe(false);
     expect(written.preferred_strategy).toBeUndefined();
   });
@@ -207,22 +220,22 @@ describe("recordLlmsFullProbe", () => {
 describe("recordRobotsProbe", () => {
   beforeEach(() => {
     cacheGetMock.mockReset();
-    cacheSetMock.mockReset();
+    cacheAtomicUpdateMock.mockReset();
     _clearWriteLocksForTests();
   });
 
   it("records a present, allowed result", async () => {
-    cacheGetMock.mockResolvedValue(null);
+    const { getStored } = setupAtomicMock(null);
     await recordRobotsProbe("https://example.com", true, true);
-    const written = lastWrittenRecord();
+    const written = lastWrittenRecord(getStored());
     expect(written.capabilities.robots_txt?.present).toBe(true);
     expect(written.capabilities.robots_txt?.allows_us).toBe(true);
   });
 
   it("records disallow", async () => {
-    cacheGetMock.mockResolvedValue(null);
+    const { getStored } = setupAtomicMock(null);
     await recordRobotsProbe("https://example.com", true, false);
-    const written = lastWrittenRecord();
+    const written = lastWrittenRecord(getStored());
     expect(written.capabilities.robots_txt?.allows_us).toBe(false);
   });
 });
@@ -230,17 +243,17 @@ describe("recordRobotsProbe", () => {
 describe("recordPostExtractSample", () => {
   beforeEach(() => {
     cacheGetMock.mockReset();
-    cacheSetMock.mockReset();
+    cacheAtomicUpdateMock.mockReset();
     _clearWriteLocksForTests();
   });
 
   it("increments sampled and present counters", async () => {
-    cacheGetMock.mockResolvedValue(null);
+    const { getStored } = setupAtomicMock(null);
     await recordPostExtractSample("https://example.com/page", {
       jsonLdPresent: true,
       ogTitlePresent: true,
     });
-    const written = lastWrittenRecord();
+    const written = lastWrittenRecord(getStored());
     expect(written.capabilities.json_ld_article?.sampled).toBe(1);
     expect(written.capabilities.json_ld_article?.present).toBe(1);
     expect(written.capabilities.og_title?.sampled).toBe(1);
@@ -251,7 +264,7 @@ describe("recordPostExtractSample", () => {
 describe("shouldSkipJsonLdPostExtract", () => {
   beforeEach(() => {
     cacheGetMock.mockReset();
-    cacheSetMock.mockReset();
+    cacheAtomicUpdateMock.mockReset();
     _clearWriteLocksForTests();
   });
 

--- a/tests/domain-db.test.ts
+++ b/tests/domain-db.test.ts
@@ -8,7 +8,6 @@ vi.mock("../src/cache.js", () => ({
 
 import { cacheAtomicUpdate, cacheGet } from "../src/cache.js";
 import {
-  _clearWriteLocksForTests,
   type DomainRecord,
   getDomainRecord,
   normalizeHostname,
@@ -69,7 +68,6 @@ describe("recordTierAttempt", () => {
   beforeEach(() => {
     cacheGetMock.mockReset();
     cacheAtomicUpdateMock.mockReset();
-    _clearWriteLocksForTests();
   });
 
   afterEach(() => vi.restoreAllMocks());
@@ -196,7 +194,6 @@ describe("recordLlmsFullProbe", () => {
   beforeEach(() => {
     cacheGetMock.mockReset();
     cacheAtomicUpdateMock.mockReset();
-    _clearWriteLocksForTests();
   });
 
   it("sets preferred_strategy to llms_full_txt on a present probe", async () => {
@@ -221,7 +218,6 @@ describe("recordRobotsProbe", () => {
   beforeEach(() => {
     cacheGetMock.mockReset();
     cacheAtomicUpdateMock.mockReset();
-    _clearWriteLocksForTests();
   });
 
   it("records a present, allowed result", async () => {
@@ -244,7 +240,6 @@ describe("recordPostExtractSample", () => {
   beforeEach(() => {
     cacheGetMock.mockReset();
     cacheAtomicUpdateMock.mockReset();
-    _clearWriteLocksForTests();
   });
 
   it("increments sampled and present counters", async () => {
@@ -265,7 +260,6 @@ describe("shouldSkipJsonLdPostExtract", () => {
   beforeEach(() => {
     cacheGetMock.mockReset();
     cacheAtomicUpdateMock.mockReset();
-    _clearWriteLocksForTests();
   });
 
   it("returns false when no record exists", async () => {

--- a/tests/tiers/wayback.test.ts
+++ b/tests/tiers/wayback.test.ts
@@ -45,8 +45,10 @@ describe("waybackFetch", () => {
     );
     const result = await waybackFetch(URL);
     expect(result).not.toBeNull();
-    expect(result!.title).toBe("[Archived] Archived Page");
-    expect(result!.text).toBe("Archived content here");
+    expect(result?.title).toBe("[Archived] Archived Page");
+    expect(result?.text).toBe(
+      "> [via Wayback Machine, archived 2024-01-01]\n\nArchived content here",
+    );
     expect(rawFetch).toHaveBeenCalledOnce();
   });
 


### PR DESCRIPTION
## Summary

- **Phase 1 — Cache backend generalization**: `CACHE_URL` is now the canonical env var. `VALKEY_URL` and `REDIS_URL` accepted as backward-compatible aliases. Works with Redis, Valkey, and Dragonfly.
- **Phase 2 — Onboarding docs**: `docker-compose.example.yml`, `docker-compose.full.yml`, `CONTRIBUTING.md`, `.github/ISSUE_TEMPLATE/` (bug + feature).
- **Phase 3a — Wayback provenance**: Archived content prepends `> [via Wayback Machine, archived YYYY-MM-DD]` header, date from CDX timestamp.
- **Phase 3b — llms.txt body → Valkey**: Body stored in Valkey under `llms:<origin>:body` (TTL: `FETCH_CACHE_TTL_SECONDS`). In-process L1 cache retained, capped at 10MB.
- **Phase 3c — domain-db atomic writes**: In-process per-hostname Promise queue replaced with Valkey WATCH/MULTI/EXEC via new `cacheAtomicUpdate()`. Handles multi-instance concurrency.
- **Phase 4 — Adblock sidecar hardening**: Startup version log in `init-adblock.js`, `docker/puppeteer-adblock/README.md` added, Dockerfile SHA256 pin verified current.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test` — 224/224 pass
- [x] `pnpm lint` — Biome clean
- [ ] Verify CACHE_URL / VALKEY_URL / REDIS_URL fallback chain connects to cache
- [ ] Verify Wayback provenance header appears in returned text
- [ ] Verify llms.txt body served from Valkey on second fetch

🤖 Co-authored with Claude Sonnet 4.6