### PR TITLE
feat: HTTP transport, tier cascade refactor, adblock proxy (v3.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.10.0] - 2026-06-05
+
+### Added
+- **HTTP/SSE transport** — set `SEARXNG_MCP_TRANSPORT=http` to run as a shared HTTP server instead of stdio. `SEARXNG_MCP_PORT` (default `3001`) and `SEARXNG_MCP_HOST` (default `127.0.0.1`) control the listen address. Intended for multi-client agent deployments; stdio remains the default for single-client use.
+- **`docker/adblock-proxy/`** — new HTTP forward proxy service using `@ghostery/adblocker` (EasyList + EasyPrivacy). Blocks plain-HTTP ad/tracker requests for tiers 2 and 3. HTTPS CONNECT is tunneled without MITM. Configure with `ADBLOCK_PROXY_URL=http://adblock-proxy:8118`. See `docker/adblock-proxy/README.md` for the two-sidecar architecture overview.
+
+### Changed
+- **Tier cascade refactored** — `Tier` interface (`src/tiers/types.ts`) with `name`, `slot`, and `fetch()`. `getTiers(url)` in `src/routing.ts` returns `{ active, skipped }` in a single call. `fetch.ts` cascade loop replaced with a clean `for…of` over active tiers. No behavior change.
+- **`ADBLOCK_PROXY_URL`** — when set, tier-3 raw Node fetches are routed through an undici `ProxyAgent`; tier-2 Crawl4AI requests include `proxy_config: { server: URL }` in the API request body.
+- **HTTP transport session handling** — stateful mode (`sessionIdGenerator: () => crypto.randomUUID()`) to prevent message ID collisions across concurrent clients.
+
 ## [3.9.0] - 2026-06-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -341,7 +341,11 @@ All service URLs are configurable via environment variables.
 | `CRAWL4AI_URL` | *(unset)* | Crawl4AI instance URL — enables second-tier fetch fallback when Firecrawl fails |
 | `CRAWL4AI_API_TOKEN` | *(unset)* | Optional Bearer token for Crawl4AI instances with API token protection |
 | `WAYBACK_ENABLED` | `false` | Set to `true` to enable Wayback Machine tier-4 fallback — fetches archived snapshots when all three tiers fail |
+| `ADBLOCK_PROXY_URL` | *(unset)* | HTTP proxy URL for tier-2 (Crawl4AI) and tier-3 (raw Node fetch) adblocking — e.g. `http://adblock-proxy:8118`. See `docker/adblock-proxy/`. |
 | `KIWIX_URL` | *(unset)* | kiwix-serve base URL (e.g. `http://localhost:8292`) — enables Kiwix fast path for Wikipedia, Stack Overflow, and Arch Wiki. Feature is disabled and zero-overhead when unset. |
+| `SEARXNG_MCP_TRANSPORT` | `stdio` | Transport mode: `stdio` (default, single-client) or `http` (shared HTTP/SSE server). |
+| `SEARXNG_MCP_PORT` | `3001` | HTTP listen port (HTTP transport mode only). |
+| `SEARXNG_MCP_HOST` | `127.0.0.1` | HTTP listen address (HTTP transport mode only). |
 
 ## Install
 

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -1,7 +1,8 @@
 # searxng-mcp full stack
 #
 # Wires all optional services: cache, Firecrawl + adblock sidecar, Crawl4AI,
-# Ollama, Kiwix, and NATS. Requires SearXNG running externally (see SEARXNG_URL).
+# adblock-proxy (tiers 2+3), Ollama, Kiwix, and NATS. Requires SearXNG running
+# externally (see SEARXNG_URL).
 #
 # Prerequisites:
 #   - Kiwix: download ZIM files to ./kiwix-data/ before starting kiwix service.
@@ -56,6 +57,19 @@ services:
       ADBLOCK_FILTERS_URL: "https://easylist.to/easylist/easylist.txt,https://easylist.to/easylist/easyprivacy.txt"
       ADBLOCK_REFRESH_HOURS: "168"
       # Set ADBLOCK_DISABLE=true to disable adblocking for debugging.
+
+  # ── Adblock proxy (tiers 2+3 HTTP proxy filter) ────────────────────────────
+  # Routes Crawl4AI and raw Node fetch through a @ghostery/adblocker HTTP proxy.
+  # Plain-HTTP ad/tracker requests are blocked with an empty 200 response.
+  # HTTPS CONNECT is tunneled without MITM — see docker/adblock-proxy/README.md.
+  adblock-proxy:
+    build:
+      context: ./docker/adblock-proxy
+    restart: unless-stopped
+    environment:
+      ADBLOCK_FILTERS_URL: "https://easylist.to/easylist/easylist.txt,https://easylist.to/easylist/easyprivacy.txt"
+      ADBLOCK_REFRESH_HOURS: "168"
+      LOG_BLOCKED: "false"
 
   # ── Crawl4AI (tier-2 fetch fallback) ────────────────────────────────────────
   crawl4ai:
@@ -145,6 +159,7 @@ volumes:
 #   EXPAND_QUERIES          false
 #   KIWIX_URL               http://localhost:8292
 #   WAYBACK_ENABLED         false
+#   ADBLOCK_PROXY_URL       http://adblock-proxy:8118
 #   NATS_URL                nats://localhost:4222
 #   CACHE_TTL_SECONDS       3600
 #   FETCH_CACHE_TTL_SECONDS 86400

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -4,6 +4,11 @@
 # adblock-proxy (tiers 2+3), Ollama, Kiwix, and NATS. Requires SearXNG running
 # externally (see SEARXNG_URL).
 #
+# Network isolation (NE-02):
+#   fetch-net    — adblock-proxy + crawl4ai only; proxy unreachable from unrelated services
+#   firecrawl-net — firecrawl-api + firecrawl-redis + firecrawl-puppeteer
+#   (default)    — cache, ollama, reranker, kiwix, nats; isolated from proxy
+#
 # Prerequisites:
 #   - Kiwix: download ZIM files to ./kiwix-data/ before starting kiwix service.
 #     See https://download.kiwix.org/ — recommended: wikipedia_en_all_maxi,
@@ -42,10 +47,14 @@ services:
     depends_on:
       - firecrawl-redis
       - firecrawl-puppeteer
+    networks:
+      - firecrawl-net
 
   firecrawl-redis:
     image: redis:7-alpine
     restart: unless-stopped
+    networks:
+      - firecrawl-net
 
   firecrawl-puppeteer:
     # Custom build: trieve/puppeteer-service-ts + @ghostery/adblocker-puppeteer
@@ -57,19 +66,27 @@ services:
       ADBLOCK_FILTERS_URL: "https://easylist.to/easylist/easylist.txt,https://easylist.to/easylist/easyprivacy.txt"
       ADBLOCK_REFRESH_HOURS: "168"
       # Set ADBLOCK_DISABLE=true to disable adblocking for debugging.
+    networks:
+      - firecrawl-net
 
   # ── Adblock proxy (tiers 2+3 HTTP proxy filter) ────────────────────────────
   # Routes Crawl4AI and raw Node fetch through a @ghostery/adblocker HTTP proxy.
   # Plain-HTTP ad/tracker requests are blocked with an empty 200 response.
   # HTTPS CONNECT is tunneled without MITM — see docker/adblock-proxy/README.md.
+  # On fetch-net only — unreachable from firecrawl, ollama, reranker, kiwix, nats.
+  # Port 8118 exposed to host so searxng-mcp (PM2/host process) can reach it.
   adblock-proxy:
     build:
       context: ./docker/adblock-proxy
     restart: unless-stopped
+    ports:
+      - "127.0.0.1:8118:8118"
     environment:
       ADBLOCK_FILTERS_URL: "https://easylist.to/easylist/easylist.txt,https://easylist.to/easylist/easyprivacy.txt"
       ADBLOCK_REFRESH_HOURS: "168"
       LOG_BLOCKED: "false"
+    networks:
+      - fetch-net
 
   # ── Crawl4AI (tier-2 fetch fallback) ────────────────────────────────────────
   crawl4ai:
@@ -80,6 +97,8 @@ services:
     environment:
       CRAWL4AI_API_TOKEN: ""  # Set to protect your instance
     shm_size: "1gb"
+    networks:
+      - fetch-net
 
   # ── Ollama (query expansion + summarization) ─────────────────────────────────
   # Required models: qwen3:4b (expand), qwen3:14b (summarize)
@@ -140,6 +159,10 @@ services:
     #   - ./nats.conf:/etc/nats/nats.conf:ro
     # command: ["-c", "/etc/nats/nats.conf"]
 
+networks:
+  fetch-net:
+  firecrawl-net:
+
 volumes:
   ollama-data:
 
@@ -159,7 +182,7 @@ volumes:
 #   EXPAND_QUERIES          false
 #   KIWIX_URL               http://localhost:8292
 #   WAYBACK_ENABLED         false
-#   ADBLOCK_PROXY_URL       http://adblock-proxy:8118
+#   ADBLOCK_PROXY_URL       http://localhost:8118
 #   NATS_URL                nats://localhost:4222
 #   CACHE_TTL_SECONDS       3600
 #   FETCH_CACHE_TTL_SECONDS 86400

--- a/docker/adblock-proxy/Dockerfile
+++ b/docker/adblock-proxy/Dockerfile
@@ -1,0 +1,23 @@
+# adblock-proxy — HTTP forward proxy with @ghostery/adblocker for searxng-mcp tiers 2+3.
+# Blocks plain-HTTP ad/tracker requests. HTTPS CONNECT is tunneled without MITM.
+FROM node:20-alpine
+
+RUN addgroup -S proxy && adduser -S proxy -G proxy
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --omit=dev
+
+COPY proxy.js ./
+
+USER proxy
+
+ENV PORT="8118"
+ENV ADBLOCK_FILTERS_URL="https://easylist.to/easylist/easylist.txt,https://easylist.to/easylist/easyprivacy.txt"
+ENV ADBLOCK_REFRESH_HOURS="168"
+ENV LOG_BLOCKED="false"
+
+EXPOSE 8118
+
+CMD ["node", "proxy.js"]

--- a/docker/adblock-proxy/Dockerfile
+++ b/docker/adblock-proxy/Dockerfile
@@ -1,6 +1,10 @@
 # adblock-proxy — HTTP forward proxy with @ghostery/adblocker for searxng-mcp tiers 2+3.
 # Blocks plain-HTTP ad/tracker requests. HTTPS CONNECT is tunneled without MITM.
-FROM node:20-alpine
+#
+# Base image pinned by digest (security check DC-01). To update:
+#   docker pull node:20-alpine
+#   docker inspect node:20-alpine --format '{{index .RepoDigests 0}}'
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
 
 RUN addgroup -S proxy && adduser -S proxy -G proxy
 

--- a/docker/adblock-proxy/README.md
+++ b/docker/adblock-proxy/README.md
@@ -1,0 +1,58 @@
+# adblock-proxy
+
+HTTP forward proxy that filters ad and tracker requests using `@ghostery/adblocker`
+(EasyList + EasyPrivacy by default). Used by searxng-mcp tiers 2 and 3.
+
+## Architecture: two-sidecar adblocking
+
+searxng-mcp uses two independent adblock mechanisms, one per fetch tier:
+
+| Sidecar | Tier | Mechanism | HTTPS coverage |
+|---------|------|-----------|----------------|
+| `docker/puppeteer-adblock/` | Tier 1 (Firecrawl/Puppeteer) | CDP-level interception via `@ghostery/adblocker-puppeteer` — hooks into the browser's network stack | Full HTTPS filtering (same process, no MITM needed) |
+| `docker/adblock-proxy/` (this service) | Tiers 2+3 (Crawl4AI, raw Node fetch) | HTTP forward proxy — blocks matched plain-HTTP requests; CONNECT tunneled without interception | Plain-HTTP only |
+
+**Why no HTTPS MITM for tiers 2+3:** Full HTTPS filtering would require distributing
+a CA certificate to Crawl4AI's Playwright runtime and Node's TLS stack. The primary
+benefit of adblocking at tiers 2+3 is reducing outbound tracker/analytics requests
+(typically separate domain, often HTTP), not filtering inline ad content. The
+complexity-to-benefit ratio doesn't justify it. The tier-1 puppeteer hook already
+provides full HTTPS filtering for that tier.
+
+## Usage
+
+```yaml
+# docker-compose.full.yml excerpt
+services:
+  adblock-proxy:
+    build:
+      context: ./docker/adblock-proxy
+    restart: unless-stopped
+
+  searxng-mcp:
+    # ... other config ...
+    environment:
+      ADBLOCK_PROXY_URL: http://adblock-proxy:8118
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `8118` | Listen port (Privoxy conventional port) |
+| `ADBLOCK_FILTERS_URL` | EasyList + EasyPrivacy | Comma-separated filter list URLs |
+| `ADBLOCK_REFRESH_HOURS` | `168` | Filter refresh interval in hours (0 = no refresh) |
+| `LOG_BLOCKED` | `false` | Log blocked request URLs to stdout |
+
+## How it works
+
+- **Plain HTTP requests**: URL is checked against the loaded filter engine. Blocked URLs
+  receive an empty `200` response (not `403`, to avoid triggering retry logic in callers).
+  Allowed requests are proxied to the target host.
+
+- **HTTPS CONNECT**: A raw TCP tunnel is established between the client and the target host.
+  No content interception. Ad domains accessible only over HTTPS are not blocked.
+
+- **Filter refresh**: Filter lists are downloaded at startup and reloaded every
+  `ADBLOCK_REFRESH_HOURS`. The server continues using the previous engine if a refresh
+  fails.

--- a/docker/adblock-proxy/package.json
+++ b/docker/adblock-proxy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "adblock-proxy",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "description": "HTTP forward proxy with @ghostery/adblocker for searxng-mcp tiers 2+3",
+  "main": "proxy.js",
+  "scripts": {
+    "start": "node proxy.js"
+  },
+  "dependencies": {
+    "@ghostery/adblocker": "^2.3.0",
+    "node-fetch": "^3.3.2"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/docker/adblock-proxy/package.json
+++ b/docker/adblock-proxy/package.json
@@ -8,8 +8,7 @@
     "start": "node proxy.js"
   },
   "dependencies": {
-    "@ghostery/adblocker": "^2.3.0",
-    "node-fetch": "^3.3.2"
+    "@ghostery/adblocker": "^2.3.0"
   },
   "engines": {
     "node": ">=20"

--- a/docker/adblock-proxy/proxy.js
+++ b/docker/adblock-proxy/proxy.js
@@ -58,6 +58,9 @@ async function loadFilters() {
   const newEngine = FiltersEngine.parse(combined, { debug: false });
   const count = newEngine.filters ? newEngine.filters.size : "unknown";
   engine = newEngine;
+  if (!engine) {
+    console.error("[adblock-proxy] WARNING: no filters loaded — all requests will pass through unfiltered");
+  }
   console.log(`[adblock-proxy] loaded filters from ${FILTERS_URLS.length} list(s) (${count} rules)`);
 }
 
@@ -114,6 +117,16 @@ const server = http.createServer((req, res) => {
   req.pipe(proxy, { end: true });
 });
 
+// RFC-1918 / loopback blocklist — applied to CONNECT targets to prevent SSRF pivot.
+// Mirrors the patterns in src/fetch-utils.ts:assertPublicUrl.
+// SECURITY[control]: blocks internal address tunneling via CONNECT. Audit: 2026-06-05/searxng-mcp-transport-2026-06.
+const PRIVATE_HOSTS = [
+  /^localhost$/i, /^127\./, /^0\.0\.0\.0$/,
+  /^10\./, /^192\.168\./, /^172\.(1[6-9]|2[0-9]|3[01])\./,
+  /^host\.docker\.internal$/i,
+  /^::1$/, /^fc[0-9a-f]{2}:/i, /^fe[89ab][0-9a-f]:/i, /^fd[0-9a-f]{2}:/i,
+];
+
 // HTTPS CONNECT — TCP tunnel, no interception
 server.on("connect", (req, clientSocket, head) => {
   const [host, portStr] = (req.url ?? "").split(":");
@@ -121,6 +134,12 @@ server.on("connect", (req, clientSocket, head) => {
 
   if (!host || !port) {
     clientSocket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
+    clientSocket.destroy();
+    return;
+  }
+
+  if (PRIVATE_HOSTS.some((r) => r.test(host))) {
+    clientSocket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
     clientSocket.destroy();
     return;
   }

--- a/docker/adblock-proxy/proxy.js
+++ b/docker/adblock-proxy/proxy.js
@@ -1,0 +1,178 @@
+"use strict";
+
+/**
+ * adblock-proxy — HTTP forward proxy with @ghostery/adblocker filter engine.
+ *
+ * Plain HTTP requests: checked against EasyList + EasyPrivacy. Blocked URLs
+ * receive an empty 200 response. Allowed requests are proxied to the target.
+ *
+ * HTTPS CONNECT: established as a TCP tunnel without interception. HTTPS
+ * ad/tracker domains are not filtered at content level (acceptable tradeoff
+ * vs. certificate complexity — see docker/adblock-proxy/README.md).
+ *
+ * Environment:
+ *   PORT                  Listen port (default: 8118)
+ *   ADBLOCK_FILTERS_URL   Comma-separated filter list URLs
+ *                         (default: EasyList + EasyPrivacy)
+ *   ADBLOCK_REFRESH_HOURS How often to refresh filters (default: 168)
+ *   LOG_BLOCKED           Log blocked request URLs (default: false)
+ */
+
+const http = require("http");
+const net = require("net");
+const { URL } = require("url");
+const { FiltersEngine, Request } = require("@ghostery/adblocker");
+
+const PORT = parseInt(process.env.PORT ?? "8118", 10);
+const FILTERS_URLS = (
+  process.env.ADBLOCK_FILTERS_URL ??
+  "https://easylist.to/easylist/easylist.txt,https://easylist.to/easylist/easyprivacy.txt"
+)
+  .split(",")
+  .map((u) => u.trim())
+  .filter(Boolean);
+const REFRESH_HOURS = parseInt(process.env.ADBLOCK_REFRESH_HOURS ?? "168", 10);
+const LOG_BLOCKED = process.env.LOG_BLOCKED === "true";
+
+let engine = null;
+
+async function loadFilters() {
+  let combined = "";
+  for (const url of FILTERS_URLS) {
+    try {
+      // Use global fetch (Node 18+)
+      const res = await fetch(url, {
+        headers: { "User-Agent": "adblock-proxy/1.0" },
+        signal: AbortSignal.timeout(30000),
+      });
+      if (!res.ok) {
+        console.error(`[adblock-proxy] filter fetch failed: ${url} status=${res.status}`);
+        continue;
+      }
+      const text = await res.text();
+      combined += text + "\n";
+    } catch (err) {
+      console.error(`[adblock-proxy] filter fetch error: ${url} ${err.message}`);
+    }
+  }
+  const newEngine = FiltersEngine.parse(combined, { debug: false });
+  const count = newEngine.filters ? newEngine.filters.size : "unknown";
+  engine = newEngine;
+  console.log(`[adblock-proxy] loaded filters from ${FILTERS_URLS.length} list(s) (${count} rules)`);
+}
+
+function isBlocked(url, sourceUrl = "") {
+  if (!engine) return false;
+  try {
+    const req = Request.fromRawDetails({ url, sourceUrl, type: "other" });
+    return engine.match(req).match;
+  } catch {
+    return false;
+  }
+}
+
+const server = http.createServer((req, res) => {
+  // Plain HTTP proxy request
+  const targetUrl = req.url;
+
+  if (isBlocked(targetUrl)) {
+    if (LOG_BLOCKED) console.log(`[adblock-proxy] blocked ${targetUrl}`);
+    res.writeHead(200, { "Content-Length": "0", "Content-Type": "text/plain" });
+    res.end();
+    return;
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(targetUrl);
+  } catch {
+    res.writeHead(400);
+    res.end();
+    return;
+  }
+
+  const options = {
+    hostname: parsed.hostname,
+    port: parsed.port || 80,
+    path: parsed.pathname + parsed.search,
+    method: req.method,
+    headers: { ...req.headers, host: parsed.host },
+  };
+
+  const proxy = http.request(options, (proxyRes) => {
+    res.writeHead(proxyRes.statusCode, proxyRes.headers);
+    proxyRes.pipe(res, { end: true });
+  });
+
+  proxy.on("error", (err) => {
+    if (!res.headersSent) {
+      res.writeHead(502);
+      res.end();
+    }
+  });
+
+  req.pipe(proxy, { end: true });
+});
+
+// HTTPS CONNECT — TCP tunnel, no interception
+server.on("connect", (req, clientSocket, head) => {
+  const [host, portStr] = (req.url ?? "").split(":");
+  const port = parseInt(portStr ?? "443", 10);
+
+  if (!host || !port) {
+    clientSocket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
+    clientSocket.destroy();
+    return;
+  }
+
+  const serverSocket = net.connect(port, host, () => {
+    clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+    serverSocket.write(head);
+    serverSocket.pipe(clientSocket);
+    clientSocket.pipe(serverSocket);
+  });
+
+  serverSocket.on("error", () => {
+    clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
+    clientSocket.destroy();
+  });
+
+  clientSocket.on("error", () => {
+    serverSocket.destroy();
+  });
+});
+
+server.on("error", (err) => {
+  console.error(`[adblock-proxy] server error: ${err.message}`);
+  process.exit(1);
+});
+
+async function start() {
+  await loadFilters();
+
+  // Periodic filter refresh
+  if (REFRESH_HOURS > 0) {
+    const ms = REFRESH_HOURS * 60 * 60 * 1000;
+    setInterval(() => {
+      loadFilters().catch((err) =>
+        console.error(`[adblock-proxy] filter refresh error: ${err.message}`)
+      );
+    }, ms);
+  }
+
+  server.listen(PORT, "0.0.0.0", () => {
+    console.log(`[adblock-proxy] listening on 0.0.0.0:${PORT}`);
+  });
+}
+
+process.on("SIGTERM", () => {
+  server.close(() => process.exit(0));
+});
+process.on("SIGINT", () => {
+  server.close(() => process.exit(0));
+});
+
+start().catch((err) => {
+  console.error(`[adblock-proxy] startup error: ${err.message}`);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tadmstr/searxng-mcp",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "MCP server for SearXNG — private web search for Claude Code",
   "main": "build/src/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "iovalkey": "^0.3.3",
     "jsdom": "^29.1.1",
     "robots-parser": "^3.0.1",
+    "undici": "^8.3.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "iovalkey": "^0.3.3",
     "jsdom": "^29.1.1",
     "robots-parser": "^3.0.1",
-    "undici": "^8.3.0",
+    "undici": "^7.0.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       robots-parser:
         specifier: ^3.0.1
         version: 3.0.1
+      undici:
+        specifier: ^8.3.0
+        version: 8.3.0
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -1319,6 +1322,10 @@ packages:
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.3.0:
+    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+    engines: {node: '>=22.19.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2727,6 +2734,8 @@ snapshots:
   undici-types@7.25.0: {}
 
   undici@7.25.0: {}
+
+  undici@8.3.0: {}
 
   unpipe@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       undici:
-        specifier: ^8.3.0
-        version: 8.3.0
+        specifier: ^7.0.0
+        version: 7.25.0
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -1322,10 +1322,6 @@ packages:
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
-
-  undici@8.3.0:
-    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
-    engines: {node: '>=22.19.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2734,8 +2730,6 @@ snapshots:
   undici-types@7.25.0: {}
 
   undici@7.25.0: {}
-
-  undici@8.3.0: {}
 
   unpipe@1.0.0: {}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,9 @@ export const KIWIX_URL = process.env.KIWIX_URL?.replace(/\/$/, "") ?? "";
 export const CRAWL4AI_URL = process.env.CRAWL4AI_URL ?? null;
 export const CRAWL4AI_API_TOKEN = process.env.CRAWL4AI_API_TOKEN;
 export const WAYBACK_ENABLED = process.env.WAYBACK_ENABLED === "true";
+export const TRANSPORT = process.env.SEARXNG_MCP_TRANSPORT ?? "stdio"; // "stdio" | "http"
+export const HTTP_PORT = parseInt(process.env.SEARXNG_MCP_PORT ?? "3001", 10);
+export const HTTP_HOST = process.env.SEARXNG_MCP_HOST ?? "127.0.0.1";
 export const RERANK_RECENCY_WEIGHT = (() => {
   const v = parseFloat(process.env.RERANK_RECENCY_WEIGHT ?? "0.15");
   if (Number.isNaN(v) || v < 0) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ export const KIWIX_URL = process.env.KIWIX_URL?.replace(/\/$/, "") ?? "";
 export const CRAWL4AI_URL = process.env.CRAWL4AI_URL ?? null;
 export const CRAWL4AI_API_TOKEN = process.env.CRAWL4AI_API_TOKEN;
 export const WAYBACK_ENABLED = process.env.WAYBACK_ENABLED === "true";
+export const ADBLOCK_PROXY_URL = process.env.ADBLOCK_PROXY_URL ?? null;
 export const TRANSPORT = process.env.SEARXNG_MCP_TRANSPORT ?? "stdio"; // "stdio" | "http"
 export const HTTP_PORT = parseInt(process.env.SEARXNG_MCP_PORT ?? "3001", 10);
 export const HTTP_HOST = process.env.SEARXNG_MCP_HOST ?? "127.0.0.1";

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -13,14 +13,13 @@ import { isKiwixHost, kiwixFetch } from "./kiwix.js";
 import { tryLlmsTxtFetch } from "./llms-txt.js";
 import { incCounter, recordHistogram, withSpan } from "./observability.js";
 import { checkRobots } from "./robots.js";
-import { getTiers, type SkipReason, TIER_NAME } from "./routing.js";
+import { getTiers, TIER_NAME } from "./routing.js";
 import {
   fetchRawHtmlForMetadata,
   githubFetch,
   tier2 as pdfTier,
   waybackFetch,
 } from "./tiers/index.js";
-import type { TierSlot } from "./types.js";
 
 // Re-export for callers that import assertPublicUrl from this module.
 export { assertPublicUrl } from "./fetch-utils.js";
@@ -224,10 +223,6 @@ export async function fetchPage(
       // Resolve data-driven + operator skips before kicking off the cascade.
       const { active: activeTiers, skipped: skipDecisions } =
         await getTiers(url);
-      const skipBy = new Map<TierSlot, SkipReason>(
-        skipDecisions.map((d) => [d.tier, d.reason]),
-      );
-
       // Announce all skipped tiers up front (metrics + events + logs).
       for (const { tier: slot, reason } of skipDecisions) {
         const tierName = TIER_NAME[slot];

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -13,14 +13,11 @@ import { isKiwixHost, kiwixFetch } from "./kiwix.js";
 import { tryLlmsTxtFetch } from "./llms-txt.js";
 import { incCounter, recordHistogram, withSpan } from "./observability.js";
 import { checkRobots } from "./robots.js";
-import { computeTierSkips, type SkipReason, TIER_NAME } from "./routing.js";
+import { getTiers, type SkipReason, TIER_NAME } from "./routing.js";
 import {
-  applyTier2Readability,
-  crawl4aiFetch,
   fetchRawHtmlForMetadata,
-  firecrawlScrape,
   githubFetch,
-  rawFetch,
+  tier2 as pdfTier,
   waybackFetch,
 } from "./tiers/index.js";
 import type { TierSlot } from "./types.js";
@@ -225,25 +222,26 @@ export async function fetchPage(
       }
 
       // Resolve data-driven + operator skips before kicking off the cascade.
-      const skipDecisions = await computeTierSkips(url);
+      const { active: activeTiers, skipped: skipDecisions } =
+        await getTiers(url);
       const skipBy = new Map<TierSlot, SkipReason>(
         skipDecisions.map((d) => [d.tier, d.reason]),
       );
-      const announceSkip = (slot: TierSlot): void => {
-        const reason = skipBy.get(slot);
-        if (!reason) return;
+
+      // Announce all skipped tiers up front (metrics + events + logs).
+      for (const { tier: slot, reason } of skipDecisions) {
         const tierName = TIER_NAME[slot];
         incCounter("fetch", { tier: tierName, outcome: "skipped" });
         events.fetchTierSkipped({ url, tier: tierName, reason });
         console.error(
           `[searxng-mcp] fetch ${slot} skipped url=${url} reason=${reason}`,
         );
-      };
+      }
 
-      // PDF fast path — Firecrawl can't extract PDF text; route directly to Crawl4AI.
+      // PDF fast path — Firecrawl can't extract PDF text; route directly to tier2.
       if (isPdfUrl(url)) {
         const pdfResult = await runTier("tier2_crawl4ai", url, () =>
-          crawl4aiFetch(url, 8000, preferFit),
+          pdfTier.fetch(url, 8000, preferFit),
         );
         if (!pdfResult) {
           throw new Error(
@@ -270,47 +268,18 @@ export async function fetchPage(
       const metadataHtmlPromise = fetchRawHtmlForMetadata(url);
 
       let fetched: TierResult | null = null;
-      if (skipBy.has("tier1")) {
-        announceSkip("tier1");
-      } else {
-        fetched = await runTier("tier1_firecrawl", url, async () => {
-          const r = await firecrawlScrape(url, 8000);
-          return r?.text ? r : null;
-        });
+      for (const tier of activeTiers) {
+        fetched = await runTier(tier.name, url, () =>
+          tier.fetch(url, 8000, preferFit),
+        );
         if (fetched) {
-          tierServed = "tier1_firecrawl";
-        } else {
-          console.error(`[searxng-mcp] fetch tier1 miss url=${url}`);
-        }
-      }
-
-      if (!fetched) {
-        if (skipBy.has("tier2")) {
-          announceSkip("tier2");
-        } else {
-          fetched = await runTier("tier2_crawl4ai", url, () =>
-            crawl4aiFetch(url, 8000, preferFit),
-          );
-          if (fetched) {
-            fetched = applyTier2Readability(fetched, url);
-            tierServed = "tier2_crawl4ai";
-            console.error(`[searxng-mcp] fetch tier2 hit url=${url}`);
-          } else {
-            console.error(`[searxng-mcp] fetch tier2 miss url=${url}`);
+          tierServed = tier.name;
+          if (tier.slot !== "tier1") {
+            console.error(`[searxng-mcp] fetch ${tier.slot} hit url=${url}`);
           }
+          break;
         }
-      }
-
-      if (!fetched) {
-        if (skipBy.has("tier3")) {
-          announceSkip("tier3");
-        } else {
-          console.error(`[searxng-mcp] fetch tier3 fallback url=${url}`);
-          fetched = await runTier("tier3_rawfetch", url, () =>
-            rawFetch(url, 8000),
-          );
-          if (fetched) tierServed = "tier3_rawfetch";
-        }
+        console.error(`[searxng-mcp] fetch ${tier.slot} miss url=${url}`);
       }
 
       if (!fetched && WAYBACK_ENABLED) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
+import { createServer } from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { HTTP_HOST, HTTP_PORT, TRANSPORT } from "./config.js";
 import { initEvents, shutdownEvents } from "./events.js";
 import { initObservability, shutdownObservability } from "./observability.js";
 import { registerTools } from "./tools.js";
@@ -10,13 +13,10 @@ await initEvents();
 
 const server = new McpServer({
   name: "searxng-mcp",
-  version: "3.7.0",
+  version: "3.9.0",
 });
 
 registerTools(server);
-
-const transport = new StdioServerTransport();
-await server.connect(transport);
 
 const shutdown = async () => {
   await Promise.allSettled([shutdownObservability(), shutdownEvents()]);
@@ -24,3 +24,30 @@ const shutdown = async () => {
 };
 process.once("SIGTERM", shutdown);
 process.once("SIGINT", shutdown);
+
+if (TRANSPORT === "http") {
+  // Stateful HTTP transport — session IDs prevent message ID collisions between
+  // concurrent clients. Multiple clients share in-process caches (L1 llms.txt,
+  // domain stats) but have separate Valkey-backed state.
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => crypto.randomUUID(),
+  });
+  await server.connect(transport);
+
+  const httpServer = createServer((req, res) => {
+    transport.handleRequest(req, res).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: msg }));
+    });
+  });
+
+  httpServer.listen(HTTP_PORT, HTTP_HOST, () => {
+    console.error(
+      `[searxng-mcp] HTTP transport listening on http://${HTTP_HOST}:${HTTP_PORT}`,
+    );
+  });
+} else {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,11 @@ if (TRANSPORT === "http") {
     console.error(
       `[searxng-mcp] HTTP transport listening on http://${HTTP_HOST}:${HTTP_PORT}`,
     );
+    if (HTTP_HOST !== "127.0.0.1") {
+      console.error(
+        `[searxng-mcp] WARNING: HTTP transport bound to ${HTTP_HOST}:${HTTP_PORT} — no built-in auth; ensure network-level protection`,
+      );
+    }
   });
 } else {
   const transport = new StdioServerTransport();

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ await initEvents();
 
 const server = new McpServer({
   name: "searxng-mcp",
-  version: "3.9.0",
+  version: "3.10.0",
 });
 
 registerTools(server);
@@ -36,9 +36,9 @@ if (TRANSPORT === "http") {
 
   const httpServer = createServer((req, res) => {
     transport.handleRequest(req, res).catch((err: unknown) => {
-      const msg = err instanceof Error ? err.message : String(err);
+      console.error("[searxng-mcp] HTTP transport error:", err);
       res.writeHead(500, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: msg }));
+      res.end(JSON.stringify({ error: "Internal server error" }));
     });
   });
 

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -5,6 +5,7 @@
 
 import { getDomainRecord, type TierName } from "./domain-db.js";
 import { getOperatorTierSkips } from "./domains.js";
+import { ALL_TIERS, type Tier } from "./tiers/index.js";
 import type { TierSlot } from "./types.js";
 
 const MIN_ATTEMPTS_FOR_DECISION = 10;
@@ -48,4 +49,20 @@ export async function computeTierSkips(
   }
 
   return Array.from(decisions, ([tier, reason]) => ({ tier, reason }));
+}
+
+/**
+ * Returns the active tier list and skip decisions for a URL.
+ *
+ * `active` is the ordered set of tiers to attempt (skips already removed).
+ * `skipped` carries the skip decisions for observability/logging callers.
+ */
+export async function getTiers(url: string): Promise<{
+  active: Tier[];
+  skipped: TierSkipDecision[];
+}> {
+  const skipped = await computeTierSkips(url);
+  const skipSlots = new Set(skipped.map((d) => d.tier));
+  const active = ALL_TIERS.filter((t) => !skipSlots.has(t.slot));
+  return { active, skipped };
 }

--- a/src/tiers/crawl4ai.ts
+++ b/src/tiers/crawl4ai.ts
@@ -1,4 +1,4 @@
-import { CRAWL4AI_API_TOKEN, CRAWL4AI_URL } from "../config.js";
+import { ADBLOCK_PROXY_URL, CRAWL4AI_API_TOKEN, CRAWL4AI_URL } from "../config.js";
 import {
   preferReadability,
   runReadability,
@@ -66,7 +66,12 @@ export async function crawl4aiFetch(
     const resp = await fetch(`${CRAWL4AI_URL}/crawl`, {
       method: "POST",
       headers: crawlHeaders,
-      body: JSON.stringify({ urls: [url] }),
+      body: JSON.stringify({
+        urls: [url],
+        ...(ADBLOCK_PROXY_URL
+          ? { proxy_config: { server: ADBLOCK_PROXY_URL } }
+          : {}),
+      }),
       signal: controller.signal,
     });
 

--- a/src/tiers/crawl4ai.ts
+++ b/src/tiers/crawl4ai.ts
@@ -1,4 +1,8 @@
-import { ADBLOCK_PROXY_URL, CRAWL4AI_API_TOKEN, CRAWL4AI_URL } from "../config.js";
+import {
+  ADBLOCK_PROXY_URL,
+  CRAWL4AI_API_TOKEN,
+  CRAWL4AI_URL,
+} from "../config.js";
 import {
   preferReadability,
   runReadability,

--- a/src/tiers/index.ts
+++ b/src/tiers/index.ts
@@ -2,4 +2,42 @@ export { applyTier2Readability, crawl4aiFetch } from "./crawl4ai.js";
 export { firecrawlScrape } from "./firecrawl.js";
 export { githubFetch } from "./github.js";
 export { fetchRawHtmlForMetadata, rawFetch } from "./raw.js";
+export type { Tier } from "./types.js";
 export { waybackFetch } from "./wayback.js";
+
+import { applyTier2Readability, crawl4aiFetch } from "./crawl4ai.js";
+import { firecrawlScrape } from "./firecrawl.js";
+import { rawFetch } from "./raw.js";
+import type { Tier } from "./types.js";
+
+/** Tier 1 — Firecrawl (Puppeteer-rendered, best quality). */
+export const tier1: Tier = {
+  name: "tier1_firecrawl",
+  slot: "tier1",
+  async fetch(url, maxChars) {
+    const r = await firecrawlScrape(url, maxChars);
+    return r?.text ? r : null;
+  },
+};
+
+/** Tier 2 — Crawl4AI (browser automation + Readability post-processing). */
+export const tier2: Tier = {
+  name: "tier2_crawl4ai",
+  slot: "tier2",
+  async fetch(url, maxChars, preferFit = false) {
+    const r = await crawl4aiFetch(url, maxChars, preferFit);
+    return r ? applyTier2Readability(r, url) : null;
+  },
+};
+
+/** Tier 3 — Raw Node.js fetch + JSDOM Readability. */
+export const tier3: Tier = {
+  name: "tier3_rawfetch",
+  slot: "tier3",
+  async fetch(url, maxChars) {
+    return rawFetch(url, maxChars);
+  },
+};
+
+/** Canonical ordered tier list. Order determines cascade priority. */
+export const ALL_TIERS: readonly Tier[] = [tier1, tier2, tier3];

--- a/src/tiers/raw.ts
+++ b/src/tiers/raw.ts
@@ -1,11 +1,17 @@
 import { Readability } from "@mozilla/readability";
 import { JSDOM } from "jsdom";
+import { ProxyAgent } from "undici";
+import { ADBLOCK_PROXY_URL } from "../config.js";
 import {
   assertPublicUrl,
   readBoundedText,
   type TierResult,
   USER_AGENT,
 } from "../fetch-utils.js";
+
+// Create a ProxyAgent once at module init when ADBLOCK_PROXY_URL is configured.
+// Passed as `dispatcher` to undici-backed fetch calls (Node.js 18+ global fetch).
+const proxyAgent = ADBLOCK_PROXY_URL ? new ProxyAgent(ADBLOCK_PROXY_URL) : null;
 
 export async function rawFetch(
   url: string,
@@ -16,11 +22,16 @@ export async function rawFetch(
   // future direct callers (SSRF-08).
   assertPublicUrl(url);
 
-  const res = await fetch(url, {
+  const fetchOptions: Parameters<typeof fetch>[1] & {
+    dispatcher?: ProxyAgent;
+  } = {
     headers: { "User-Agent": USER_AGENT },
     redirect: "manual",
     signal: AbortSignal.timeout(15000),
-  });
+  };
+  if (proxyAgent) fetchOptions.dispatcher = proxyAgent;
+
+  const res = await fetch(url, fetchOptions);
 
   if (res.headers.get("content-type")?.includes("application/pdf")) {
     throw new Error(

--- a/src/tiers/types.ts
+++ b/src/tiers/types.ts
@@ -1,0 +1,21 @@
+import type { TierName } from "../domain-db.js";
+import type { TierResult } from "../fetch-utils.js";
+import type { TierSlot } from "../types.js";
+
+/**
+ * A single fetch tier in the cascade.
+ *
+ * `slot` maps to the TierSlot used for skip decisions (tier1/2/3).
+ * `name` is the full observability label (tier1_firecrawl, etc.).
+ * `fetch` returns null on miss/error; the runTier wrapper handles
+ * observability recording.
+ */
+export interface Tier {
+  name: TierName;
+  slot: TierSlot;
+  fetch(
+    url: string,
+    maxChars: number,
+    preferFit?: boolean,
+  ): Promise<TierResult | null>;
+}

--- a/tests/extractors/readability.test.ts
+++ b/tests/extractors/readability.test.ts
@@ -31,7 +31,7 @@ describe("preferReadability", () => {
   it("prefers Readability when its text is longer than baseline", () => {
     expect(
       preferReadability(
-        { text: "long readable text " + "x".repeat(2000) },
+        { text: `long readable text ${"x".repeat(2000)}` },
         { text: "medium baseline ".repeat(40) },
       ),
     ).toBe(true);

--- a/tests/fetch-cascade.test.ts
+++ b/tests/fetch-cascade.test.ts
@@ -1,0 +1,165 @@
+// Tests for the Phase-2 tier cascade refactor: Tier interface, getTiers(),
+// and ALL_TIERS ordering. These tests complement the routing.test.ts suite
+// (which covers computeTierSkips) by verifying the Tier objects and the
+// getTiers helper that wires skips into an active tier list.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/cache.js", () => ({
+  cacheGet: vi.fn(),
+  cacheSet: vi.fn(),
+}));
+
+vi.mock("../src/domains.js", () => ({
+  getOperatorTierSkips: vi.fn(() => []),
+}));
+
+import { cacheGet } from "../src/cache.js";
+import type { DomainRecord } from "../src/domain-db.js";
+import { getOperatorTierSkips } from "../src/domains.js";
+import { getTiers } from "../src/routing.js";
+import { ALL_TIERS, tier1, tier2, tier3 } from "../src/tiers/index.js";
+
+const cacheGetMock = vi.mocked(cacheGet);
+const getOpSkipMock = vi.mocked(getOperatorTierSkips);
+
+const NOW = Date.now();
+
+function stat(attempts: number, ok: number, fail: number) {
+  return { attempts, ok, fail, window_start_ms: NOW };
+}
+
+function record(overrides: Partial<DomainRecord>): DomainRecord {
+  return {
+    schema_version: 2,
+    domain: "example.com",
+    first_seen: "2026-05-01T00:00:00Z",
+    last_fetch: "2026-05-01T00:00:00Z",
+    capabilities: {},
+    tier_stats_30d: {
+      tier1: stat(0, 0, 0),
+      tier2: stat(0, 0, 0),
+      tier3: stat(0, 0, 0),
+    },
+    ...overrides,
+  };
+}
+
+describe("Tier objects", () => {
+  it("tier1 has name=tier1_firecrawl and slot=tier1", () => {
+    expect(tier1.name).toBe("tier1_firecrawl");
+    expect(tier1.slot).toBe("tier1");
+  });
+
+  it("tier2 has name=tier2_crawl4ai and slot=tier2", () => {
+    expect(tier2.name).toBe("tier2_crawl4ai");
+    expect(tier2.slot).toBe("tier2");
+  });
+
+  it("tier3 has name=tier3_rawfetch and slot=tier3", () => {
+    expect(tier3.name).toBe("tier3_rawfetch");
+    expect(tier3.slot).toBe("tier3");
+  });
+
+  it("ALL_TIERS contains tier1, tier2, tier3 in priority order", () => {
+    expect(ALL_TIERS).toHaveLength(3);
+    expect(ALL_TIERS[0]).toBe(tier1);
+    expect(ALL_TIERS[1]).toBe(tier2);
+    expect(ALL_TIERS[2]).toBe(tier3);
+  });
+
+  it("each Tier has a fetch function", () => {
+    for (const tier of ALL_TIERS) {
+      expect(typeof tier.fetch).toBe("function");
+    }
+  });
+});
+
+describe("getTiers — active tier list", () => {
+  beforeEach(() => {
+    cacheGetMock.mockReset();
+    getOpSkipMock.mockReset();
+    getOpSkipMock.mockReturnValue([]);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns all three tiers when no skips apply", async () => {
+    cacheGetMock.mockResolvedValue(null);
+    const { active, skipped } = await getTiers("https://example.com/p");
+    expect(active).toHaveLength(3);
+    expect(active.map((t) => t.slot)).toEqual(["tier1", "tier2", "tier3"]);
+    expect(skipped).toHaveLength(0);
+  });
+
+  it("excludes tier1 when success rate < 30% over >=10 attempts", async () => {
+    cacheGetMock.mockResolvedValue(
+      JSON.stringify(
+        record({
+          tier_stats_30d: {
+            tier1: stat(20, 4, 16), // 20% success rate
+            tier2: stat(0, 0, 0),
+            tier3: stat(0, 0, 0),
+          },
+        }),
+      ),
+    );
+    const { active, skipped } = await getTiers("https://example.com/p");
+    expect(active.map((t) => t.slot)).toEqual(["tier2", "tier3"]);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]).toEqual({ tier: "tier1", reason: "low_success_rate" });
+  });
+
+  it("excludes operator-override tiers from the active list", async () => {
+    cacheGetMock.mockResolvedValue(null);
+    getOpSkipMock.mockReturnValue(["tier1", "tier3"]);
+    const { active, skipped } = await getTiers("https://example.com/p");
+    expect(active.map((t) => t.slot)).toEqual(["tier2"]);
+    expect(skipped.map((s) => s.tier)).toEqual(
+      expect.arrayContaining(["tier1", "tier3"]),
+    );
+  });
+
+  it("returns empty active list when all tiers are skipped", async () => {
+    cacheGetMock.mockResolvedValue(null);
+    getOpSkipMock.mockReturnValue(["tier1", "tier2", "tier3"]);
+    const { active, skipped } = await getTiers("https://example.com/p");
+    expect(active).toHaveLength(0);
+    expect(skipped).toHaveLength(3);
+  });
+
+  it("preserves tier order in active list after partial skip", async () => {
+    cacheGetMock.mockResolvedValue(
+      JSON.stringify(
+        record({
+          tier_stats_30d: {
+            tier1: stat(0, 0, 0),
+            tier2: stat(20, 2, 18), // 10% success rate → skip
+            tier3: stat(0, 0, 0),
+          },
+        }),
+      ),
+    );
+    const { active } = await getTiers("https://example.com/p");
+    expect(active.map((t) => t.slot)).toEqual(["tier1", "tier3"]);
+  });
+
+  it("skipped list carries both low_success_rate and operator_override reasons", async () => {
+    cacheGetMock.mockResolvedValue(
+      JSON.stringify(
+        record({
+          tier_stats_30d: {
+            tier1: stat(20, 1, 19), // low success → skip
+            tier2: stat(0, 0, 0),
+            tier3: stat(0, 0, 0),
+          },
+        }),
+      ),
+    );
+    getOpSkipMock.mockReturnValue(["tier3"]); // operator override
+    const { skipped } = await getTiers("https://example.com/p");
+    const byTier = new Map(skipped.map((s) => [s.tier, s.reason]));
+    expect(byTier.get("tier1")).toBe("low_success_rate");
+    expect(byTier.get("tier3")).toBe("operator_override");
+  });
+});

--- a/tests/tiers/crawl4ai.test.ts
+++ b/tests/tiers/crawl4ai.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../src/config.js", () => ({
   CRAWL4AI_URL: "http://crawl4ai:8000",
   CRAWL4AI_API_TOKEN: undefined,
+  ADBLOCK_PROXY_URL: null,
 }));
 
 const mockFetch = vi.fn();

--- a/tests/tiers/crawl4ai.test.ts
+++ b/tests/tiers/crawl4ai.test.ts
@@ -37,15 +37,15 @@ describe("crawl4aiFetch", () => {
     mockFetch.mockResolvedValueOnce(syncResponse());
     const result = await crawl4aiFetch(URL);
     expect(result).not.toBeNull();
-    expect(result!.title).toBe("Page Title");
-    expect(result!.text).toContain("Some text");
+    expect(result?.title).toBe("Page Title");
+    expect(result?.text).toContain("Some text");
   });
 
   it("truncates text to maxChars", async () => {
     mockFetch.mockResolvedValueOnce(syncResponse("abcdefghij"));
     const result = await crawl4aiFetch(URL, 3);
     expect(result).not.toBeNull();
-    expect(result!.text).toBe("abc");
+    expect(result?.text).toBe("abc");
   });
 
   it("returns null when sync result has empty markdown", async () => {
@@ -97,8 +97,8 @@ describe("pollCrawl4aiTask", () => {
     vi.useRealTimers();
 
     expect(result).not.toBeNull();
-    expect(result!.title).toBe("Polled Page");
-    expect(result!.text).toBe("page content");
+    expect(result?.title).toBe("Polled Page");
+    expect(result?.text).toBe("page content");
   });
 
   it("returns null when status is failed", async () => {

--- a/tests/transport.test.ts
+++ b/tests/transport.test.ts
@@ -1,7 +1,11 @@
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 // Minimal MCP server for transport tests — no tools, just verifies
 // the HTTP transport can be instantiated and handle requests.
@@ -20,8 +24,13 @@ beforeAll(async () => {
     transport.handleRequest(req, res).catch((err: unknown) => {
       const msg = err instanceof Error ? err.message : String(err);
       const stack = err instanceof Error ? err.stack : "";
-      process.stdout.write(`[transport-test] handleRequest error: ${msg}\n${stack}\n`);
-      if (!res.headersSent) { res.writeHead(500); res.end(JSON.stringify({ error: msg })); }
+      process.stdout.write(
+        `[transport-test] handleRequest error: ${msg}\n${stack}\n`,
+      );
+      if (!res.headersSent) {
+        res.writeHead(500);
+        res.end(JSON.stringify({ error: msg }));
+      }
     });
   });
 
@@ -69,7 +78,9 @@ describe("HTTP transport", () => {
       }),
     });
     const rawBody = await res.text();
-    process.stdout.write(`[transport-test-debug] status=${res.status} ct=${res.headers.get("content-type")} body=${rawBody.slice(0, 300)}\n`);
+    process.stdout.write(
+      `[transport-test-debug] status=${res.status} ct=${res.headers.get("content-type")} body=${rawBody.slice(0, 300)}\n`,
+    );
     // The SDK may return 200 with SSE body or 200 with JSON body depending on Accept negotiation.
     // Accept both; just verify the response is well-formed.
     expect(res.status).toBe(200);

--- a/tests/transport.test.ts
+++ b/tests/transport.test.ts
@@ -1,0 +1,83 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+// Minimal MCP server for transport tests — no tools, just verifies
+// the HTTP transport can be instantiated and handle requests.
+
+let httpServer: ReturnType<typeof createServer>;
+let port: number;
+
+beforeAll(async () => {
+  const server = new McpServer({ name: "test-server", version: "0.0.0" });
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => crypto.randomUUID(),
+  });
+  await server.connect(transport);
+
+  httpServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+    transport.handleRequest(req, res).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      const stack = err instanceof Error ? err.stack : "";
+      process.stdout.write(`[transport-test] handleRequest error: ${msg}\n${stack}\n`);
+      if (!res.headersSent) { res.writeHead(500); res.end(JSON.stringify({ error: msg })); }
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, "127.0.0.1", () => resolve());
+  });
+  port = (httpServer.address() as { port: number }).port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    httpServer.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+// MCP Streamable HTTP transport requires Accept: application/json, text/event-stream
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+};
+
+describe("HTTP transport", () => {
+  it("rejects requests missing the required Accept header with 406", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    expect(res.status).toBe(406);
+  });
+
+  it("handles a valid JSON-RPC initialize request", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/`, {
+      method: "POST",
+      headers: MCP_HEADERS,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test-client", version: "0.0.0" },
+        },
+      }),
+    });
+    const rawBody = await res.text();
+    process.stdout.write(`[transport-test-debug] status=${res.status} ct=${res.headers.get("content-type")} body=${rawBody.slice(0, 300)}\n`);
+    // The SDK may return 200 with SSE body or 200 with JSON body depending on Accept negotiation.
+    // Accept both; just verify the response is well-formed.
+    expect(res.status).toBe(200);
+    // SSE body format: "event: message\ndata: {...}\n\n"
+    // JSON body format: "{...}"
+    expect(rawBody.length).toBeGreaterThan(0);
+    // Either way, the response should contain the jsonrpc field
+    expect(rawBody).toContain('"jsonrpc"');
+    expect(rawBody).toContain('"result"');
+  });
+});


### PR DESCRIPTION
## Summary

- **Phase 1 — HTTP/SSE transport**: `SEARXNG_MCP_TRANSPORT=http` runs the server as a stateful HTTP/SSE server. `SEARXNG_MCP_PORT` (default `3001`) and `SEARXNG_MCP_HOST` (default `127.0.0.1`) control the listen address. stdio remains the default.
- **Phase 2 — Tier cascade refactor**: `Tier` interface (`src/tiers/types.ts`), `getTiers(url)` returning `{ active, skipped }`, clean `for…of` loop in `fetch.ts`. No behavior change; all existing tests pass.
- **Phase 3 — Adblock proxy for tiers 2+3**: `docker/adblock-proxy/` — Node.js HTTP proxy using `@ghostery/adblocker`. Routes Crawl4AI via `proxy_config` in request body; routes raw Node fetch via undici `ProxyAgent`. HTTPS tunneled without MITM. Wired by `ADBLOCK_PROXY_URL`.

## Test plan

- [ ] `pnpm build && pnpm test` — 25 test files, 237 tests, 0 type errors
- [ ] `tests/transport.test.ts` — 406 on missing Accept header; 200 with SSE body on valid initialize
- [ ] `tests/fetch-cascade.test.ts` — Tier shapes, ALL_TIERS ordering, getTiers skip logic
- [ ] `tests/tiers/crawl4ai.test.ts` — proxy_config mock (`ADBLOCK_PROXY_URL: null`) verified
- [ ] `docker build -t searxng-adblock-proxy docker/adblock-proxy/` — builds clean on Node 20 alpine