### PR TITLE
feat(crawl): add crawl_site tool with Firecrawl/sitemap/BFS strategy cascade (v3.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.11.0] - 2026-06-05
+
+### Added
+- **`crawl_site` tool** — crawls a site and returns a manifest (URL, title, 200-char snippet per page). Full page content is written to the existing fetch cache so follow-up `fetch_url` calls hit the cache at 100%. Three-phase strategy cascade: Firecrawl `/v2/crawl` (JS rendering, async polling) → sitemap-first (robots.txt `Sitemap:` directives + `/sitemap.xml` + `/sitemap_index.xml`, batch-fetched via existing tier cascade) → BFS via JSDOM (opt-in, `CRAWL_BFS_ENABLED=true`). Manifest is cached under `crawl:` keys with configurable TTL (`CRAWL_MANIFEST_TTL_SECONDS`, default 6h).
+- **`clear_cache "crawl"` target** — purges `crawl:*` manifest cache keys. `clear_cache "all"` now also clears crawl manifests.
+- **New env vars:** `CRAWL_MANIFEST_TTL_SECONDS` (default 21600), `CRAWL_MAX_PAGES_DEFAULT` (default 20), `CRAWL_BFS_ENABLED` (default false), `CRAWL_BFS_MAX_DEPTH` (default 3), `FIRECRAWL_CRAWL_POLL_INTERVAL_MS` (default 2000), `FIRECRAWL_CRAWL_MAX_WAIT_MS` (default 120000).
+- **`fast-xml-parser` dependency** — pure-JS XML parser for sitemap parsing (no native bindings).
+
 ## [3.10.0] - 2026-06-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **New env vars:** `CRAWL_MANIFEST_TTL_SECONDS` (default 21600), `CRAWL_MAX_PAGES_DEFAULT` (default 20), `CRAWL_BFS_ENABLED` (default false), `CRAWL_BFS_MAX_DEPTH` (default 3), `FIRECRAWL_CRAWL_POLL_INTERVAL_MS` (default 2000), `FIRECRAWL_CRAWL_MAX_WAIT_MS` (default 120000).
 - **`fast-xml-parser` dependency** — pure-JS XML parser for sitemap parsing (no native bindings).
 
+### Security
+- **`crawlSite()` SSRF guard** — `assertPublicUrl(url)` now called at entry before any strategy dispatch; previously the user-supplied URL could reach Firecrawl (delegation SSRF) or robots.txt fetch (process SSRF) without validation.
+- **Bounded response reads** — `fetchSitemapXml` and BFS raw HTML re-fetch now use `readBoundedText()` (2MB cap) instead of unbounded `res.text()`.
+- **Firecrawl job ID validation** — job ID validated against `/^[a-zA-Z0-9_-]{1,128}$/` before URL path interpolation.
+- **`assertPublicUrl` blocklist expanded** — `169.254.0.0/16` (RFC 3927 link-local / AWS IMDS) and `100.64.0.0/10` (RFC 6598 CGNAT) added.
+
 ## [3.10.0] - 2026-06-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tadmstr/searxng-mcp",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "MCP server for SearXNG — private web search for Claude Code",
   "main": "build/src/index.js",
   "bin": {
@@ -46,6 +46,7 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
     "@opentelemetry/sdk-metrics": "^2.7.1",
     "@opentelemetry/sdk-node": "^0.218.0",
+    "fast-xml-parser": "^5.8.0",
     "iovalkey": "^0.3.3",
     "jsdom": "^29.1.1",
     "robots-parser": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@opentelemetry/sdk-node':
         specifier: ^0.218.0
         version: 0.218.0(@opentelemetry/api@1.9.1)
+      fast-xml-parser:
+        specifier: ^5.8.0
+        version: 5.8.0
       iovalkey:
         specifier: ^0.3.3
         version: 0.3.3
@@ -265,6 +268,9 @@ packages:
   '@nats-io/transport-node@3.4.0':
     resolution: {integrity: sha512-hH7u7ejIBTFEJIZ8rIcMrHJI6wl+HhpO5sVFs1+ppmXa8RuB2+Lh1+UwTzZ5xTNNm1TKcRkYy+2qCV56qp8RxA==}
     engines: {node: '>= 18.0.0'}
+
+  '@nodable/entities@2.1.1':
+    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
 
   '@opentelemetry/api-logs@0.218.0':
     resolution: {integrity: sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==}
@@ -830,6 +836,13 @@ packages:
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.8.0:
+    resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
+    hasBin: true
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1105,6 +1118,10 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -1256,6 +1273,9 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -1451,6 +1471,10 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -1652,6 +1676,8 @@ snapshots:
       '@nats-io/nats-core': 3.4.0
       '@nats-io/nkeys': 2.0.3
       '@nats-io/nuid': 3.0.0
+
+  '@nodable/entities@2.1.1': {}
 
   '@opentelemetry/api-logs@0.218.0':
     dependencies:
@@ -2242,6 +2268,19 @@ snapshots:
 
   fast-uri@3.1.2: {}
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.8.0:
+    dependencies:
+      '@nodable/entities': 2.1.1
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+      xml-naming: 0.1.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -2486,6 +2525,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-to-regexp@8.4.2: {}
@@ -2678,6 +2719,8 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strnum@2.3.0: {}
+
   symbol-tree@3.2.4: {}
 
   tinybench@2.9.0: {}
@@ -2810,6 +2853,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xmlchars@2.2.0: {}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,28 @@ export const ADBLOCK_PROXY_URL = process.env.ADBLOCK_PROXY_URL ?? null;
 export const TRANSPORT = process.env.SEARXNG_MCP_TRANSPORT ?? "stdio"; // "stdio" | "http"
 export const HTTP_PORT = parseInt(process.env.SEARXNG_MCP_PORT ?? "3001", 10);
 export const HTTP_HOST = process.env.SEARXNG_MCP_HOST ?? "127.0.0.1";
+export const CRAWL_MANIFEST_TTL_SECONDS = parseInt(
+  process.env.CRAWL_MANIFEST_TTL_SECONDS ?? "21600",
+  10,
+);
+export const CRAWL_MAX_PAGES_DEFAULT = parseInt(
+  process.env.CRAWL_MAX_PAGES_DEFAULT ?? "20",
+  10,
+);
+export const CRAWL_BFS_ENABLED = process.env.CRAWL_BFS_ENABLED === "true";
+export const CRAWL_BFS_MAX_DEPTH = parseInt(
+  process.env.CRAWL_BFS_MAX_DEPTH ?? "3",
+  10,
+);
+export const FIRECRAWL_CRAWL_POLL_INTERVAL_MS = parseInt(
+  process.env.FIRECRAWL_CRAWL_POLL_INTERVAL_MS ?? "2000",
+  10,
+);
+export const FIRECRAWL_CRAWL_MAX_WAIT_MS = parseInt(
+  process.env.FIRECRAWL_CRAWL_MAX_WAIT_MS ?? "120000",
+  10,
+);
+
 export const RERANK_RECENCY_WEIGHT = (() => {
   const v = parseFloat(process.env.RERANK_RECENCY_WEIGHT ?? "0.15");
   if (Number.isNaN(v) || v < 0) {

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -1,0 +1,507 @@
+import { createHash } from "node:crypto";
+import { XMLParser } from "fast-xml-parser";
+import { cacheGet, cacheSet, fetchCacheKey } from "./cache.js";
+import {
+  CRAWL_BFS_ENABLED,
+  CRAWL_BFS_MAX_DEPTH,
+  CRAWL_MANIFEST_TTL_SECONDS,
+  FETCH_CACHE_TTL_SECONDS,
+  FIRECRAWL_API_KEY,
+  FIRECRAWL_CRAWL_MAX_WAIT_MS,
+  FIRECRAWL_CRAWL_POLL_INTERVAL_MS,
+  FIRECRAWL_URL,
+} from "./config.js";
+import { fetchPage } from "./fetch.js";
+import { incCounter, recordHistogram } from "./observability.js";
+import { checkRobots, getRobotsForOrigin } from "./robots.js";
+
+export interface CrawlPage {
+  url: string;
+  title: string;
+  snippet: string;
+}
+
+export interface CrawlManifest {
+  strategy: "firecrawl" | "sitemap" | "bfs" | "error";
+  base_url: string;
+  page_count: number;
+  pages: CrawlPage[];
+  cached: boolean;
+  note?: string;
+}
+
+function crawlManifestCacheKey(
+  url: string,
+  maxPages: number,
+  sameDomainOnly: boolean,
+  includePath?: string,
+  excludePath?: string,
+): string {
+  const raw = `${url}|${maxPages}|${sameDomainOnly}|${includePath ?? ""}|${excludePath ?? ""}`;
+  return `crawl:${createHash("sha256").update(raw).digest("hex")}`;
+}
+
+function makeSnippet(text: string): string {
+  return text.replace(/\s+/g, " ").trim().slice(0, 200);
+}
+
+// ─── Phase 1: Firecrawl ──────────────────────────────────────────────────────
+
+interface FirecrawlPage {
+  markdown?: string;
+  metadata?: { title?: string; sourceURL?: string };
+}
+
+interface FirecrawlPollResponse {
+  status: string;
+  total?: number;
+  completed?: number;
+  data?: FirecrawlPage[];
+}
+
+async function pollFirecrawlJob(
+  jobId: string,
+): Promise<FirecrawlPollResponse | null> {
+  const deadline = Date.now() + FIRECRAWL_CRAWL_MAX_WAIT_MS;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, FIRECRAWL_CRAWL_POLL_INTERVAL_MS));
+    try {
+      const res = await fetch(`${FIRECRAWL_URL}/v2/crawl/${jobId}`, {
+        headers: { Authorization: `Bearer ${FIRECRAWL_API_KEY}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) return null;
+      const body = (await res.json()) as FirecrawlPollResponse;
+      if (body.status === "completed") return body;
+      if (body.status === "failed" || body.status === "cancelled") return null;
+    } catch {
+      return null;
+    }
+  }
+  return null; // timeout
+}
+
+export async function firecrawlCrawl(
+  url: string,
+  maxPages: number,
+  includePath?: string,
+  excludePath?: string,
+): Promise<CrawlManifest | null> {
+  if (!FIRECRAWL_URL) return null;
+  try {
+    const body: Record<string, unknown> = {
+      url,
+      limit: maxPages,
+      scrapeOptions: { formats: ["markdown"] },
+    };
+    if (includePath) body.includePaths = [includePath];
+    if (excludePath) body.excludePaths = [excludePath];
+
+    const startRes = await fetch(`${FIRECRAWL_URL}/v2/crawl`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${FIRECRAWL_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!startRes.ok) return null;
+    const startJson = (await startRes.json()) as {
+      success?: boolean;
+      id?: string;
+    };
+    if (!startJson.success || !startJson.id) return null;
+
+    const poll = await pollFirecrawlJob(startJson.id);
+    if (!poll?.data) return null;
+
+    const pages: CrawlPage[] = [];
+    for (const page of poll.data) {
+      const pageUrl = page.metadata?.sourceURL;
+      if (!pageUrl) continue;
+      const title = page.metadata?.title ?? pageUrl;
+      const text = page.markdown ?? "";
+      const snippet = makeSnippet(text);
+
+      // Cache full content under fetch: key
+      const fetchKey = fetchCacheKey(pageUrl);
+      await cacheSet(
+        fetchKey,
+        JSON.stringify({ title, url: pageUrl, text }),
+        FETCH_CACHE_TTL_SECONDS,
+      );
+      pages.push({ url: pageUrl, title, snippet });
+    }
+
+    return {
+      strategy: "firecrawl",
+      base_url: url,
+      page_count: pages.length,
+      pages,
+      cached: false,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Phase 2: Sitemap-first ──────────────────────────────────────────────────
+
+const xmlParser = new XMLParser({
+  ignoreAttributes: false,
+  isArray: (name) => ["url", "sitemap"].includes(name),
+});
+
+export function extractSitemapUrls(xml: string): string[] {
+  try {
+    const result = xmlParser.parse(xml) as Record<string, unknown>;
+    const urlset = result.urlset as
+      | { url?: Array<{ loc?: unknown }> }
+      | undefined;
+    if (urlset?.url) {
+      return urlset.url
+        .map((u) => String(u.loc ?? ""))
+        .filter((loc) => loc.startsWith("http"));
+    }
+    const idx = result.sitemapindex as
+      | { sitemap?: Array<{ loc?: unknown }> }
+      | undefined;
+    if (idx?.sitemap) {
+      return idx.sitemap
+        .map((s) => String(s.loc ?? ""))
+        .filter((loc) => loc.startsWith("http"));
+    }
+  } catch {
+    // malformed XML — return empty
+  }
+  return [];
+}
+
+async function fetchSitemapXml(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: { "User-Agent": "searxng-mcp" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
+export async function discoverSitemapUrls(
+  origin: string,
+  maxDepth = 3,
+): Promise<string[]> {
+  const candidates: string[] = [];
+  const allUrls = new Set<string>();
+
+  // Try robots.txt Sitemap: directives first
+  try {
+    const robots = await getRobotsForOrigin(origin);
+    if (robots.body) {
+      const sitemapLines = robots.body
+        .split("\n")
+        .filter((l) => l.toLowerCase().startsWith("sitemap:"))
+        .map((l) => l.split(":").slice(1).join(":").trim());
+      candidates.push(...sitemapLines);
+    }
+  } catch {
+    // continue
+  }
+
+  // Well-known paths as fallback
+  candidates.push(`${origin}/sitemap.xml`, `${origin}/sitemap_index.xml`);
+
+  async function processSitemap(url: string, depth: number): Promise<void> {
+    if (depth > maxDepth) return;
+    const xml = await fetchSitemapXml(url);
+    if (!xml) return;
+    const locs = extractSitemapUrls(xml);
+    for (const loc of locs) {
+      if (loc.endsWith(".xml")) {
+        // Child sitemap — recurse
+        if (!allUrls.has(loc)) {
+          allUrls.add(loc);
+          await processSitemap(loc, depth + 1);
+        }
+      } else {
+        allUrls.add(loc);
+      }
+    }
+  }
+
+  for (const candidate of candidates) {
+    if (!allUrls.has(candidate)) {
+      await processSitemap(candidate, 0);
+      if (allUrls.size > 0) break; // first hit wins
+    }
+  }
+
+  return Array.from(allUrls).filter((u) => !u.endsWith(".xml"));
+}
+
+async function batchFetch(
+  urls: string[],
+  maxPages: number,
+  concurrency = 5,
+): Promise<CrawlPage[]> {
+  const sliced = urls.slice(0, maxPages);
+  const pages: CrawlPage[] = [];
+
+  for (let i = 0; i < sliced.length; i += concurrency) {
+    const chunk = sliced.slice(i, i + concurrency);
+    const results = await Promise.allSettled(
+      chunk.map(async (url) => {
+        const robots = await checkRobots(url, "searxng-mcp");
+        if (!robots.allowed) return null;
+        const { title, text } = await fetchPage(url, 8000);
+        const snippet = makeSnippet(text);
+        return { url, title, snippet };
+      }),
+    );
+    for (const r of results) {
+      if (r.status === "fulfilled" && r.value) pages.push(r.value);
+    }
+  }
+  return pages;
+}
+
+export async function sitemapCrawl(
+  url: string,
+  maxPages: number,
+  includePath?: string,
+  excludePath?: string,
+): Promise<CrawlManifest | null> {
+  try {
+    const origin = new URL(url).origin;
+    let urls = await discoverSitemapUrls(origin);
+    if (urls.length === 0) return null;
+
+    if (includePath) urls = urls.filter((u) => u.includes(includePath));
+    if (excludePath) urls = urls.filter((u) => !u.includes(excludePath));
+    if (urls.length === 0) return null;
+
+    const pages = await batchFetch(urls, maxPages);
+    return {
+      strategy: "sitemap",
+      base_url: url,
+      page_count: pages.length,
+      pages,
+      cached: false,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Phase 3: BFS ────────────────────────────────────────────────────────────
+
+export async function bfsCrawl(
+  startUrl: string,
+  maxPages: number,
+  maxDepth: number,
+  sameDomainOnly: boolean,
+  includePath?: string,
+  excludePath?: string,
+): Promise<CrawlManifest> {
+  const startHost = new URL(startUrl).hostname;
+  const visited = new Set<string>();
+  const queue: Array<{ url: string; depth: number }> = [
+    { url: startUrl, depth: 0 },
+  ];
+  const pages: CrawlPage[] = [];
+
+  while (queue.length > 0 && visited.size < maxPages) {
+    const item = queue.shift();
+    if (!item) break;
+    const normalizedUrl = item.url.split("#")[0]; // strip fragment
+    if (visited.has(normalizedUrl)) continue;
+    if (item.depth > maxDepth) continue;
+
+    const robots = await checkRobots(normalizedUrl, "searxng-mcp");
+    if (!robots.allowed) continue;
+
+    visited.add(normalizedUrl);
+
+    let fetchedTitle = normalizedUrl;
+    let fetchedText = "";
+    let rawHtml = "";
+
+    try {
+      const result = await fetchPage(normalizedUrl, 8000);
+      fetchedTitle = result.title;
+      fetchedText = result.text;
+
+      // Extract links from the raw response — re-fetch with raw tier for link
+      // extraction. fetchPage already cached the content; we need HTML for links.
+      const rawRes = await fetch(normalizedUrl, {
+        headers: { "User-Agent": "searxng-mcp" },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (rawRes.ok) rawHtml = await rawRes.text();
+    } catch {
+      continue;
+    }
+
+    pages.push({
+      url: normalizedUrl,
+      title: fetchedTitle,
+      snippet: makeSnippet(fetchedText),
+    });
+
+    // Extract links via JSDOM (already a dep)
+    if (rawHtml && item.depth < maxDepth) {
+      try {
+        const { JSDOM } = await import("jsdom");
+        const dom = new JSDOM(rawHtml, { url: normalizedUrl });
+        const anchors = dom.window.document.querySelectorAll("a[href]");
+        for (const anchor of anchors) {
+          const href = (anchor as HTMLAnchorElement).href;
+          if (!href.startsWith("http")) continue;
+          const normalized = href.split("#")[0];
+          if (visited.has(normalized)) continue;
+
+          const parsed = new URL(normalized);
+          if (sameDomainOnly && parsed.hostname !== startHost) continue;
+          if (includePath && !parsed.pathname.includes(includePath)) continue;
+          if (excludePath && parsed.pathname.includes(excludePath)) continue;
+
+          queue.push({ url: normalized, depth: item.depth + 1 });
+        }
+      } catch {
+        // JSDOM unavailable or parse error — skip link extraction
+      }
+    }
+  }
+
+  return {
+    strategy: "bfs",
+    base_url: startUrl,
+    page_count: pages.length,
+    pages,
+    cached: false,
+    note: `BFS depth limited to ${maxDepth}`,
+  };
+}
+
+// ─── Strategy cascade ────────────────────────────────────────────────────────
+
+export async function crawlSite(
+  url: string,
+  maxPages: number,
+  sameDomainOnly: boolean,
+  includePath?: string,
+  excludePath?: string,
+): Promise<CrawlManifest> {
+  const t0 = Date.now();
+  const cacheKey = crawlManifestCacheKey(
+    url,
+    maxPages,
+    sameDomainOnly,
+    includePath,
+    excludePath,
+  );
+
+  // Check manifest cache
+  const cached = await cacheGet(cacheKey);
+  if (cached) {
+    try {
+      const manifest = JSON.parse(cached) as CrawlManifest;
+      incCounter("crawl", {
+        strategy: manifest.strategy,
+        outcome: "manifest_hit",
+      });
+      return { ...manifest, cached: true };
+    } catch {
+      // corrupt cache — fall through
+    }
+  }
+
+  let manifest: CrawlManifest | null = null;
+
+  // Phase 1: Firecrawl
+  if (FIRECRAWL_URL) {
+    manifest = await firecrawlCrawl(url, maxPages, includePath, excludePath);
+    if (manifest) {
+      incCounter("crawl", { strategy: "firecrawl", outcome: "success" });
+    }
+  }
+
+  // Phase 2: Sitemap
+  if (!manifest) {
+    manifest = await sitemapCrawl(url, maxPages, includePath, excludePath);
+    if (manifest) {
+      incCounter("crawl", { strategy: "sitemap", outcome: "fallback_sitemap" });
+    }
+  }
+
+  // Phase 3: BFS (opt-in)
+  if (!manifest && CRAWL_BFS_ENABLED) {
+    manifest = await bfsCrawl(
+      url,
+      maxPages,
+      CRAWL_BFS_MAX_DEPTH,
+      sameDomainOnly,
+      includePath,
+      excludePath,
+    );
+    if (manifest) {
+      incCounter("crawl", { strategy: "bfs", outcome: "fallback_bfs" });
+    }
+  }
+
+  if (!manifest) {
+    incCounter("crawl", { strategy: "none", outcome: "error" });
+    return {
+      strategy: "error",
+      base_url: url,
+      page_count: 0,
+      pages: [],
+      cached: false,
+      note: "All crawl strategies failed. No sitemap found and BFS is disabled.",
+    };
+  }
+
+  // Cache the manifest
+  await cacheSet(
+    cacheKey,
+    JSON.stringify(manifest),
+    CRAWL_MANIFEST_TTL_SECONDS,
+  );
+
+  const durationSeconds = (Date.now() - t0) / 1000;
+  recordHistogram("crawl", durationSeconds, { strategy: manifest.strategy });
+
+  return manifest;
+}
+
+// ─── Format output ───────────────────────────────────────────────────────────
+
+export function formatCrawlManifest(manifest: CrawlManifest): string {
+  if (manifest.strategy === "error") {
+    return `Crawl failed: ${manifest.note ?? "Unknown error"}`;
+  }
+
+  const header = `Strategy: ${manifest.strategy} | base: ${manifest.base_url} | ${manifest.page_count} pages${manifest.cached ? " (cached)" : ""}`;
+  const note = manifest.note ? `\n${manifest.note}` : "";
+
+  if (manifest.pages.length === 0) {
+    return `${header}${note}\n\nNo pages found.`;
+  }
+
+  const tableHeader = `\n\n| # | URL | Title | Snippet |\n|---|-----|-------|---------|\n`;
+  const rows = manifest.pages
+    .map(
+      (p, i) =>
+        `| ${i + 1} | ${p.url} | ${p.title.replace(/\|/g, "\\|")} | ${p.snippet.replace(/\|/g, "\\|")} |`,
+    )
+    .join("\n");
+
+  const footer =
+    "\n\nFull content cached. Use fetch_url on any URL above for complete text.";
+
+  return `${header}${note}${tableHeader}${rows}${footer}`;
+}

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -12,6 +12,7 @@ import {
   FIRECRAWL_URL,
 } from "./config.js";
 import { assertPublicUrl, fetchPage } from "./fetch.js";
+import { readBoundedText } from "./fetch-utils.js";
 import { incCounter, recordHistogram } from "./observability.js";
 import { checkRobots, getRobotsForOrigin } from "./robots.js";
 
@@ -112,6 +113,8 @@ export async function firecrawlCrawl(
       id?: string;
     };
     if (!startJson.success || !startJson.id) return null;
+    // Validate job ID before interpolating into URL path (F-03)
+    if (!/^[a-zA-Z0-9_-]{1,128}$/.test(startJson.id)) return null;
 
     const poll = await pollFirecrawlJob(startJson.id);
     if (!poll?.data) return null;
@@ -186,7 +189,7 @@ async function fetchSitemapXml(url: string): Promise<string | null> {
       signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) return null;
-    return await res.text();
+    return await readBoundedText(res); // bounded read — prevents oversized sitemap DoS (F-02)
   } catch {
     return null;
   }
@@ -342,7 +345,7 @@ export async function bfsCrawl(
         headers: { "User-Agent": "searxng-mcp" },
         signal: AbortSignal.timeout(10_000),
       });
-      if (rawRes.ok) rawHtml = await rawRes.text();
+      if (rawRes.ok) rawHtml = await readBoundedText(rawRes); // bounded read — prevents oversized HTML DoS (F-02)
     } catch {
       continue;
     }
@@ -397,6 +400,7 @@ export async function crawlSite(
   includePath?: string,
   excludePath?: string,
 ): Promise<CrawlManifest> {
+  assertPublicUrl(url); // SSRF guard — validate before any strategy dispatch (F-01)
   const t0 = Date.now();
   const cacheKey = crawlManifestCacheKey(
     url,
@@ -410,6 +414,9 @@ export async function crawlSite(
   const cached = await cacheGet(cacheKey);
   if (cached) {
     try {
+      // SECURITY[accepted]: JSON.parse without schema validation. Cache is written only by
+      // crawlSite itself from trusted crawl results. Corrupt entries fall through to a live
+      // crawl via the catch block. Auditor confirmed no action required. Audit: 2026-06-05/searxng-mcp-crawl-2026-06.
       const manifest = JSON.parse(cached) as CrawlManifest;
       incCounter("crawl", {
         strategy: manifest.strategy,
@@ -497,7 +504,7 @@ export function formatCrawlManifest(manifest: CrawlManifest): string {
   const rows = manifest.pages
     .map(
       (p, i) =>
-        `| ${i + 1} | ${p.url} | ${p.title.replace(/\|/g, "\\|")} | ${p.snippet.replace(/\|/g, "\\|")} |`,
+        `| ${i + 1} | ${p.url.replace(/\|/g, "\\|")} | ${p.title.replace(/\|/g, "\\|")} | ${p.snippet.replace(/\|/g, "\\|")} |`,
     )
     .join("\n");
 

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -11,7 +11,7 @@ import {
   FIRECRAWL_CRAWL_POLL_INTERVAL_MS,
   FIRECRAWL_URL,
 } from "./config.js";
-import { fetchPage } from "./fetch.js";
+import { assertPublicUrl, fetchPage } from "./fetch.js";
 import { incCounter, recordHistogram } from "./observability.js";
 import { checkRobots, getRobotsForOrigin } from "./robots.js";
 
@@ -180,6 +180,7 @@ export function extractSitemapUrls(xml: string): string[] {
 
 async function fetchSitemapXml(url: string): Promise<string | null> {
   try {
+    assertPublicUrl(url); // SSRF guard — sitemap URLs can come from untrusted robots.txt
     const res = await fetch(url, {
       headers: { "User-Agent": "searxng-mcp" },
       signal: AbortSignal.timeout(10_000),

--- a/src/events.ts
+++ b/src/events.ts
@@ -135,6 +135,22 @@ export const events = {
   cacheMiss(p: { key_type: string; namespace: string }): void {
     publishEvent("cache.miss", p);
   },
+  crawlRequested(p: {
+    url: string;
+    max_pages: number;
+    same_domain_only: boolean;
+  }): void {
+    publishEvent("crawl.requested", p);
+  },
+  crawlCompleted(p: {
+    url: string;
+    strategy: string;
+    page_count: number;
+    latency_ms: number;
+    cached: boolean;
+  }): void {
+    publishEvent("crawl.completed", p);
+  },
   error(p: {
     stage: string;
     url?: string;

--- a/src/fetch-utils.ts
+++ b/src/fetch-utils.ts
@@ -41,6 +41,8 @@ export function assertPublicUrl(url: string): void {
     /^::1$/,
     /^0:0:0:0:0:0:0:1$/,
     /^fd[0-9a-f]{2}:/i,
+    /^169\.254\./, // RFC 3927 link-local / AWS IMDS (F-04)
+    /^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\./, // RFC 6598 CGNAT (F-04)
   ];
   if (blocked.some((r) => r.test(hostname))) {
     throw new Error(`Internal/private addresses are not allowed`);

--- a/src/robots.ts
+++ b/src/robots.ts
@@ -65,7 +65,9 @@ async function fetchRobotsTxt(origin: string): Promise<CachedRobots> {
   }
 }
 
-async function getRobotsForOrigin(origin: string): Promise<CachedRobots> {
+export async function getRobotsForOrigin(
+  origin: string,
+): Promise<CachedRobots> {
   const key = robotsCacheKey(origin);
   const cached = await cacheGet(key);
   if (cached) {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { cacheClear } from "./cache.js";
 import { newRequestId, withRequestId } from "./context.js";
+import { crawlSite, formatCrawlManifest } from "./crawl.js";
 import { events } from "./events.js";
 import { fetchPage } from "./fetch.js";
 import { incCounter, recordHistogram, withSpan } from "./observability.js";
@@ -338,6 +339,47 @@ export async function handleFetchUrl({
   });
 }
 
+export async function handleCrawlSite({
+  url,
+  max_pages,
+  same_domain_only,
+  include_path,
+  exclude_path,
+}: {
+  url: string;
+  max_pages: number;
+  same_domain_only: boolean;
+  include_path?: string;
+  exclude_path?: string;
+}) {
+  return instrumentTool("crawl_site", async () => {
+    const t0 = Date.now();
+    events.crawlRequested({ url, max_pages, same_domain_only });
+    const manifest = await crawlSite(
+      url,
+      max_pages,
+      same_domain_only,
+      include_path,
+      exclude_path,
+    );
+    const latency_ms = Date.now() - t0;
+    events.crawlCompleted({
+      url,
+      strategy: manifest.strategy,
+      page_count: manifest.page_count,
+      latency_ms,
+      cached: manifest.cached,
+    });
+    incCounter("crawl", {
+      outcome: manifest.strategy === "error" ? "error" : "success",
+    });
+    recordHistogram("tool.crawl_site", latency_ms / 1000, {});
+    return {
+      content: [{ type: "text" as const, text: formatCrawlManifest(manifest) }],
+    };
+  });
+}
+
 export async function handleClearCache({ target }: { target: string }) {
   return instrumentTool("clear_cache", async () => {
     let cleared = 0;
@@ -346,6 +388,9 @@ export async function handleClearCache({ target }: { target: string }) {
     }
     if (target === "fetch" || target === "all") {
       cleared += await cacheClear("fetch:*");
+    }
+    if (target === "crawl" || target === "all") {
+      cleared += await cacheClear("crawl:*");
     }
     return {
       content: [
@@ -466,14 +511,43 @@ export function registerTools(server: McpServer): void {
   );
 
   server.tool(
+    "crawl_site",
+    "Crawl a site and return a manifest of pages with titles and snippets. " +
+      "Full page content is cached — call fetch_url on any page URL for the full text. " +
+      "Strategy: Firecrawl (JS rendering) → sitemap-first → BFS (if enabled).",
+    {
+      url: z.string().url().describe("Base URL to crawl"),
+      max_pages: z.coerce
+        .number()
+        .min(1)
+        .max(100)
+        .default(20)
+        .describe("Maximum pages to crawl (default 20, max 100)"),
+      same_domain_only: z.coerce
+        .boolean()
+        .default(true)
+        .describe("Restrict crawl to the same domain (default true)"),
+      include_path: z
+        .string()
+        .optional()
+        .describe("Only include URLs matching this path prefix (e.g. '/docs')"),
+      exclude_path: z
+        .string()
+        .optional()
+        .describe("Exclude URLs matching this path prefix (e.g. '/blog')"),
+    },
+    handleCrawlSite,
+  );
+
+  server.tool(
     "clear_cache",
     "Purge the search and/or fetch result cache. Useful when researching fast-moving topics where cached results from the past hour may be stale.",
     {
       target: z
-        .enum(["search", "fetch", "all"])
+        .enum(["search", "fetch", "crawl", "all"])
         .default("all")
         .describe(
-          "Which cache to clear: search results, fetched pages, or all (default all)",
+          "Which cache to clear: search results, fetched pages, crawl manifests, or all (default all)",
         ),
     },
     handleClearCache,

--- a/tests/crawl.test.ts
+++ b/tests/crawl.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/cache.js", () => ({
+  cacheGet: vi.fn(),
+  cacheSet: vi.fn(),
+  cacheClear: vi.fn(),
+  fetchCacheKey: vi
+    .fn()
+    .mockImplementation(
+      (url: string) => `fetch:${Buffer.from(url).toString("hex")}`,
+    ),
+}));
+
+vi.mock("../src/robots.js", () => ({
+  checkRobots: vi.fn().mockResolvedValue({ allowed: true }),
+  getRobotsForOrigin: vi.fn().mockResolvedValue({ body: null, fetched: "" }),
+}));
+
+vi.mock("../src/fetch.js", () => ({
+  fetchPage: vi.fn(),
+  assertPublicUrl: vi.fn(),
+}));
+
+vi.mock("../src/observability.js", () => ({
+  incCounter: vi.fn(),
+  recordHistogram: vi.fn(),
+  withSpan: vi.fn((_name: string, _attrs: unknown, fn: () => unknown) => fn()),
+}));
+
+vi.mock("../src/config.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../src/config.js")>(
+      "../src/config.js",
+    );
+  return {
+    ...actual,
+    FIRECRAWL_URL: "http://localhost:3002",
+    FIRECRAWL_API_KEY: "test-key",
+    CRAWL_BFS_ENABLED: false,
+    CRAWL_BFS_MAX_DEPTH: 2,
+    FIRECRAWL_CRAWL_POLL_INTERVAL_MS: 50,
+    FIRECRAWL_CRAWL_MAX_WAIT_MS: 500,
+    CRAWL_MANIFEST_TTL_SECONDS: 21600,
+    FETCH_CACHE_TTL_SECONDS: 86400,
+  };
+});
+
+import { cacheClear, cacheGet, cacheSet } from "../src/cache.js";
+import type { CrawlManifest } from "../src/crawl.js";
+import {
+  bfsCrawl,
+  crawlSite,
+  extractSitemapUrls,
+  sitemapCrawl,
+} from "../src/crawl.js";
+import { fetchPage } from "../src/fetch.js";
+import { checkRobots, getRobotsForOrigin } from "../src/robots.js";
+
+const cacheGetMock = vi.mocked(cacheGet);
+const cacheSetMock = vi.mocked(cacheSet);
+const cacheClearMock = vi.mocked(cacheClear);
+const checkRobotsMock = vi.mocked(checkRobots);
+const getRobotsForOriginMock = vi.mocked(getRobotsForOrigin);
+const fetchPageMock = vi.mocked(fetchPage);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  cacheGetMock.mockResolvedValue(null);
+  cacheSetMock.mockResolvedValue(undefined);
+  checkRobotsMock.mockResolvedValue({ allowed: true });
+  getRobotsForOriginMock.mockResolvedValue({ body: null, fetched: "" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── 1. Sitemap parser ───────────────────────────────────────────────────────
+
+describe("extractSitemapUrls", () => {
+  it("parses valid sitemap.xml", () => {
+    const xml = `<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/page1</loc></url>
+  <url><loc>https://example.com/page2</loc></url>
+</urlset>`;
+    const urls = extractSitemapUrls(xml);
+    expect(urls).toContain("https://example.com/page1");
+    expect(urls).toContain("https://example.com/page2");
+  });
+
+  it("parses sitemap_index.xml and returns child sitemap locs", () => {
+    const xml = `<?xml version="1.0"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/sitemap1.xml</loc></sitemap>
+  <sitemap><loc>https://example.com/sitemap2.xml</loc></sitemap>
+</sitemapindex>`;
+    const locs = extractSitemapUrls(xml);
+    expect(locs).toContain("https://example.com/sitemap1.xml");
+    expect(locs).toContain("https://example.com/sitemap2.xml");
+  });
+
+  it("strips non-http locs", () => {
+    const xml = `<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/page</loc></url>
+  <url><loc>ftp://example.com/file</loc></url>
+  <url><loc></loc></url>
+</urlset>`;
+    const urls = extractSitemapUrls(xml);
+    expect(urls).toEqual(["https://example.com/page"]);
+  });
+
+  it("returns empty array for malformed XML", () => {
+    const urls = extractSitemapUrls("<not valid xml {{");
+    expect(urls).toEqual([]);
+  });
+
+  it("handles single URL (not wrapped in array by fast-xml-parser by default)", () => {
+    const xml = `<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/only</loc></url>
+</urlset>`;
+    const urls = extractSitemapUrls(xml);
+    expect(urls).toEqual(["https://example.com/only"]);
+  });
+});
+
+// ─── 2. BFS deduplication ────────────────────────────────────────────────────
+
+describe("bfsCrawl deduplication", () => {
+  it("visits each URL only once even if linked from multiple pages", async () => {
+    let callCount = 0;
+    fetchPageMock.mockImplementation(async (url: string) => {
+      callCount++;
+      return { title: `Page ${callCount}`, url, text: "content" };
+    });
+
+    vi.spyOn(global, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const _url = typeof input === "string" ? input : input.toString();
+        // All pages link to /target — creates duplicate enqueue attempts
+        const html = `<html><body><a href="https://example.com/target">link</a><a href="https://example.com/target">dup</a></body></html>`;
+        return new Response(html, { status: 200 });
+      },
+    );
+
+    const manifest = await bfsCrawl("https://example.com/", 10, 2, true);
+
+    // /target should appear at most once
+    const urls = manifest.pages.map((p) => p.url);
+    const unique = new Set(urls);
+    expect(urls.length).toBe(unique.size);
+  });
+});
+
+// ─── 3. same_domain_only filter ─────────────────────────────────────────────
+
+describe("bfsCrawl same_domain_only", () => {
+  it("does not enqueue off-domain links when same_domain_only=true", async () => {
+    fetchPageMock.mockResolvedValue({
+      title: "Home",
+      url: "https://example.com/",
+      text: "home content",
+    });
+
+    vi.spyOn(global, "fetch").mockImplementation(async () => {
+      const html = `<html><body>
+        <a href="https://example.com/internal">internal</a>
+        <a href="https://other.com/external">external</a>
+      </body></html>`;
+      return new Response(html, { status: 200 });
+    });
+
+    const manifest = await bfsCrawl("https://example.com/", 5, 2, true);
+    const hosts = manifest.pages.map((p) => new URL(p.url).hostname);
+    for (const host of hosts) {
+      expect(host).toBe("example.com");
+    }
+  });
+});
+
+// ─── 4. max_pages cap ────────────────────────────────────────────────────────
+
+describe("sitemapCrawl max_pages", () => {
+  it("never fetches more than max_pages regardless of sitemap size", async () => {
+    // Mock discoverSitemapUrls indirectly via fetch
+    vi.spyOn(global, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.endsWith("robots.txt"))
+          return new Response("", { status: 404 });
+        if (url.endsWith("sitemap.xml")) {
+          const locs = Array.from(
+            { length: 50 },
+            (_, i) => `<url><loc>https://example.com/page${i}</loc></url>`,
+          ).join("\n");
+          return new Response(
+            `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${locs}</urlset>`,
+            { status: 200, headers: { "Content-Type": "text/xml" } },
+          );
+        }
+        return new Response("", { status: 404 });
+      },
+    );
+
+    fetchPageMock.mockImplementation(async (url: string) => ({
+      title: "Page",
+      url,
+      text: "content",
+    }));
+
+    const manifest = await sitemapCrawl("https://example.com/", 5);
+    expect(manifest).not.toBeNull();
+    expect(manifest?.page_count).toBeLessThanOrEqual(5);
+  });
+});
+
+// ─── 5. Manifest cache hit ───────────────────────────────────────────────────
+
+describe("crawlSite manifest cache", () => {
+  it("returns cached manifest with cached=true on second call", async () => {
+    const stored: CrawlManifest = {
+      strategy: "sitemap",
+      base_url: "https://example.com/",
+      page_count: 2,
+      pages: [
+        { url: "https://example.com/a", title: "A", snippet: "snippet a" },
+        { url: "https://example.com/b", title: "B", snippet: "snippet b" },
+      ],
+      cached: false,
+    };
+    cacheGetMock.mockResolvedValue(JSON.stringify(stored));
+
+    const manifest = await crawlSite("https://example.com/", 20, true);
+
+    expect(manifest.cached).toBe(true);
+    expect(manifest.strategy).toBe("sitemap");
+    expect(manifest.page_count).toBe(2);
+    // Should not have called cacheSet (returned from cache)
+    expect(cacheSetMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─── 6. clear_cache "crawl" ──────────────────────────────────────────────────
+
+import { handleClearCache } from "../src/tools.js";
+
+describe("handleClearCache crawl target", () => {
+  it("calls cacheClear with crawl:* pattern for target='crawl'", async () => {
+    cacheClearMock.mockResolvedValue(3);
+    await handleClearCache({ target: "crawl" });
+    expect(cacheClearMock).toHaveBeenCalledWith("crawl:*");
+    expect(cacheClearMock).not.toHaveBeenCalledWith("search:*");
+    expect(cacheClearMock).not.toHaveBeenCalledWith("fetch:*");
+  });
+
+  it("clears crawl:* keys when target='all'", async () => {
+    cacheClearMock.mockResolvedValue(1);
+    await handleClearCache({ target: "all" });
+    const patterns = cacheClearMock.mock.calls.map((c) => c[0]);
+    expect(patterns).toContain("crawl:*");
+    expect(patterns).toContain("search:*");
+    expect(patterns).toContain("fetch:*");
+  });
+});
+
+// ─── 7. Robots.txt respect ───────────────────────────────────────────────────
+
+describe("robots.txt respect", () => {
+  it("skips disallowed URLs during batch fetch in sitemapCrawl", async () => {
+    vi.spyOn(global, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.endsWith("robots.txt"))
+          return new Response("", { status: 404 });
+        if (url.endsWith("sitemap.xml")) {
+          return new Response(
+            `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url><loc>https://example.com/allowed</loc></url>
+            <url><loc>https://example.com/blocked</loc></url>
+          </urlset>`,
+            { status: 200 },
+          );
+        }
+        return new Response("", { status: 404 });
+      },
+    );
+
+    checkRobotsMock.mockImplementation(async (url: string) => {
+      if (url.includes("blocked"))
+        return { allowed: false, reason: "disallowed" as const };
+      return { allowed: true };
+    });
+
+    fetchPageMock.mockResolvedValue({
+      title: "Allowed",
+      url: "https://example.com/allowed",
+      text: "allowed content",
+    });
+
+    const manifest = await sitemapCrawl("https://example.com/", 10);
+    expect(manifest).not.toBeNull();
+    const urls = manifest?.pages.map((p) => p.url);
+    expect(urls).not.toContain("https://example.com/blocked");
+    expect(urls).toContain("https://example.com/allowed");
+  });
+});

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -200,7 +200,8 @@ describe("handleClearCache", () => {
     const result = await handleClearCache({ target: "all" });
     expect(cacheClear).toHaveBeenCalledWith("search:*");
     expect(cacheClear).toHaveBeenCalledWith("fetch:*");
-    expect(result.content[0].text).toContain("10 cache entries");
+    expect(cacheClear).toHaveBeenCalledWith("crawl:*");
+    expect(result.content[0].text).toContain("15 cache entries");
   });
 
   it("clears only search cache when target is search", async () => {


### PR DESCRIPTION
## Summary

- New `crawl_site` MCP tool: takes a base URL, crawls the site, returns a manifest (URL + title + 200-char snippet per page)
- Full page content written to the existing Valkey fetch cache — follow-up `fetch_url` calls hit the cache at 100%, no second crawl needed
- Three-phase strategy cascade: Firecrawl `/v2/crawl` (JS rendering, async poll) → sitemap-first (robots.txt `Sitemap:` + `/sitemap.xml` + `/sitemap_index.xml`) → BFS via JSDOM (opt-in, `CRAWL_BFS_ENABLED=true`)
- Manifest cached under `crawl:` keys (`CRAWL_MANIFEST_TTL_SECONDS`, default 6h)
- `clear_cache "crawl"` purges crawl manifests; `"all"` now includes crawl keys
- New dep: `fast-xml-parser` (pure JS, no native bindings)
- 6 new env vars with safe defaults — no behavior change for existing deployments

## Test plan

- [ ] `pnpm test` — 249/249 pass
- [ ] `pnpm lint` — clean
- [ ] `pnpm build` — clean
- [ ] `crawl_site` on a site with sitemap returns manifest with ≤ max_pages entries
- [ ] Second call with same args returns `cached: true`
- [ ] `fetch_url` on any manifest URL returns cached content
- [ ] `clear_cache "crawl"` purges only `crawl:*` keys
- [ ] `clear_cache "all"` purges search, fetch, and crawl keys

🤖 Co-authored with Claude Sonnet 4.6