### PR TITLE
fix(summarize): tolerate citations missing key_facts

### DIFF
--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -105,10 +105,37 @@ export async function summarizePages(
     const raw = (data.message.content.match(/\{[\s\S]*\}/) ?? [
       data.message.content,
     ])[0];
-    const parsed = JSON.parse(raw) as SummaryResult;
+    // The model controls this JSON, so treat it as untrusted and normalize
+    // each citation to the Citation contract here — the trust boundary. A
+    // model may return a citation without `key_facts` (or url/title), which
+    // previously reached formatSummaryResult and crashed it on
+    // `c.key_facts.map(...)`.
+    const parsed = JSON.parse(raw) as {
+      summary?: unknown;
+      citations?: unknown;
+    };
+    const citations: Citation[] = Array.isArray(parsed.citations)
+      ? parsed.citations.map((c): Citation => {
+          const entry = (c ?? {}) as {
+            url?: unknown;
+            title?: unknown;
+            key_facts?: unknown;
+          };
+          const url = typeof entry.url === "string" ? entry.url : "";
+          return {
+            url,
+            title: typeof entry.title === "string" ? entry.title : url,
+            key_facts: Array.isArray(entry.key_facts)
+              ? entry.key_facts.filter(
+                  (f): f is string => typeof f === "string",
+                )
+              : [],
+          };
+        })
+      : [];
     return {
-      summary: parsed.summary ?? "",
-      citations: Array.isArray(parsed.citations) ? parsed.citations : [],
+      summary: typeof parsed.summary === "string" ? parsed.summary : "",
+      citations,
     };
   } catch {
     // Ollama unavailable, timeout, or parse error — return null to signal fallback
@@ -118,9 +145,11 @@ export async function summarizePages(
 
 export function formatSummaryResult(result: SummaryResult): string {
   if (!result.summary) return "";
-  const citationText = result.citations
+  const citationText = (result.citations ?? [])
     .map((c: Citation) => {
-      const facts = c.key_facts.map((f) => `     - ${f}`).join("\n");
+      const facts = (Array.isArray(c.key_facts) ? c.key_facts : [])
+        .map((f) => `     - ${f}`)
+        .join("\n");
       return `  - ${c.title}\n    URL: ${c.url}\n${facts}`;
     })
     .join("\n\n");

--- a/tests/ollama.test.ts
+++ b/tests/ollama.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Citation } from "../src/types.js";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -141,5 +142,80 @@ describe("summarizePages", () => {
       { title: "T", url: "https://example.com", text: "t" },
     ]);
     expect(result).toEqual({ summary: "", citations: [] });
+  });
+
+  it("normalizes a citation missing key_facts to an empty array", async () => {
+    // Regression: a model may omit key_facts. Previously this survived
+    // summarizePages and later crashed formatSummaryResult on
+    // `c.key_facts.map(...)`.
+    process.env.OLLAMA_URL = "http://ollama:11434";
+    const { summarizePages } = await import("../src/ollama.js");
+    const payload = {
+      summary: "answer",
+      citations: [{ url: "https://example.com", title: "Example" }],
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({ message: { content: JSON.stringify(payload) } }),
+    });
+    const result = await summarizePages("query", [
+      { title: "Example", url: "https://example.com", text: "t" },
+    ]);
+    expect(result.citations).toHaveLength(1);
+    expect(result.citations[0].key_facts).toEqual([]);
+  });
+
+  it("drops non-string key_facts entries", async () => {
+    process.env.OLLAMA_URL = "http://ollama:11434";
+    const { summarizePages } = await import("../src/ollama.js");
+    const payload = {
+      summary: "answer",
+      citations: [
+        { url: "https://x.com", title: "X", key_facts: ["ok", 42, null] },
+      ],
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({ message: { content: JSON.stringify(payload) } }),
+    });
+    const result = await summarizePages("query", [
+      { title: "X", url: "https://x.com", text: "t" },
+    ]);
+    expect(result.citations[0].key_facts).toEqual(["ok"]);
+  });
+});
+
+describe("formatSummaryResult", () => {
+  it("returns empty string when summary is empty", async () => {
+    const { formatSummaryResult } = await import("../src/ollama.js");
+    expect(formatSummaryResult({ summary: "", citations: [] })).toBe("");
+  });
+
+  it("does not throw when a citation is missing key_facts", async () => {
+    // Defensive: the exported formatter must tolerate malformed citations
+    // even if a caller bypasses summarizePages' normalization.
+    const { formatSummaryResult } = await import("../src/ollama.js");
+    const out = formatSummaryResult({
+      summary: "answer",
+      citations: [
+        { url: "https://example.com", title: "Example" } as unknown as Citation,
+      ],
+    });
+    expect(out).toContain("answer");
+    expect(out).toContain("https://example.com");
+  });
+
+  it("renders key_facts as bulleted lines when present", async () => {
+    const { formatSummaryResult } = await import("../src/ollama.js");
+    const out = formatSummaryResult({
+      summary: "answer",
+      citations: [
+        { url: "https://x.com", title: "X", key_facts: ["f1", "f2"] },
+      ],
+    });
+    expect(out).toContain("- f1");
+    expect(out).toContain("- f2");
   });
 });


### PR DESCRIPTION
## Problem

`search_and_summarize` (any path that calls `formatSummaryResult`) throws

```
TypeError: Cannot read properties of undefined (reading 'map')
```

whenever the summarize model returns a citation object **without a `key_facts` array** — the whole tool call fails even though search + fetch succeeded.

Root cause: `summarizePages` validates that `citations` is an array but passes each element through unnormalized (`JSON.parse(raw) as SummaryResult` asserts a shape the model doesn't guarantee). A citation missing `key_facts` then reaches `formatSummaryResult`, where `c.key_facts.map(...)` throws.

This reproduces easily with smaller local summarize models (e.g. `qwen2.5:3b` via Ollama) that don't always emit every field of the requested JSON schema.

## Fix

- Treat the model-controlled JSON as untrusted and **normalize each citation to the `Citation` contract at the trust boundary** in `summarizePages`: coerce `url`/`title` to strings and `key_facts` to `string[]` (dropping non-string entries); enforce `summary` as a string.
- Add a **defensive guard** in the exported `formatSummaryResult` so it also tolerates malformed input from any caller.
- Replace the unsound `as SummaryResult` cast (which hid the missing-field case from `tsc`) with an `unknown`-typed parse plus explicit `typeof` / `Array.isArray` guards.

Output for well-formed input is unchanged.

## Tests

Adds regression coverage in `tests/ollama.test.ts` (including the first tests for `formatSummaryResult`):

- `summarizePages` normalizes a citation missing `key_facts` → `[]`
- `summarizePages` drops non-string `key_facts` entries
- `formatSummaryResult` does not throw on a citation missing `key_facts`; renders `key_facts` when present; returns `""` on empty summary

The three bug-targeting tests **fail on `main`** (they throw / return `undefined`) and pass with the fix. Full suite (254 tests), `biome` lint, and `tsc --typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
