### PR TITLE
feat(llm): OpenAI-compatible backend for expand + summarize

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,10 @@ All service URLs are configurable via environment variables.
 | `OLLAMA_API_KEY` | *(unset)* | Bearer token for authenticated Ollama proxies — adds `Authorization: Bearer <key>` header when set |
 | `OLLAMA_EXPAND_MODEL` | `qwen3:4b` | Model used by query expansion (`expand` parameter). Override without rebuilding. |
 | `OLLAMA_SUMMARIZE_MODEL` | `qwen3:14b` | Model used by `search_and_summarize`. Override without rebuilding. |
+| `LLM_BASE_URL` | *(unset)* | OpenAI-compatible chat endpoint (e.g. vLLM, llama.cpp, LM Studio) for `expand` + `search_and_summarize`. Must include the API path — e.g. `http://host:8000/v1` — the server appends `/chat/completions`. When set, takes precedence over `OLLAMA_URL`, so an already-loaded model can be reused instead of running a separate Ollama model. |
+| `LLM_MODEL` | *(unset)* | Model id for the OpenAI-compatible backend; overrides `OLLAMA_EXPAND_MODEL` / `OLLAMA_SUMMARIZE_MODEL` when set. |
+| `LLM_API_KEY` | *(unset)* | Bearer token for the OpenAI-compatible backend — adds `Authorization: Bearer <key>` when set. |
+| `LLM_DISABLE_THINKING` | `true` | Sends `chat_template_kwargs.enable_thinking: false` so reasoning models (e.g. Qwen3) return direct output. Set to `false` for servers that reject that field. |
 | `CACHE_URL` | `redis://localhost:6381` | Redis-compatible URL — enables result caching. Also accepts `VALKEY_URL` or `REDIS_URL` as aliases. Works with Redis, Valkey, and Dragonfly. Server degrades gracefully if unavailable. |
 | `CACHE_TTL_SECONDS` | `3600` | Search result cache TTL in seconds |
 | `FETCH_CACHE_TTL_SECONDS` | `86400` | Fetched page cache TTL in seconds |

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,18 @@ export const OLLAMA_EXPAND_MODEL =
   process.env.OLLAMA_EXPAND_MODEL ?? "qwen3:4b";
 export const OLLAMA_SUMMARIZE_MODEL =
   process.env.OLLAMA_SUMMARIZE_MODEL ?? "qwen3:14b";
+// OpenAI-compatible chat backend for expand + summarize (vLLM, llama.cpp, LM
+// Studio, etc.). When LLM_BASE_URL is set it takes precedence over the Ollama
+// endpoint, so an already-loaded chat model can be reused instead of running a
+// separate Ollama model. LLM_MODEL overrides the per-capability model names.
+// LLM_DISABLE_THINKING (default on) sends `chat_template_kwargs.enable_thinking:
+// false` so reasoning models (e.g. Qwen3) return direct output; set it to
+// "false" for servers that reject that field.
+export const LLM_BASE_URL = (process.env.LLM_BASE_URL ?? "").replace(/\/$/, "");
+export const LLM_MODEL = process.env.LLM_MODEL ?? "";
+export const LLM_API_KEY = process.env.LLM_API_KEY ?? "";
+export const LLM_DISABLE_THINKING =
+  process.env.LLM_DISABLE_THINKING !== "false";
 export const EXPAND_QUERIES_DEFAULT = process.env.EXPAND_QUERIES === "true";
 export const KIWIX_URL = process.env.KIWIX_URL?.replace(/\/$/, "") ?? "";
 export const HISTER_URL = process.env.HISTER_URL?.replace(/\/$/, "") ?? "";

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -105,10 +105,37 @@ export async function summarizePages(
     const raw = (data.message.content.match(/\{[\s\S]*\}/) ?? [
       data.message.content,
     ])[0];
-    const parsed = JSON.parse(raw) as SummaryResult;
+    // The model controls this JSON, so treat it as untrusted and normalize
+    // each citation to the Citation contract here — the trust boundary. A
+    // model may return a citation without `key_facts` (or url/title), which
+    // previously reached formatSummaryResult and crashed it on
+    // `c.key_facts.map(...)`.
+    const parsed = JSON.parse(raw) as {
+      summary?: unknown;
+      citations?: unknown;
+    };
+    const citations: Citation[] = Array.isArray(parsed.citations)
+      ? parsed.citations.map((c): Citation => {
+          const entry = (c ?? {}) as {
+            url?: unknown;
+            title?: unknown;
+            key_facts?: unknown;
+          };
+          const url = typeof entry.url === "string" ? entry.url : "";
+          return {
+            url,
+            title: typeof entry.title === "string" ? entry.title : url,
+            key_facts: Array.isArray(entry.key_facts)
+              ? entry.key_facts.filter(
+                  (f): f is string => typeof f === "string",
+                )
+              : [],
+          };
+        })
+      : [];
     return {
-      summary: parsed.summary ?? "",
-      citations: Array.isArray(parsed.citations) ? parsed.citations : [],
+      summary: typeof parsed.summary === "string" ? parsed.summary : "",
+      citations,
     };
   } catch {
     // Ollama unavailable, timeout, or parse error — return null to signal fallback
@@ -118,9 +145,11 @@ export async function summarizePages(
 
 export function formatSummaryResult(result: SummaryResult): string {
   if (!result.summary) return "";
-  const citationText = result.citations
+  const citationText = (result.citations ?? [])
     .map((c: Citation) => {
-      const facts = c.key_facts.map((f) => `     - ${f}`).join("\n");
+      const facts = (Array.isArray(c.key_facts) ? c.key_facts : [])
+        .map((f) => `     - ${f}`)
+        .join("\n");
       return `  - ${c.title}\n    URL: ${c.url}\n${facts}`;
     })
     .join("\n\n");

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -1,4 +1,8 @@
 import {
+  LLM_API_KEY,
+  LLM_BASE_URL,
+  LLM_DISABLE_THINKING,
+  LLM_MODEL,
   OLLAMA_API_KEY,
   OLLAMA_EXPAND_MODEL,
   OLLAMA_SUMMARIZE_MODEL,
@@ -11,8 +15,65 @@ import type {
   SummaryResult,
 } from "./types.js";
 
+type ChatMessage = { role: string; content: string };
+
+/**
+ * Run a chat completion and return the assistant text.
+ *
+ * Prefers an OpenAI-compatible endpoint (`LLM_BASE_URL`) so an already-loaded
+ * vLLM / llama.cpp / LM Studio model can be reused; otherwise falls back to the
+ * Ollama `/api/chat` endpoint. Both suppress reasoning traces.
+ */
+async function llmChat(
+  model: string,
+  messages: ChatMessage[],
+  timeoutMs: number,
+): Promise<string> {
+  if (LLM_BASE_URL) {
+    const res = await fetch(`${LLM_BASE_URL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(LLM_API_KEY && { Authorization: `Bearer ${LLM_API_KEY}` }),
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        stream: false,
+        temperature: 0.2,
+        ...(LLM_DISABLE_THINKING
+          ? { chat_template_kwargs: { enable_thinking: false } }
+          : {}),
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) throw new Error(`LLM error: ${res.status}`);
+    const data = (await res.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    return data.choices?.[0]?.message?.content ?? "";
+  }
+  const res = await fetch(`${OLLAMA_URL}/api/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(OLLAMA_API_KEY && { Authorization: `Bearer ${OLLAMA_API_KEY}` }),
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      stream: false,
+      options: { think: false },
+    }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) throw new Error(`Ollama error: ${res.status}`);
+  const data = (await res.json()) as OllamaChatResponse;
+  return data.message.content;
+}
+
 export async function expandQuery(query: string): Promise<string[]> {
-  if (!OLLAMA_URL) return [];
+  if (!OLLAMA_URL && !LLM_BASE_URL) return [];
   const prompt =
     `Generate 2-3 search query variants for the query below. ` +
     `Output ONLY the variant queries, one per line. No numbering, no explanations, no extra text.\n\n` +
@@ -24,25 +85,32 @@ export async function expandQuery(query: string): Promise<string[]> {
     `Output 2 or 3 variants only:`;
 
   try {
-    const res = await fetch(`${OLLAMA_URL}/api/generate`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(OLLAMA_API_KEY && { Authorization: `Bearer ${OLLAMA_API_KEY}` }),
-      },
-      body: JSON.stringify({
-        model: OLLAMA_EXPAND_MODEL,
-        prompt,
-        stream: false,
-        options: { think: false },
-      }),
-      signal: AbortSignal.timeout(12000),
-    });
-
-    if (!res.ok) throw new Error(`Ollama error: ${res.status}`);
-
-    const data = (await res.json()) as OllamaGenerateResponse;
-    return data.response
+    let text: string;
+    if (LLM_BASE_URL) {
+      text = await llmChat(
+        LLM_MODEL || OLLAMA_EXPAND_MODEL,
+        [{ role: "user", content: prompt }],
+        12000,
+      );
+    } else {
+      const res = await fetch(`${OLLAMA_URL}/api/generate`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(OLLAMA_API_KEY && { Authorization: `Bearer ${OLLAMA_API_KEY}` }),
+        },
+        body: JSON.stringify({
+          model: OLLAMA_EXPAND_MODEL,
+          prompt,
+          stream: false,
+          options: { think: false },
+        }),
+        signal: AbortSignal.timeout(12000),
+      });
+      if (!res.ok) throw new Error(`Ollama error: ${res.status}`);
+      text = ((await res.json()) as OllamaGenerateResponse).response;
+    }
+    return text
       .split("\n")
       .map((line) => line.trim())
       .filter((line) => line.length > 0 && line !== query)
@@ -57,7 +125,7 @@ export async function summarizePages(
   query: string,
   pages: Array<{ title: string; url: string; text: string }>,
 ): Promise<SummaryResult> {
-  if (!OLLAMA_URL) return { summary: "", citations: [] };
+  if (!OLLAMA_URL && !LLM_BASE_URL) return { summary: "", citations: [] };
   if (pages.length === 0) {
     return { summary: "No content to summarize.", citations: [] };
   }
@@ -70,41 +138,28 @@ export async function summarizePages(
     )
     .join("\n\n---\n\n");
 
+  const messages: ChatMessage[] = [
+    {
+      role: "system",
+      content:
+        "You are a research assistant. Synthesize the provided sources to answer the query. " +
+        "Respond with JSON only, no markdown fences, matching this exact schema: " +
+        '{"summary":"<synthesized answer>","citations":[{"url":"<url>","title":"<title>","key_facts":["<fact>"]}]} ' +
+        "Include only sources that contributed to the answer. key_facts: 1-3 short phrases per source.",
+    },
+    {
+      role: "user",
+      content: `Query: ${query}\n\nSources:\n${pageBlocks}`,
+    },
+  ];
+
   try {
-    const res = await fetch(`${OLLAMA_URL}/api/chat`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(OLLAMA_API_KEY && { Authorization: `Bearer ${OLLAMA_API_KEY}` }),
-      },
-      body: JSON.stringify({
-        model: OLLAMA_SUMMARIZE_MODEL,
-        messages: [
-          {
-            role: "system",
-            content:
-              "You are a research assistant. Synthesize the provided sources to answer the query. " +
-              "Respond with JSON only, no markdown fences, matching this exact schema: " +
-              '{"summary":"<synthesized answer>","citations":[{"url":"<url>","title":"<title>","key_facts":["<fact>"]}]} ' +
-              "Include only sources that contributed to the answer. key_facts: 1-3 short phrases per source.",
-          },
-          {
-            role: "user",
-            content: `Query: ${query}\n\nSources:\n${pageBlocks}`,
-          },
-        ],
-        stream: false,
-        options: { think: false },
-      }),
-      signal: AbortSignal.timeout(45000),
-    });
-
-    if (!res.ok) throw new Error(`Ollama error: ${res.status}`);
-
-    const data = (await res.json()) as OllamaChatResponse;
-    const raw = (data.message.content.match(/\{[\s\S]*\}/) ?? [
-      data.message.content,
-    ])[0];
+    const content = await llmChat(
+      LLM_MODEL || OLLAMA_SUMMARIZE_MODEL,
+      messages,
+      45000,
+    );
+    const raw = (content.match(/\{[\s\S]*\}/) ?? [content])[0];
     // The model controls this JSON, so treat it as untrusted and normalize
     // each citation to the Citation contract here — the trust boundary. A
     // model may return a citation without `key_facts` (or url/title), which

--- a/tests/ollama.test.ts
+++ b/tests/ollama.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Citation } from "../src/types.js";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -141,5 +142,80 @@ describe("summarizePages", () => {
       { title: "T", url: "https://example.com", text: "t" },
     ]);
     expect(result).toEqual({ summary: "", citations: [] });
+  });
+
+  it("normalizes a citation missing key_facts to an empty array", async () => {
+    // Regression: a model may omit key_facts. Previously this survived
+    // summarizePages and later crashed formatSummaryResult on
+    // `c.key_facts.map(...)`.
+    process.env.OLLAMA_URL = "http://ollama:11434";
+    const { summarizePages } = await import("../src/ollama.js");
+    const payload = {
+      summary: "answer",
+      citations: [{ url: "https://example.com", title: "Example" }],
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({ message: { content: JSON.stringify(payload) } }),
+    });
+    const result = await summarizePages("query", [
+      { title: "Example", url: "https://example.com", text: "t" },
+    ]);
+    expect(result.citations).toHaveLength(1);
+    expect(result.citations[0].key_facts).toEqual([]);
+  });
+
+  it("drops non-string key_facts entries", async () => {
+    process.env.OLLAMA_URL = "http://ollama:11434";
+    const { summarizePages } = await import("../src/ollama.js");
+    const payload = {
+      summary: "answer",
+      citations: [
+        { url: "https://x.com", title: "X", key_facts: ["ok", 42, null] },
+      ],
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({ message: { content: JSON.stringify(payload) } }),
+    });
+    const result = await summarizePages("query", [
+      { title: "X", url: "https://x.com", text: "t" },
+    ]);
+    expect(result.citations[0].key_facts).toEqual(["ok"]);
+  });
+});
+
+describe("formatSummaryResult", () => {
+  it("returns empty string when summary is empty", async () => {
+    const { formatSummaryResult } = await import("../src/ollama.js");
+    expect(formatSummaryResult({ summary: "", citations: [] })).toBe("");
+  });
+
+  it("does not throw when a citation is missing key_facts", async () => {
+    // Defensive: the exported formatter must tolerate malformed citations
+    // even if a caller bypasses summarizePages' normalization.
+    const { formatSummaryResult } = await import("../src/ollama.js");
+    const out = formatSummaryResult({
+      summary: "answer",
+      citations: [
+        { url: "https://example.com", title: "Example" } as unknown as Citation,
+      ],
+    });
+    expect(out).toContain("answer");
+    expect(out).toContain("https://example.com");
+  });
+
+  it("renders key_facts as bulleted lines when present", async () => {
+    const { formatSummaryResult } = await import("../src/ollama.js");
+    const out = formatSummaryResult({
+      summary: "answer",
+      citations: [
+        { url: "https://x.com", title: "X", key_facts: ["f1", "f2"] },
+      ],
+    });
+    expect(out).toContain("- f1");
+    expect(out).toContain("- f2");
   });
 });

--- a/tests/ollama.test.ts
+++ b/tests/ollama.test.ts
@@ -5,17 +5,25 @@ const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 // Reset env before each test; individual tests set what they need
+const LLM_ENV = [
+  "OLLAMA_URL",
+  "OLLAMA_API_KEY",
+  "LLM_BASE_URL",
+  "LLM_MODEL",
+  "LLM_API_KEY",
+  "LLM_DISABLE_THINKING",
+];
+function clearLlmEnv() {
+  for (const k of LLM_ENV) delete process.env[k];
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.resetModules();
-  delete process.env.OLLAMA_URL;
-  delete process.env.OLLAMA_API_KEY;
+  clearLlmEnv();
 });
 
-afterEach(() => {
-  delete process.env.OLLAMA_URL;
-  delete process.env.OLLAMA_API_KEY;
-});
+afterEach(clearLlmEnv);
 
 describe("expandQuery", () => {
   it("returns empty array when OLLAMA_URL is not set", async () => {
@@ -217,5 +225,91 @@ describe("formatSummaryResult", () => {
     });
     expect(out).toContain("- f1");
     expect(out).toContain("- f2");
+  });
+});
+
+describe("OpenAI-compatible backend (LLM_BASE_URL)", () => {
+  const okJson = (content: string) => ({
+    ok: true,
+    json: () => Promise.resolve({ choices: [{ message: { content } }] }),
+  });
+  const lastCall = () => mockFetch.mock.calls[0] as [string, RequestInit];
+  const bodyOf = (opts: RequestInit) => JSON.parse(opts.body as string);
+
+  it("summarizePages POSTs to <LLM_BASE_URL>/chat/completions with thinking disabled and LLM_MODEL", async () => {
+    process.env.LLM_BASE_URL = "http://llm:8000/v1";
+    process.env.LLM_MODEL = "my-model";
+    const { summarizePages } = await import("../src/ollama.js");
+    mockFetch.mockResolvedValueOnce(
+      okJson(JSON.stringify({ summary: "s", citations: [] })),
+    );
+    const result = await summarizePages("q", [
+      { title: "T", url: "https://e.com", text: "t" },
+    ]);
+    const [url, opts] = lastCall();
+    expect(url).toBe("http://llm:8000/v1/chat/completions");
+    const body = bodyOf(opts);
+    expect(body.model).toBe("my-model");
+    expect(body.chat_template_kwargs).toEqual({ enable_thinking: false });
+    expect(
+      (opts.headers as Record<string, string>).Authorization,
+    ).toBeUndefined();
+    expect(result.summary).toBe("s");
+  });
+
+  it("strips a single trailing slash from LLM_BASE_URL", async () => {
+    process.env.LLM_BASE_URL = "http://llm:8000/v1/";
+    const { summarizePages } = await import("../src/ollama.js");
+    mockFetch.mockResolvedValueOnce(okJson('{"summary":"s","citations":[]}'));
+    await summarizePages("q", [
+      { title: "T", url: "https://e.com", text: "t" },
+    ]);
+    expect(lastCall()[0]).toBe("http://llm:8000/v1/chat/completions");
+  });
+
+  it("omits chat_template_kwargs when LLM_DISABLE_THINKING=false", async () => {
+    process.env.LLM_BASE_URL = "http://llm:8000/v1";
+    process.env.LLM_DISABLE_THINKING = "false";
+    const { summarizePages } = await import("../src/ollama.js");
+    mockFetch.mockResolvedValueOnce(okJson('{"summary":"s","citations":[]}'));
+    await summarizePages("q", [
+      { title: "T", url: "https://e.com", text: "t" },
+    ]);
+    expect(bodyOf(lastCall()[1]).chat_template_kwargs).toBeUndefined();
+  });
+
+  it("adds Authorization when LLM_API_KEY is set", async () => {
+    process.env.LLM_BASE_URL = "http://llm:8000/v1";
+    process.env.LLM_API_KEY = "sk-abc";
+    const { summarizePages } = await import("../src/ollama.js");
+    mockFetch.mockResolvedValueOnce(okJson('{"summary":"s","citations":[]}'));
+    await summarizePages("q", [
+      { title: "T", url: "https://e.com", text: "t" },
+    ]);
+    expect(
+      (lastCall()[1].headers as Record<string, string>).Authorization,
+    ).toBe("Bearer sk-abc");
+  });
+
+  it("degrades to empty summary when choices are missing", async () => {
+    process.env.LLM_BASE_URL = "http://llm:8000/v1";
+    const { summarizePages } = await import("../src/ollama.js");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    const result = await summarizePages("q", [
+      { title: "T", url: "https://e.com", text: "t" },
+    ]);
+    expect(result).toEqual({ summary: "", citations: [] });
+  });
+
+  it("expandQuery uses /chat/completions when LLM_BASE_URL is set", async () => {
+    process.env.LLM_BASE_URL = "http://llm:8000/v1";
+    const { expandQuery } = await import("../src/ollama.js");
+    mockFetch.mockResolvedValueOnce(okJson("variant one\nvariant two"));
+    const result = await expandQuery("orig");
+    expect(lastCall()[0]).toBe("http://llm:8000/v1/chat/completions");
+    expect(result).toEqual(["variant one", "variant two"]);
   });
 });


### PR DESCRIPTION
## Summary

Adds an **OpenAI-compatible chat backend** for query expansion and summarization, so an already-running chat server (vLLM, llama.cpp, LM Studio, …) can be reused instead of standing up a separate Ollama model.

Previously `expandQuery` and `summarizePages` spoke only Ollama's API (`/api/generate`, `/api/chat`). If your summarize-capable model is served over an OpenAI-compatible endpoint, you had to run a second (often smaller) model in Ollama just for these calls — wasteful when a capable model is already loaded elsewhere.

## What changed

- New config (`src/config.ts`): `LLM_BASE_URL`, `LLM_MODEL`, `LLM_API_KEY`, `LLM_DISABLE_THINKING`.
- New `llmChat()` helper (`src/ollama.ts`): when `LLM_BASE_URL` is set, POSTs to `${LLM_BASE_URL}/chat/completions` (OpenAI shape) and reads `choices[0].message.content`; otherwise uses the existing Ollama `/api/chat`.
- `LLM_DISABLE_THINKING` (default on) sends `chat_template_kwargs: { enable_thinking: false }` so reasoning models (e.g. Qwen3) return direct output rather than a `<think>` trace. Set it to `false` for servers that reject that field.
- `expandQuery` uses the OpenAI path when `LLM_BASE_URL` is set (otherwise unchanged `/api/generate`); `summarizePages` routes through `llmChat`. `LLM_MODEL` overrides the per-capability model names.

## Behavior / compatibility

- **The Ollama path is unchanged** when `LLM_BASE_URL` is unset. In that mode `llmChat` hits `/api/chat` and returns `data.message.content` — the same shape the existing tests assert.
- Missing/empty `choices` degrade to `""` (caught by the existing try/catch → fallback). `LLM_API_KEY` sends `Authorization: Bearer` only when set. Trailing slash on `LLM_BASE_URL` is stripped.

Example:
```
LLM_BASE_URL=http://your-vllm-host:8000/v1
LLM_MODEL=Qwen/Qwen3.6-35B-A3B-FP8
```

## Tests

Full suite (254 tests, incl. the existing Ollama-path coverage), `biome` lint, and `tsc --typecheck` all pass.

> Note: this branch is **stacked on #15** (the citations `key_facts` crash fix), since both touch `summarizePages` and this feature relies on that normalization. It shows both commits until #15 merges, then collapses to just the feature commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
