### PR TITLE
Fix HTTP transport rejecting concurrent client sessions

### DIFF
--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+
+function sendJsonRpcError(
+  res: ServerResponse,
+  status: number,
+  message: string,
+): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code: -32600, message },
+      id: null,
+    }),
+  );
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw.length > 0 ? JSON.parse(raw) : undefined;
+}
+
+/**
+ * Builds a Node HTTP request listener that routes each request to the
+ * StreamableHTTPServerTransport for its MCP session. A new transport (and
+ * MCP server, via `createServer`) is instantiated per session and keyed by
+ * the Mcp-Session-Id header, per the SDK's documented stateful multi-session
+ * pattern — a single shared transport rejects every session after the first.
+ */
+export function createHttpRequestListener(
+  createServer: () => McpServer,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  const transports = new Map<string, StreamableHTTPServerTransport>();
+
+  return (req, res) => {
+    void (async () => {
+      try {
+        const sessionId = req.headers["mcp-session-id"];
+        const existing =
+          typeof sessionId === "string" ? transports.get(sessionId) : undefined;
+
+        if (existing) {
+          await existing.handleRequest(req, res);
+          return;
+        }
+
+        if (typeof sessionId === "string") {
+          sendJsonRpcError(res, 404, "Session not found");
+          return;
+        }
+
+        const parsedBody =
+          req.method === "POST" ? await readJsonBody(req) : undefined;
+
+        if (!isInitializeRequest(parsedBody)) {
+          sendJsonRpcError(res, 400, "No valid session ID provided");
+          return;
+        }
+
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (id) => {
+            transports.set(id, transport);
+          },
+        });
+        transport.onclose = () => {
+          if (transport.sessionId) transports.delete(transport.sessionId);
+        };
+
+        const server = createServer();
+        await server.connect(transport);
+        await transport.handleRequest(req, res, parsedBody);
+      } catch (err: unknown) {
+        console.error("[searxng-mcp] HTTP transport error:", err);
+        if (!res.headersSent) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Internal server error" }));
+        }
+      }
+    })();
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,21 +2,23 @@
 import { createServer } from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { HTTP_HOST, HTTP_PORT, TRANSPORT } from "./config.js";
 import { initEvents, shutdownEvents } from "./events.js";
+import { createHttpRequestListener } from "./http-transport.js";
 import { initObservability, shutdownObservability } from "./observability.js";
 import { registerTools } from "./tools.js";
 
 await initObservability();
 await initEvents();
 
-const server = new McpServer({
-  name: "searxng-mcp",
-  version: "3.10.0",
-});
-
-registerTools(server);
+const createSearxngServer = () => {
+  const server = new McpServer({
+    name: "searxng-mcp",
+    version: "3.10.0",
+  });
+  registerTools(server);
+  return server;
+};
 
 const shutdown = async () => {
   await Promise.allSettled([shutdownObservability(), shutdownEvents()]);
@@ -26,21 +28,13 @@ process.once("SIGTERM", shutdown);
 process.once("SIGINT", shutdown);
 
 if (TRANSPORT === "http") {
-  // Stateful HTTP transport — session IDs prevent message ID collisions between
-  // concurrent clients. Multiple clients share in-process caches (L1 llms.txt,
-  // domain stats) but have separate Valkey-backed state.
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: () => crypto.randomUUID(),
-  });
-  await server.connect(transport);
-
-  const httpServer = createServer((req, res) => {
-    transport.handleRequest(req, res).catch((err: unknown) => {
-      console.error("[searxng-mcp] HTTP transport error:", err);
-      res.writeHead(500, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Internal server error" }));
-    });
-  });
+  // Stateful HTTP transport — each MCP session gets its own transport (and
+  // server) instance, keyed by Mcp-Session-Id, so concurrent clients don't
+  // collide on a single shared transport. Multiple clients share in-process
+  // caches (L1 llms.txt, domain stats) but have separate Valkey-backed state.
+  const httpServer = createServer(
+    createHttpRequestListener(createSearxngServer),
+  );
 
   httpServer.listen(HTTP_PORT, HTTP_HOST, () => {
     console.error(
@@ -53,6 +47,7 @@ if (TRANSPORT === "http") {
     }
   });
 } else {
+  const server = createSearxngServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/tests/http-session-routing.test.ts
+++ b/tests/http-session-routing.test.ts
@@ -1,0 +1,87 @@
+import { createServer, type Server } from "node:http";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createHttpRequestListener } from "../src/http-transport.js";
+
+let httpServer: Server;
+let port: number;
+
+beforeAll(async () => {
+  const listener = createHttpRequestListener(
+    () => new McpServer({ name: "test-server", version: "0.0.0" }),
+  );
+  httpServer = createServer(listener);
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, "127.0.0.1", () => resolve());
+  });
+  port = (httpServer.address() as { port: number }).port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    httpServer.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+};
+
+function initializeRequest(id: number) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "test-client", version: "0.0.0" },
+    },
+  };
+}
+
+describe("HTTP session routing", () => {
+  it("gives two concurrent clients distinct sessions instead of rejecting the second", async () => {
+    const [resA, resB] = await Promise.all([
+      fetch(`http://127.0.0.1:${port}/`, {
+        method: "POST",
+        headers: MCP_HEADERS,
+        body: JSON.stringify(initializeRequest(1)),
+      }),
+      fetch(`http://127.0.0.1:${port}/`, {
+        method: "POST",
+        headers: MCP_HEADERS,
+        body: JSON.stringify(initializeRequest(2)),
+      }),
+    ]);
+
+    expect(resA.status).toBe(200);
+    expect(resB.status).toBe(200);
+
+    const sessionA = resA.headers.get("mcp-session-id");
+    const sessionB = resB.headers.get("mcp-session-id");
+
+    expect(sessionA).toBeTruthy();
+    expect(sessionB).toBeTruthy();
+    expect(sessionA).not.toBe(sessionB);
+  });
+
+  it("rejects a request carrying an unknown session ID with 404", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/`, {
+      method: "GET",
+      headers: { ...MCP_HEADERS, "mcp-session-id": "not-a-real-session" },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects a non-initialize request without a session ID with 400", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/`, {
+      method: "POST",
+      headers: MCP_HEADERS,
+      body: JSON.stringify({ jsonrpc: "2.0", id: 99, method: "ping" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- `src/index.ts` created one `StreamableHTTPServerTransport` for the whole process and reused it for every request. Only the first client's `initialize` succeeded; every later client got `HTTP 400 "Server already initialized"`.
- This broke the shared `searxng-mcp` HTTP service (port 8504) for every agent except whichever connected first, blocking Phase 6-7 of the SXNG-13 stdio→HTTP cutover.
- New `src/http-transport.ts` routes each request by the `Mcp-Session-Id` header, creating a new transport + `McpServer` per session (the SDK's documented stateful multi-session pattern) instead of sharing one instance.

Fixes SXNG-14.

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 381/381 passing (38 files), including new `tests/http-session-routing.test.ts` covering concurrent sessions, unknown-session 404, and non-init-without-session 400
- [x] `pnpm build` — clean
- [x] Manual smoke test: built server on a scratch port, two concurrent `initialize` POSTs reproducing the exact ticket scenario — both now return 200 with distinct `Mcp-Session-Id` values (previously the second would 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)