### PR TITLE
Fix CI dependency-audit job — npm retired the endpoints pnpm audit uses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,12 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Install pnpm
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      # npmjs.org retired the audit endpoints `pnpm audit` depends on (410,
+      # even on latest pnpm) — npm's own audit already speaks the new bulk
+      # advisory endpoint, so generate a throwaway lockfile from package.json
+      # and audit with that instead. See SXNG-15.
+      - name: Generate npm lockfile for audit
+        run: npm install --package-lock-only
 
       - name: Audit dependencies
-        run: pnpm audit --prod
+        run: npm audit --omit=dev


### PR DESCRIPTION
## Summary
- `pnpm audit --prod` fails with `ERR_PNPM_AUDIT_BAD_RESPONSE` — npmjs.org retired the quick/full audit endpoints pnpm's `audit` command calls (HTTP 410, "Use the bulk advisory endpoint instead").
- Confirmed this isn't a version-lag issue: tested pnpm 11.13.1 (latest stable) against this repo's exact deps — same 410. Bumping pnpm doesn't fix it.
- npm's own `audit` already speaks the replacement bulk advisory endpoint. Swapped the CI step to generate a throwaway `package-lock.json` from `package.json` (gitignored, not committed) and run `npm audit --omit=dev` against that instead.
- Checked all other `~/repos/personal/*` repos: only `searxng-mcp` runs `pnpm audit` in CI. `bsky-mcp-server`/`unraid-mcp-server` (also pnpm) have no audit step; everything else uses `pip-audit`, which is unaffected. No cross-repo propagation needed.

Fixes SXNG-15.

## Test plan
- [x] Reproduced the 410 locally against this repo's deps with both the pinned pnpm (10.30.3) and latest stable (11.13.1)
- [x] Verified `npm install --package-lock-only` + `npm audit --omit=dev` runs clean against this repo's deps (0 vulnerabilities) in a simulated fresh-checkout environment
- [x] Verified `npm audit` actually detects real vulnerabilities (not a silent no-op) — added a known-vulnerable `minimatch@3.0.4` devDependency in a scratch copy, audit correctly flagged 1 high-severity finding and exited 1; clean tree exits 0
- [x] Verified `npm install --package-lock-only` needs a clean checkout — it crashes if pnpm's `node_modules/.pnpm` layout already exists, which is why this step doesn't run after a `pnpm install` in the same job

🤖 Generated with [Claude Code](https://claude.com/claude-code)