### PR TITLE
fix: bound res.json() reads in Firecrawl/Crawl4AI tiers (SXNG-23) → v3.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.15.1] - 2026-07-16
+
+### Security
+- **Bounded reads in the Firecrawl/Crawl4AI tiers (SXNG-23)** — `src/tiers/firecrawl.ts` and `src/tiers/crawl4ai.ts` now read responses via `readBoundedText` (2 MB cap) before `JSON.parse` instead of unbounded `res.json()`, matching the tier-3 / robots / llms / sitemap / Reddit fetches. Follow-up to the SXNG-21 audit LOW finding (the Reddit case was fixed in 3.15.0); consistency/defense-in-depth against an unexpectedly large response from those internal services.
+
 ## [3.15.0] - 2026-07-16
 
 Feature bundle from a 2026-07-16 competitive review (mcp-searxng, Perplexica, SurfSense, Jina Reader, Tavily/Exa MCP). All additive — no breaking tool-schema changes. Plane: SXNG-21.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tadmstr/searxng-mcp",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "description": "MCP server for SearXNG — private web search for Claude Code",
   "main": "build/src/index.js",
   "bin": {

--- a/src/tiers/crawl4ai.ts
+++ b/src/tiers/crawl4ai.ts
@@ -7,7 +7,11 @@ import {
   preferReadability,
   runReadability,
 } from "../extractors/readability.js";
-import type { FetchTuning, TierResult } from "../fetch-utils.js";
+import {
+  type FetchTuning,
+  readBoundedText,
+  type TierResult,
+} from "../fetch-utils.js";
 
 export async function pollCrawl4aiTask(
   taskId: string,
@@ -26,7 +30,10 @@ export async function pollCrawl4aiTask(
       const resp = await fetch(`${CRAWL4AI_URL}/task/${taskId}`, { signal });
       if (!resp.ok) return null;
 
-      const data = (await resp.json()) as Record<string, unknown>;
+      const data = JSON.parse(await readBoundedText(resp)) as Record<
+        string,
+        unknown
+      >;
       if (data.status === "completed") {
         const result = data.result as Record<string, unknown> | null;
         const md = result?.markdown as Record<string, string> | null;
@@ -93,7 +100,12 @@ export async function crawl4aiFetch(
     });
 
     if (!resp.ok) return null;
-    const data = (await resp.json()) as Record<string, unknown>;
+    // Bounded read (2 MB cap) before JSON.parse — consistency with the rest of
+    // the fetch layer; caps memory even on an unexpected oversized response.
+    const data = JSON.parse(await readBoundedText(resp)) as Record<
+      string,
+      unknown
+    >;
 
     // Synchronous response — results returned directly
     if (Array.isArray(data.results) && data.results.length > 0) {

--- a/src/tiers/firecrawl.ts
+++ b/src/tiers/firecrawl.ts
@@ -1,5 +1,9 @@
 import { FIRECRAWL_API_KEY, FIRECRAWL_URL } from "../config.js";
-import type { FetchTuning, TierResult } from "../fetch-utils.js";
+import {
+  type FetchTuning,
+  readBoundedText,
+  type TierResult,
+} from "../fetch-utils.js";
 import type { FirecrawlScrapeResponse } from "../types.js";
 
 export async function firecrawlScrape(
@@ -33,7 +37,11 @@ export async function firecrawlScrape(
     throw new Error(`Firecrawl error: ${res.status} ${res.statusText}`);
   }
 
-  const data = (await res.json()) as FirecrawlScrapeResponse;
+  // Bounded read (2 MB cap) before JSON.parse — consistency with the rest of
+  // the fetch layer; caps memory even on an unexpected oversized response.
+  const data = JSON.parse(
+    await readBoundedText(res),
+  ) as FirecrawlScrapeResponse;
 
   if (!data.success || !data.data) {
     throw new Error(data.error ?? "Firecrawl returned no data");

--- a/tests/tiers/crawl4ai.test.ts
+++ b/tests/tiers/crawl4ai.test.ts
@@ -18,10 +18,10 @@ beforeEach(() => {
 
 const URL = "https://example.com/page";
 
-const syncResponse = (text = "# Page Content\n\nSome text") => ({
-  ok: true,
-  json: () =>
-    Promise.resolve({
+// Real Response so crawl4aiFetch's readBoundedText(resp) has a body to read.
+const syncResponse = (text = "# Page Content\n\nSome text") =>
+  new Response(
+    JSON.stringify({
       results: [
         {
           markdown: { raw_markdown: text },
@@ -30,7 +30,8 @@ const syncResponse = (text = "# Page Content\n\nSome text") => ({
         },
       ],
     }),
-});
+    { status: 200 },
+  );
 
 describe("crawl4aiFetch", () => {
   it("returns result immediately on synchronous response", async () => {
@@ -55,10 +56,11 @@ describe("crawl4aiFetch", () => {
   });
 
   it("returns null for invalid task_id format (path traversal guard)", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ task_id: "../../etc/passwd" }),
-    });
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ task_id: "../../etc/passwd" }), {
+        status: 200,
+      }),
+    );
     const result = await crawl4aiFetch(URL);
     expect(result).toBeNull();
   });
@@ -95,10 +97,9 @@ describe("crawl4aiFetch", () => {
 
 describe("pollCrawl4aiTask", () => {
   it("returns result when status is completed", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
           status: "completed",
           result: {
             markdown: { raw_markdown: "page content" },
@@ -106,7 +107,9 @@ describe("pollCrawl4aiTask", () => {
             html: null,
           },
         }),
-    });
+        { status: 200 },
+      ),
+    );
 
     vi.useFakeTimers();
     const controller = new AbortController();
@@ -122,10 +125,9 @@ describe("pollCrawl4aiTask", () => {
   });
 
   it("returns null when status is failed", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ status: "failed" }),
-    });
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: "failed" }), { status: 200 }),
+    );
 
     vi.useFakeTimers();
     const controller = new AbortController();

--- a/tests/tiers/firecrawl.test.ts
+++ b/tests/tiers/firecrawl.test.ts
@@ -11,23 +11,23 @@ beforeEach(() => {
 
 const URL = "https://example.com/page";
 
+// Real Response so firecrawlScrape's readBoundedText(res) has a body to read.
 function mockSuccess(overrides?: object) {
-  return {
-    ok: true,
-    json: () =>
-      Promise.resolve({
-        success: true,
-        data: {
-          markdown: "# Title\n\nContent here",
-          html: "<h1>Title</h1><p>Content here</p>",
-          metadata: {
-            title: "Title",
-            sourceURL: URL,
-          },
-          ...overrides,
+  return new Response(
+    JSON.stringify({
+      success: true,
+      data: {
+        markdown: "# Title\n\nContent here",
+        html: "<h1>Title</h1><p>Content here</p>",
+        metadata: {
+          title: "Title",
+          sourceURL: URL,
         },
-      }),
-  };
+        ...overrides,
+      },
+    }),
+    { status: 200 },
+  );
 }
 
 describe("firecrawlScrape", () => {
@@ -56,11 +56,12 @@ describe("firecrawlScrape", () => {
   });
 
   it("throws when success is false with error message", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({ success: false, error: "bot-blocked", data: null }),
-    });
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ success: false, error: "bot-blocked", data: null }),
+        { status: 200 },
+      ),
+    );
     await expect(firecrawlScrape(URL)).rejects.toThrow("bot-blocked");
   });
 


### PR DESCRIPTION
Post-SXNG-21-audit follow-up.

## SXNG-23 — bounded tier reads
`src/tiers/firecrawl.ts` and `src/tiers/crawl4ai.ts` now read responses via `readBoundedText` (2 MB cap) + `JSON.parse` instead of unbounded `res.json()`, matching the tier-3 / robots / llms / sitemap / Reddit fetches. Consistency + defense-in-depth against an unexpectedly large response from those internal services. (The Reddit case was already fixed in 3.15.0; this closes the pre-existing tier sites the audit flagged.)

Tier test mocks updated to real `Response` objects so `readBoundedText` has a body to read.

## SXNG-24 — NOT included (deferred)
The `pnpm.overrides` `"vite": ">=8.0.16"` isn't honored under pnpm 10.30.3's auto-installed-peer resolution — vite stays at 8.0.7 even after `pnpm install --lockfile-only`. Forcing it means a full lockfile regen, which is disproportionate for a **Windows-only dev-server advisory in a test-only devDependency** with no prod or CI impact (CI runs `npm audit --omit=dev`). Left deferred on SXNG-24 with a note; likely resolves naturally on the next `vitest` major bump.

## Verification
- `pnpm build` / `pnpm lint` clean
- `pnpm test` — 472 tests pass

Bumps 3.15.0 → **3.15.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)