### PR TITLE
Lite mode: only SearXNG is required, and make the code say so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.20.0] - 2026-09-03
+
 Only SearXNG is required, and the code now says so as well as the README (build
 `searxng-mcp-lite-mode-2026-09`, vikunja#636). `README.md:160` claimed "SearXNG and Firecrawl are
 required" while `README.md:16` correctly said only SearXNG is. The stricter claim was wrong:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+Only SearXNG is required, and the code now says so as well as the README (build
+`searxng-mcp-lite-mode-2026-09`, vikunja#636). `README.md:160` claimed "SearXNG and Firecrawl are
+required" while `README.md:16` correctly said only SearXNG is. The stricter claim was wrong:
+`runTier` converts every tier failure into a miss rather than a fatal, and tier 3 is a raw HTTP
+fetch plus Readability running wholly in-process. Verified end to end — with Firecrawl, Crawl4AI,
+the cache and the reranker all dead, `fetchPage` returns clean extracted content via tier 3.
+
+### Added
+- **`FIRECRAWL_ENABLED` and `CRAWL4AI_ENABLED`**, both defaulting to `true` and read as
+  `!== "false"`, matching the existing `YOUTUBE_TRANSCRIPT_ENABLED` / `REDDIT_FASTPATH_ENABLED`
+  convention. A deployment that sets neither behaves exactly as v3.19.1 did. Deliberately *not*
+  derived from whether `FIRECRAWL_URL` was explicitly set: it defaults to `http://localhost:3002`,
+  so sniffing the env var would have silently disabled tier 1 for anyone already running Firecrawl
+  on the default port — a breaking change dressed as a fix.
+- **A startup capability line** naming which of tier1/2/3, cache, reranker, LLM, Kiwix, Hister,
+  solver, Wayback, OTel and NATS are configured. It reports configuration, never reachability —
+  nothing is probed, so it cannot delay or fail startup. This is the operator's answer to "why is
+  quality worse than I expected", which until now had to be guessed at.
+
+### Fixed
+- **Tier 1 had no unconfigured guard, unlike tier 2.** `firecrawlScrape` always attempted
+  `FIRECRAWL_URL`, so a Firecrawl-less deployment paid a failed connection on every fetch — cheap
+  on loopback (ECONNREFUSED), but a routable-but-dead host costs the full 15s
+  `AbortSignal.timeout`. With `FIRECRAWL_ENABLED=false` no connection is attempted at all,
+  confirmed against a stub listener that counts hits, with the switch left on as the negative
+  control.
+- **Unconfigured tiers no longer pollute the domain capability database.** Tier 2's null return
+  still booked a `miss` through `runTier`, so `tier_stats_30d` accumulated failures meaning "not
+  deployed" rather than "tried and failed" — and those same numbers drive `computeTierSkips`
+  routing and `domain_stats` output, so the pollution was never cosmetic. Three lite-mode fetches
+  measured before and after: **tier1 3 attempts/3 fail and tier2 3 attempts/3 fail, against 0 and 0
+  after**, with tier3 3/3 in both. At ten attempts those fabricated failures would have crossed the
+  30% threshold and started skipping tiers on the strength of a service that was never installed.
+
+### Changed
+- **`not_configured` is a third `SkipReason`** alongside `operator_override` and
+  `low_success_rate`, so unconfigured tiers route through the existing skip machinery — the
+  `searxng.fetch.tier.skipped` event, the `searxng_fetch_total{outcome=skipped}` counter and the
+  routing filter — rather than a parallel gate. That reuse *is* the stat fix: a skipped tier is
+  never recorded as an attempt. `not_configured` takes precedence over both other reasons, since
+  an override cannot un-skip a tier there is nothing to call.
+- **The `skipped` counter is now labelled with `reason`.** Previously
+  `searxng_fetch_total{outcome=skipped}` could not distinguish a tier that was never deployed from
+  one that is failing. Three values, so cardinality is unaffected, and queries that do not select
+  on `reason` aggregate the same total as before.
+- **One behaviour change, and it is the point of the build:** with `CRAWL4AI_URL` unset, tier 2
+  goes from *attempted, returns null, books a miss* to *skipped, books nothing*. No outbound call
+  changes — `crawl4aiFetch` already returned `null` without touching the network — so fetch results
+  are identical. What changes is the stats and the log line, which is the defect being fixed.
+- **README restructured around a minimal-config path.** Prerequisites is now tiered
+  (required / strongly recommended / optional), with each optional service naming the capability it
+  unlocks and the variable that turns it on, plus a SearXNG-only Quick Start stating plainly what
+  does and does not work in that configuration.
+
 ## [3.19.1] - 2026-09-03
 
 Seventeen advisories (9 high) cleared from the production dependency tree, and the CI gate that reported `found 0 vulnerabilities` the entire time they were shipping (build `searxng-mcp-audit-gate-2026-09`, vikunja#633). The versions are the smaller half. The `audit` job ran `npm install --package-lock-only` and audited *that* — which re-resolves every dependency from the semver ranges in `package.json`, answering "what would a fresh install get today" about a tree that ships nowhere. The image is built from `pnpm-lock.yaml`, which pins. So CI read undici 7.29.0 and passed green while the deployed container ran **7.28.0 with four highs**. No `--audit-level` value could have caught that: the threshold picks which findings fail, not which tree is read. Versions drift again in weeks; the gate reading the shipped lockfile is what stops the next drift shipping silently.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm](https://img.shields.io/npm/v/@tadmstr/searxng-mcp)](https://www.npmjs.com/package/@tadmstr/searxng-mcp)
 
-An MCP server for private web search via a self-hosted [SearXNG](https://github.com/searxng/searxng) instance. Results are reranked by a local ML model, full-page content is fetched via Firecrawl, and an optional Ollama instance provides query expansion and LLM-synthesized summaries.
+An MCP server for private web search via a self-hosted [SearXNG](https://github.com/searxng/searxng) instance. SearXNG is the only requirement; everything else is optional and layers on top — a local ML model reranks results, a three-tier cascade (Firecrawl, Crawl4AI, in-process raw fetch) retrieves full-page content, and an Ollama instance provides query expansion and LLM-synthesized summaries.
 
 Designed for use with Claude Code and LibreChat agents that need web search without sending queries to a third-party search API.
 
@@ -13,9 +13,29 @@ Built with [Claude Code](https://claude.ai/code) using the multi-agent workflow 
 
 ## Quick Start
 
-A running [SearXNG](https://github.com/searxng/searxng) instance is required. A cache backend is strongly recommended.
+**A running [SearXNG](https://github.com/searxng/searxng) instance is the only requirement.**
+Everything else is optional and improves a specific dimension — see [Prerequisites](#prerequisites).
 
-**Minimal stack** — start a Dragonfly/Valkey cache backend and run searxng-mcp:
+**SearXNG only** — nothing else deployed:
+
+```bash
+SEARXNG_URL=http://localhost:8081 \
+  FIRECRAWL_ENABLED=false \
+  npx @tadmstr/searxng-mcp
+```
+
+What works in this configuration: `search` returns ranked results, and `fetch_url` /
+`search_and_fetch` return extracted page content via tier 3 (raw HTTP fetch + Readability, wholly
+in-process). What does not: semantic reranking (results keep SearXNG's ordering), query expansion
+and `search_and_summarize` (no LLM), caching (every call is live), JS-heavy page rendering, and
+offline serving. The startup capability line tells you which of these are off.
+
+`FIRECRAWL_ENABLED=false` is what makes it a *clean* minimal run rather than merely a working one:
+`FIRECRAWL_URL` defaults to `http://localhost:3002`, so without the switch every fetch first
+attempts a connection to a Firecrawl that is not there, and books the failure into the domain
+capability database.
+
+**Recommended minimum** — add a cache backend, which is the single largest latency win:
 
 ```bash
 docker compose -f docker-compose.example.yml up -d
@@ -157,7 +177,7 @@ flowchart TD
     style result fill:#ffffff,stroke:#333333,color:#000000
 ```
 
-SearXNG and Firecrawl are required. Crawl4AI, Valkey, Ollama, Kiwix, and the reranker are optional — the server degrades gracefully when any of these are unavailable.
+**Only SearXNG is required.** Every tier below it is optional: Firecrawl, Crawl4AI, Valkey, Ollama, Kiwix, the reranker, the solver and Wayback each improve a named dimension, and the server degrades gracefully when any of them is unavailable. Tier 3 is a raw HTTP fetch plus Readability running in-process, so `fetch_url` still returns extracted content with nothing else deployed. Set `FIRECRAWL_ENABLED=false` and leave `CRAWL4AI_URL` unset to say so explicitly — those tiers are then skipped with `reason: not_configured` rather than attempted and missed.
 
 ### Adblocking
 
@@ -198,7 +218,7 @@ See [`docker/adblock-proxy/`](docker/adblock-proxy/) for the service definition,
 
 ### Data-driven tier routing
 
-Before invoking the fetch cascade, searxng-mcp reads the domain's `tier_stats_30d` (see [domain capability database](#domain-capability-database)) and skips any tier with success rate below 30% over at least 10 attempts. Cold-start domains (<10 attempts) keep the default cascade. Each skip emits a `searxng.fetch.tier.skipped` NATS event with `reason: low_success_rate` and increments `searxng_fetch_total{outcome=skipped}`.
+Before invoking the fetch cascade, searxng-mcp reads the domain's `tier_stats_30d` (see [domain capability database](#domain-capability-database)) and skips any tier with success rate below 30% over at least 10 attempts. Cold-start domains (<10 attempts) keep the default cascade. Each skip emits a `searxng.fetch.tier.skipped` NATS event and increments `searxng_fetch_total{outcome=skipped}`, both carrying the reason. Three reasons exist: `low_success_rate` (the stats rule above), `operator_override` (a `tier_skip` entry in `domains.json`), and `not_configured` (the tier's service is switched off, or has no URL). `not_configured` takes precedence over both others — an override cannot un-skip a tier there is nothing to call. Because a skipped tier is never recorded as an attempt, an unconfigured tier no longer books misses into `tier_stats_30d` meaning “not deployed” rather than “tried and failed”.
 
 **Operator override.** Add a `tier_skip` map to `domains.json` to force-skip tiers regardless of stats:
 
@@ -454,13 +474,48 @@ or, when the cache backend is unreachable:
 
 ## Prerequisites
 
-- Node.js 20+
-- pnpm (or npm)
-- A running [SearXNG](https://github.com/searxng/searxng) instance
-- A running [Firecrawl](https://github.com/mendableai/firecrawl) instance
-- A running reranker exposing a Jina-compatible `/v1/rerank` endpoint (optional)
-- A running [Valkey](https://valkey.io/) or Redis-compatible instance (optional, for result caching)
-- A running [Ollama](https://ollama.com/) instance with `qwen3:4b` and/or `qwen3:14b` pulled (optional, for query expansion and summarization)
+**Runtime:** Node.js 20+, and pnpm (or npm).
+
+### Required
+
+- A running [SearXNG](https://github.com/searxng/searxng) instance, with JSON output enabled (see below).
+
+That is the whole list. Everything under it is progressive enhancement.
+
+### Strongly recommended
+
+| Service | What it buys you |
+|---------|------------------|
+| [Valkey](https://valkey.io/), Dragonfly or any Redis-compatible cache | Repeat searches and fetches are served from cache instead of re-run. The single largest latency win. Fail-soft: a cache timeout serves live. |
+| A reranker with a Jina-compatible `/v1/rerank` endpoint | Reorders results by semantic relevance to the query. Without it results keep SearXNG's own ordering and a throttled degradation line is logged. |
+
+Neither has a kill switch — both have a default URL and are always attempted, because both fail
+soft. Absence costs quality and latency, never correctness.
+
+### Optional
+
+| Service | Capability it unlocks | Turn it on with |
+|---------|----------------------|-----------------|
+| [Firecrawl](https://github.com/mendableai/firecrawl) | Fetch tier 1 — Puppeteer-rendered pages, best extraction quality on JS-heavy sites | On by default; `FIRECRAWL_URL`, or `FIRECRAWL_ENABLED=false` to skip the tier |
+| [Crawl4AI](https://github.com/unclecode/crawl4ai) | Fetch tier 2 — browser automation fallback when tier 1 returns empty content | `CRAWL4AI_URL` |
+| [Ollama](https://ollama.com/) with `qwen3:4b` and/or `qwen3:14b`, or any OpenAI-compatible endpoint | Query expansion and LLM-synthesized summaries (`search_and_summarize`) | `OLLAMA_URL` or `LLM_BASE_URL` |
+| [kiwix-serve](https://github.com/kiwix/kiwix-tools) | Offline serving of Wikipedia, Stack Overflow and the Arch Wiki from local ZIM archives | `KIWIX_URL` |
+| Hister | Archived-page fallback from a private archive | `HISTER_URL` |
+| [Byparr](https://github.com/ThePhaseless/Byparr) or FlareSolverr | Solves Cloudflare-style interstitials on the domains that serve them | `SOLVER_URL` + `SOLVER_ENABLED=true` |
+| Wayback Machine | Tier-4 fallback to an archived snapshot when all three tiers fail | `WAYBACK_ENABLED=true` |
+| An OTLP collector / NATS | Traces and metrics; a JetStream event stream of every search and fetch | `OTEL_EXPORTER_OTLP_ENDPOINT` / `NATS_URL` |
+
+On startup the server logs one line naming exactly which of these are configured, so a
+lower-quality result set can be traced to a missing service rather than guessed at:
+
+```
+[searxng-mcp] capabilities on=tier3,cache,reranker off=tier1,tier2,llm,kiwix,hister,solver,wayback,otel,nats
+```
+
+It reports configuration, not reachability — nothing is probed, so the line never delays startup.
+
+The rest of this section is setup reference for whichever of the above you chose to deploy —
+skip any you did not.
 
 ### SearXNG
 
@@ -473,15 +528,15 @@ search:
     - json
 ```
 
-### Reranker
+### Reranker (recommended)
 
 The reranker must expose a Jina-compatible `/v1/rerank` endpoint. A lightweight FlashRank wrapper works well — see the [`docker/reranker/`](https://github.com/TadMSTR/homelab-agent/tree/main/docker/reranker) reference in [homelab-agent](https://github.com/TadMSTR/homelab-agent).
 
-### Firecrawl
+### Firecrawl (optional — fetch tier 1)
 
 Any Firecrawl-compatible instance works. The local [firecrawl-simple](https://github.com/mendableai/firecrawl/tree/main/apps/api) deployment is sufficient. Set `FIRECRAWL_API_KEY` if your instance requires authentication (defaults to `placeholder-local` for local deployments that skip auth).
 
-### Crawl4AI
+### Crawl4AI (optional — fetch tier 2)
 
 [Crawl4AI](https://github.com/unclecode/crawl4ai) is an optional second-tier fetch fallback used when Firecrawl returns empty content (bot-blocked pages, JS-heavy sites). Set `CRAWL4AI_URL` to enable it. If unset, the cascade skips to raw HTTP fetch.
 
@@ -539,6 +594,7 @@ All service URLs are configurable via environment variables.
 |----------|---------|-------------|
 | `SEARXNG_URL` | `http://localhost:8081` | SearXNG instance URL |
 | `FIRECRAWL_URL` | `http://localhost:3002` | Firecrawl instance URL |
+| `FIRECRAWL_ENABLED` | `true` | Set to `false` when no Firecrawl is deployed — tier 1 is then skipped with `reason: not_configured` instead of attempting a connection on every fetch |
 | `RERANKER_URL` | `http://localhost:8787` | Reranker instance URL |
 | `FIRECRAWL_API_KEY` | `placeholder-local` | Firecrawl API key (if required) |
 | `GITHUB_TOKEN` | *(unset)* | GitHub personal access token — increases rate limit from 60 to 5,000 req/hour |
@@ -564,6 +620,7 @@ All service URLs are configurable via environment variables.
 | `FIRECRAWL_CRAWL_MAX_WAIT_MS` | `120000` | Maximum time to wait for a Firecrawl crawl job before falling back to sitemap |
 | `EXPAND_QUERIES` | `false` | Set to `true` to enable query expansion globally |
 | `CRAWL4AI_URL` | *(unset)* | Crawl4AI instance URL — enables second-tier fetch fallback when Firecrawl fails |
+| `CRAWL4AI_ENABLED` | `true` | Set to `false` to skip tier 2 regardless of `CRAWL4AI_URL`. Tier 2 is also skipped when `CRAWL4AI_URL` is unset |
 | `CRAWL4AI_API_TOKEN` | *(unset)* | Optional Bearer token for Crawl4AI instances with API token protection |
 | `WAYBACK_ENABLED` | `false` | Set to `true` to enable Wayback Machine tier-4 fallback — fetches archived snapshots when all three tiers fail |
 | `SOLVER_URL` | *(unset)* | Base URL of a Byparr (or other FlareSolverr `POST /v1`-compatible) challenge-solving service, e.g. `http://byparr:8191`. Unset leaves the tier inert regardless of `SOLVER_ENABLED`. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tadmstr/searxng-mcp",
-  "version": "3.19.1",
+  "version": "3.20.0",
   "description": "MCP server for SearXNG — private web search for Claude Code",
   "main": "build/src/index.js",
   "bin": {

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -1,0 +1,63 @@
+// Startup capability reporting. Answers the operator question "why is quality
+// worse than I expected" — the most common cause is an optional service that
+// was never configured, and until now nothing said so at startup.
+//
+// This reports *configuration*, never health: nothing here probes a service or
+// opens a socket. A capability listed as on can still be unreachable, and that
+// shows up separately on the existing degradation paths (rerankWithFallback,
+// the Ollama fallbacks, the throttled cache lines).
+
+import {
+  CACHE_URL,
+  HISTER_URL,
+  KIWIX_URL,
+  LLM_BASE_URL,
+  OLLAMA_URL,
+  RERANKER_URL,
+  SOLVER_ENABLED,
+  SOLVER_URL,
+  tierConfigured,
+  WAYBACK_ENABLED,
+} from "./config.js";
+import { logInfo } from "./log.js";
+
+/**
+ * Capability name → whether it is active, in the order it is reported.
+ *
+ * Tier availability is read from `tierConfigured()` rather than recomputed, so
+ * this line and the `not_configured` skips in routing.ts cannot disagree.
+ *
+ * cache and reranker have a non-empty default URL and no kill switch, so they
+ * are always attempted and always report on. Both fail soft (a cache timeout
+ * serves live, the reranker falls back to the upstream order), which is why
+ * neither is a prerequisite.
+ */
+export function capabilities(): Record<string, boolean> {
+  const tiers = tierConfigured();
+  return {
+    tier1: tiers.tier1,
+    tier2: tiers.tier2,
+    tier3: tiers.tier3,
+    cache: Boolean(CACHE_URL),
+    reranker: Boolean(RERANKER_URL),
+    llm: Boolean(LLM_BASE_URL || OLLAMA_URL),
+    kiwix: Boolean(KIWIX_URL),
+    hister: Boolean(HISTER_URL),
+    solver: SOLVER_ENABLED && Boolean(SOLVER_URL),
+    wayback: WAYBACK_ENABLED,
+    otel: Boolean(process.env.OTEL_EXPORTER_OTLP_ENDPOINT),
+    nats: Boolean(process.env.NATS_URL),
+  };
+}
+
+/** The single startup line. Kept to one line however many capabilities exist. */
+export function capabilityLine(): string {
+  const caps = capabilities();
+  const on = Object.keys(caps).filter((k) => caps[k]);
+  const off = Object.keys(caps).filter((k) => !caps[k]);
+  return `capabilities on=${on.join(",") || "none"} off=${off.join(",") || "none"}`;
+}
+
+export function logCapabilities(): void {
+  logInfo(capabilityLine());
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import type { TierSlot } from "./types.js";
+
 export const SEARXNG_URL = process.env.SEARXNG_URL ?? "http://localhost:8081";
 export const FIRECRAWL_URL =
   process.env.FIRECRAWL_URL ?? "http://localhost:3002";
@@ -70,6 +72,36 @@ export const HISTER_URL = process.env.HISTER_URL?.replace(/\/$/, "") ?? "";
 export const HISTER_TOKEN = process.env.HISTER_TOKEN ?? "";
 export const CRAWL4AI_URL = process.env.CRAWL4AI_URL ?? null;
 export const CRAWL4AI_API_TOKEN = process.env.CRAWL4AI_API_TOKEN;
+// Fetch-tier kill switches. Only SearXNG is genuinely required — tier 3 is an
+// in-process raw fetch + Readability, so a deployment with no Firecrawl and no
+// Crawl4AI still serves fetch_url. These switches let such a deployment say so,
+// and the tier is then skipped as `not_configured` rather than attempted and
+// missed (see computeTierSkips in routing.ts).
+//
+// They default to *true* and are read as `!== "false"`, matching
+// YOUTUBE_TRANSCRIPT_ENABLED / REDDIT_FASTPATH_ENABLED. Deliberately NOT
+// derived from whether FIRECRAWL_URL was explicitly set: it defaults to
+// http://localhost:3002, so an instance already running Firecrawl on the
+// default port without an env var would silently lose tier 1. An explicit
+// switch is behaviour-neutral by construction.
+export const FIRECRAWL_ENABLED = process.env.FIRECRAWL_ENABLED !== "false";
+export const CRAWL4AI_ENABLED = process.env.CRAWL4AI_ENABLED !== "false";
+/**
+ * Effective per-tier availability, derived from the switches above and the URL
+ * each one gates. Single source of truth: the `not_configured` skips in
+ * routing.ts and the startup capability line in index.ts both read this, so
+ * they cannot disagree about what is on.
+ *
+ * Reports *configuration*, never reachability — nothing here probes a service.
+ * Tier 3 is in-process (raw fetch + Readability) and so is always available.
+ */
+export function tierConfigured(): Record<TierSlot, boolean> {
+  return {
+    tier1: FIRECRAWL_ENABLED,
+    tier2: CRAWL4AI_ENABLED && Boolean(CRAWL4AI_URL),
+    tier3: true,
+  };
+}
 export const WAYBACK_ENABLED = process.env.WAYBACK_ENABLED === "true";
 // Challenge-solving tier. SOLVER_URL points at a FlareSolverr-v1-compatible
 // solver — Byparr on forge (`http://byparr:8191`); FlareSolverr itself speaks

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -399,7 +399,12 @@ export async function fetchPage(
       // Announce all skipped tiers up front (metrics + events + logs).
       for (const { tier: slot, reason } of skipDecisions) {
         const tierName = TIER_NAME[slot];
-        incCounter("fetch", { tier: tierName, outcome: "skipped" });
+        // `reason` is labelled here, not just carried on the event: without it
+        // searxng_fetch_total{outcome="skipped"} cannot tell a tier that is not
+        // configured from one that is failing. Three values, so cardinality is
+        // a non-issue, and existing queries that do not select on reason still
+        // aggregate the same total.
+        incCounter("fetch", { tier: tierName, outcome: "skipped", reason });
         events.fetchTierSkipped({ url, tier: tierName, reason });
         console.error(
           `[searxng-mcp] fetch ${slot} skipped url=${url} reason=${reason}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import { createServer } from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { logCapabilities } from "./capabilities.js";
 import {
   HTTP_AUTH_TOKEN,
   HTTP_HOST,
@@ -45,6 +46,10 @@ process.on("unhandledRejection", (reason) => {
 
 await initObservability();
 await initEvents();
+// After both inits so the OTel/NATS entries report what actually got wired,
+// and before transport setup so the line is present even if the transport
+// fails to come up.
+logCapabilities();
 
 const createSearxngServer = () => {
   const server = new McpServer({

--- a/src/log.ts
+++ b/src/log.ts
@@ -6,6 +6,10 @@
 
 const PREFIX = "[searxng-mcp]";
 
+export function logInfo(message: string): void {
+  console.error(`${PREFIX} ${message}`);
+}
+
 export function logError(message: string): void {
   console.error(`${PREFIX} ${message}`);
 }

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,8 +1,9 @@
-// Data-driven tier routing. Skips tiers that are clearly bad fits for a
-// domain — either by operator override (`tier_skip` in domains.json) or by
-// observed success rate (Phase 4 stats). Falls back to the full cascade
-// during cold start (<10 attempts).
+// Data-driven tier routing. Skips tiers that cannot or should not run for a
+// domain — because the tier is not configured at all, by operator override
+// (`tier_skip` in domains.json), or by observed success rate (Phase 4 stats).
+// Falls back to the full cascade during cold start (<10 attempts).
 
+import { tierConfigured } from "./config.js";
 import {
   currentWindowStat,
   getDomainRecord,
@@ -15,7 +16,10 @@ import type { TierSlot } from "./types.js";
 const MIN_ATTEMPTS_FOR_DECISION = 10;
 const LOW_SUCCESS_THRESHOLD = 0.3;
 
-export type SkipReason = "operator_override" | "low_success_rate";
+export type SkipReason =
+  | "operator_override"
+  | "low_success_rate"
+  | "not_configured";
 
 export interface TierSkipDecision {
   tier: TierSlot;
@@ -33,8 +37,24 @@ export async function computeTierSkips(
 ): Promise<TierSkipDecision[]> {
   const decisions = new Map<TierSlot, SkipReason>();
 
-  // Operator overrides always win.
+  // Seeded FIRST, and this ordering is the one precedence rule a reader will
+  // not guess: `not_configured` is absolute. An operator override cannot
+  // un-skip an unconfigured tier — there is nothing to call — so the later
+  // passes must not be able to overwrite this entry. Both of them skip slots
+  // already in the map, so seeding first is what makes it absolute.
+  //
+  // Routing an unconfigured tier through the skip machinery (rather than
+  // letting it fail inside runTier) is also what keeps the domain database
+  // honest: a skipped tier is never recorded as an attempt, so tier_stats_30d
+  // stops accumulating misses that mean "not configured" rather than "tried
+  // and failed" — the same stats that drive the low_success_rate pass below.
+  for (const [slot, configured] of Object.entries(tierConfigured())) {
+    if (!configured) decisions.set(slot as TierSlot, "not_configured");
+  }
+
+  // Operator overrides win over the stats pass.
   for (const tier of getOperatorTierSkips(url)) {
+    if (decisions.has(tier)) continue;
     decisions.set(tier, "operator_override");
   }
 

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -1,0 +1,97 @@
+// The startup capability line. It is the operator's answer to "why is quality
+// worse than I expected", so the thing worth testing is that it reports
+// configuration honestly — and, in particular, that it never probes.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const CAP_ENV = [
+  "FIRECRAWL_ENABLED",
+  "CRAWL4AI_ENABLED",
+  "CRAWL4AI_URL",
+  "KIWIX_URL",
+  "HISTER_URL",
+  "LLM_BASE_URL",
+  "OLLAMA_URL",
+  "SOLVER_URL",
+  "SOLVER_ENABLED",
+  "WAYBACK_ENABLED",
+  "OTEL_EXPORTER_OTLP_ENDPOINT",
+  "NATS_URL",
+];
+
+function clearCapEnv() {
+  for (const k of CAP_ENV) delete process.env[k];
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  clearCapEnv();
+});
+
+afterEach(clearCapEnv);
+
+describe("capabilityLine", () => {
+  it("reports a bare deployment as tier3 + cache + reranker only", async () => {
+    const { capabilityLine } = await import("../src/capabilities.js");
+    expect(capabilityLine()).toBe(
+      "capabilities on=tier1,tier3,cache,reranker " +
+        "off=tier2,llm,kiwix,hister,solver,wayback,otel,nats",
+    );
+  });
+
+  it("moves tier1 to off when Firecrawl is switched off", async () => {
+    process.env.FIRECRAWL_ENABLED = "false";
+    const { capabilityLine } = await import("../src/capabilities.js");
+    expect(capabilityLine()).toContain("on=tier3,cache,reranker");
+    expect(capabilityLine()).toMatch(/off=tier1,tier2,/);
+  });
+
+  it("stays a single line however many capabilities are on", async () => {
+    process.env.CRAWL4AI_URL = "http://crawl4ai:11235";
+    process.env.KIWIX_URL = "http://kiwix:8080";
+    process.env.HISTER_URL = "http://hister:8080";
+    process.env.LLM_BASE_URL = "http://llm:8000/v1";
+    process.env.SOLVER_URL = "http://byparr:8191";
+    process.env.SOLVER_ENABLED = "true";
+    process.env.WAYBACK_ENABLED = "true";
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://otel:4318";
+    process.env.NATS_URL = "nats://nats:4222";
+    const { capabilityLine } = await import("../src/capabilities.js");
+    const line = capabilityLine();
+    expect(line).not.toContain("\n");
+    expect(line).toContain("off=none");
+  });
+
+  // A configured solver still needs its switch, matching the cascade's own
+  // gate — reporting it on from the URL alone would misdescribe the deployment.
+  it("reports the solver off when its URL is set but the switch is not", async () => {
+    process.env.SOLVER_URL = "http://byparr:8191";
+    const { capabilityLine } = await import("../src/capabilities.js");
+    expect(capabilityLine()).toMatch(/off=.*solver/);
+  });
+
+  // The line must be derivable with every optional service dead, so it can
+  // never delay or fail startup. If it probed, this would hang or throw.
+  it("does not touch the network", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("no network in this test"));
+    const { capabilityLine } = await import("../src/capabilities.js");
+    expect(capabilityLine()).toContain("capabilities on=");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("agrees with tierConfigured about the tiers", async () => {
+    process.env.FIRECRAWL_ENABLED = "false";
+    const { capabilities } = await import("../src/capabilities.js");
+    const { tierConfigured } = await import("../src/config.js");
+    const caps = capabilities();
+    const tiers = tierConfigured();
+    expect({
+      tier1: caps.tier1,
+      tier2: caps.tier2,
+      tier3: caps.tier3,
+    }).toEqual(tiers);
+  });
+});

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -17,6 +17,7 @@ const CAP_ENV = [
   "WAYBACK_ENABLED",
   "OTEL_EXPORTER_OTLP_ENDPOINT",
   "NATS_URL",
+  "HISTER_TOKEN",
 ];
 
 function clearCapEnv() {
@@ -80,6 +81,31 @@ describe("capabilityLine", () => {
     expect(capabilityLine()).toContain("capabilities on=");
     expect(fetchSpy).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
+  });
+
+  // The line is built from Object.keys of a record whose values are already
+  // collapsed to booleans, so no URL or credential can reach it. That is a
+  // security property of the construction rather than of a redaction step, and
+  // it would regress silently if the line were ever "improved" to show where
+  // each service points — hence an explicit test rather than a comment.
+  it("emits no URL, host or credential from any configured service", async () => {
+    process.env.HISTER_URL = "http://hister.internal.example:8080";
+    process.env.HISTER_TOKEN = "s3cret-hister-token";
+    process.env.LLM_BASE_URL = "http://llm.internal.example:8000/v1";
+    process.env.KIWIX_URL = "http://kiwix.internal.example:8292";
+    process.env.SOLVER_URL = "http://byparr.internal.example:8191";
+    process.env.NATS_URL = "nats://user:pw@nats.internal.example:4222";
+    const { capabilityLine } = await import("../src/capabilities.js");
+    const line = capabilityLine();
+    for (const leak of [
+      "internal.example",
+      "s3cret-hister-token",
+      "://",
+      "8080",
+      "user:pw",
+    ]) {
+      expect(line).not.toContain(leak);
+    }
   });
 
   it("agrees with tierConfigured about the tiers", async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -15,6 +15,9 @@ const CONFIG_ENV = [
   "HTTP_SESSION_IDLE_TIMEOUT_MS",
   "HTTP_MAX_SESSIONS",
   "SEARXNG_MCP_AUTH_TOKEN",
+  "FIRECRAWL_ENABLED",
+  "CRAWL4AI_ENABLED",
+  "CRAWL4AI_URL",
 ];
 
 function clearConfigEnv() {
@@ -255,5 +258,80 @@ describe("isLoopbackHost", () => {
     ]) {
       expect(isLoopbackHost(host), host).toBe(false);
     }
+  });
+});
+
+describe("fetch-tier kill switches", () => {
+  it("both default to enabled when unset", async () => {
+    const { FIRECRAWL_ENABLED, CRAWL4AI_ENABLED } = await import(
+      "../src/config.js"
+    );
+    expect(FIRECRAWL_ENABLED).toBe(true);
+    expect(CRAWL4AI_ENABLED).toBe(true);
+  });
+
+  // The `!== "false"` convention shared with YOUTUBE_TRANSCRIPT_ENABLED and
+  // REDDIT_FASTPATH_ENABLED: only the exact string disables, so a typo or a
+  // "0" leaves the tier on rather than silently killing it.
+  it('only the exact string "false" disables them', async () => {
+    process.env.FIRECRAWL_ENABLED = "false";
+    process.env.CRAWL4AI_ENABLED = "False";
+    const { FIRECRAWL_ENABLED, CRAWL4AI_ENABLED } = await import(
+      "../src/config.js"
+    );
+    expect(FIRECRAWL_ENABLED).toBe(false);
+    expect(CRAWL4AI_ENABLED).toBe(true);
+  });
+
+  it("neither 0 nor an empty string disables them", async () => {
+    process.env.FIRECRAWL_ENABLED = "0";
+    process.env.CRAWL4AI_ENABLED = "";
+    const { FIRECRAWL_ENABLED, CRAWL4AI_ENABLED } = await import(
+      "../src/config.js"
+    );
+    expect(FIRECRAWL_ENABLED).toBe(true);
+    expect(CRAWL4AI_ENABLED).toBe(true);
+  });
+});
+
+describe("tierConfigured", () => {
+  // Tier 2 needs a URL as well as its switch: CRAWL4AI_URL has no default, so
+  // the switch alone cannot make the tier callable. Tier 1 differs because
+  // FIRECRAWL_URL defaults to http://localhost:3002.
+  it("reports tier2 unconfigured when CRAWL4AI_URL is unset", async () => {
+    const { tierConfigured } = await import("../src/config.js");
+    expect(tierConfigured()).toEqual({
+      tier1: true,
+      tier2: false,
+      tier3: true,
+    });
+  });
+
+  it("reports tier2 configured once CRAWL4AI_URL is set", async () => {
+    process.env.CRAWL4AI_URL = "http://crawl4ai:11235";
+    const { tierConfigured } = await import("../src/config.js");
+    expect(tierConfigured().tier2).toBe(true);
+  });
+
+  it("reports tier2 unconfigured when its switch is off despite a URL", async () => {
+    process.env.CRAWL4AI_URL = "http://crawl4ai:11235";
+    process.env.CRAWL4AI_ENABLED = "false";
+    const { tierConfigured } = await import("../src/config.js");
+    expect(tierConfigured().tier2).toBe(false);
+  });
+
+  it("reports tier1 unconfigured when Firecrawl is switched off", async () => {
+    process.env.FIRECRAWL_ENABLED = "false";
+    const { tierConfigured } = await import("../src/config.js");
+    expect(tierConfigured().tier1).toBe(false);
+  });
+
+  // Tier 3 is in-process, so no configuration can turn it off. This is what
+  // makes SearXNG the only genuine prerequisite.
+  it("always reports tier3 configured, whatever else is off", async () => {
+    process.env.FIRECRAWL_ENABLED = "false";
+    process.env.CRAWL4AI_ENABLED = "false";
+    const { tierConfigured } = await import("../src/config.js");
+    expect(tierConfigured().tier3).toBe(true);
   });
 });

--- a/tests/fetch-cascade.test.ts
+++ b/tests/fetch-cascade.test.ts
@@ -5,6 +5,17 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// These suites exercise the operator-override and stats passes, which are
+// orthogonal to whether a tier is configured at all. Pin a fully-configured
+// baseline so every pre-existing assertion keeps meaning what it meant before
+// `not_configured` existed — CRAWL4AI_URL is unset in the test env, which would
+// otherwise skip tier2 in every case here and hide what these cases check.
+// The not_configured pass has its own cases, which drive this mock explicitly.
+vi.mock("../src/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/config.js")>()),
+  tierConfigured: vi.fn(() => ({ tier1: true, tier2: true, tier3: true })),
+}));
+
 vi.mock("../src/cache.js", () => ({
   cacheGet: vi.fn(),
   cacheSet: vi.fn(),

--- a/tests/fetch-lite-mode.test.ts
+++ b/tests/fetch-lite-mode.test.ts
@@ -1,0 +1,206 @@
+// Lite mode, end to end through the real routing + real tier objects.
+//
+// The claim under test is negative and cannot be inferred from a green
+// cascade: with Firecrawl and Crawl4AI unconfigured, no connection to either
+// is *attempted*, and neither tier books an attempt in the domain database.
+// A fetch would succeed today either way — slowly, by falling through a failed
+// tier 1 — so asserting on the returned content proves nothing about the fix.
+//
+// Deliberately narrow mock surface: routing.js and tiers/index.js are REAL, so
+// the skip decisions and the tier objects under them are the shipped ones.
+// Only tiers/raw.js is stubbed, which leaves tier 1's real firecrawlScrape
+// wired to the real global fetch — the call this test asserts never happens.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/config.js")>()),
+  tierConfigured: vi.fn(),
+}));
+
+vi.mock("node:dns/promises", () => ({
+  lookup: () => Promise.resolve([{ address: "93.184.216.34", family: 4 }]),
+}));
+
+vi.mock("../src/cache.js", () => ({
+  cacheGet: vi.fn().mockResolvedValue(null),
+  cacheSet: vi.fn().mockResolvedValue(undefined),
+  fetchCacheKey: (url: string) => `fetch:${url}`,
+}));
+
+vi.mock("../src/domains.js", () => ({
+  getBlockList: vi.fn(() => []),
+  urlMatchesDomain: vi.fn(() => false),
+  getOperatorTierSkips: vi.fn(() => []),
+}));
+
+vi.mock("../src/domain-db.js", () => ({
+  recordTierAttempt: vi.fn().mockResolvedValue(undefined),
+  recordPostExtractSample: vi.fn().mockResolvedValue(undefined),
+  recordMetadataFetchAttempt: vi.fn().mockResolvedValue(undefined),
+  getDomainRecord: vi.fn().mockResolvedValue(null),
+  currentWindowStat: (s: unknown) => s,
+}));
+
+vi.mock("../src/events.js", () => ({
+  events: {
+    fetchRequested: vi.fn(),
+    fetchCompleted: vi.fn(),
+    fetchTierMiss: vi.fn(),
+    fetchTierSkipped: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../src/observability.js", () => ({
+  incCounter: vi.fn(),
+  recordHistogram: vi.fn(),
+  withSpan: (_name: string, _attrs: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("../src/robots.js", () => ({
+  checkRobots: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+
+vi.mock("../src/hister.js", () => ({
+  histerFetch: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../src/kiwix.js", () => ({
+  isKiwixHost: vi.fn(() => false),
+  kiwixFetch: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../src/llms-txt.js", () => ({
+  tryLlmsTxtFetch: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../src/content-type.js", () => ({
+  probeStructuredContent: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../src/reddit.js", () => ({
+  isRedditHost: vi.fn(() => false),
+  redditFetch: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../src/extractors/post-extract.js", () => ({
+  postExtract: (r: { baselineTitle: string; baselineText: string }) => ({
+    title: r.baselineTitle,
+    text: r.baselineText,
+    source: "baseline",
+    jsonLdPresent: false,
+  }),
+}));
+
+// Tier 3 only. Tier 1 and tier 2 keep their real implementations so that an
+// attempt by either one is observable as a real outbound fetch.
+vi.mock("../src/tiers/raw.js", () => ({
+  rawFetch: vi.fn().mockResolvedValue({
+    title: "Example Domain",
+    url: "https://example.com/article",
+    text: "served by tier 3",
+    html: "<html><body>served by tier 3</body></html>",
+  }),
+  fetchRawHtmlForMetadata: vi.fn().mockResolvedValue(null),
+}));
+
+import { FIRECRAWL_URL, tierConfigured } from "../src/config.js";
+import { recordTierAttempt } from "../src/domain-db.js";
+import { fetchPage } from "../src/fetch.js";
+import { incCounter } from "../src/observability.js";
+
+const tierConfiguredMock = vi.mocked(tierConfigured);
+const recordTierAttemptMock = vi.mocked(recordTierAttempt);
+const incCounterMock = vi.mocked(incCounter);
+
+const URL_UNDER_TEST = "https://example.com/article";
+
+/** Every URL global fetch was called with during the case. */
+let fetchTargets: string[] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchTargets = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation(((input: RequestInfo) => {
+    fetchTargets.push(String(input));
+    // Anything that gets here in lite mode is the failure the test exists to
+    // catch, so fail it the way a dead service would rather than hanging.
+    return Promise.reject(new Error("ECONNREFUSED"));
+  }) as typeof fetch);
+});
+
+describe("lite mode — tier1 and tier2 unconfigured", () => {
+  beforeEach(() => {
+    tierConfiguredMock.mockReturnValue({
+      tier1: false,
+      tier2: false,
+      tier3: true,
+    });
+  });
+
+  it("serves content from tier 3", async () => {
+    const out = await fetchPage(URL_UNDER_TEST);
+    expect(out.text).toContain("served by tier 3");
+  });
+
+  it("attempts no connection to Firecrawl", async () => {
+    await fetchPage(URL_UNDER_TEST);
+    expect(fetchTargets.filter((u) => u.startsWith(FIRECRAWL_URL))).toEqual([]);
+  });
+
+  // The stat-pollution fix. A skipped tier is not an attempt, so nothing may
+  // reach the domain database on its behalf — those same numbers feed the
+  // low_success_rate routing pass and domain_stats.
+  it("books no domain-db attempt for either skipped tier", async () => {
+    await fetchPage(URL_UNDER_TEST);
+    const tiersRecorded = recordTierAttemptMock.mock.calls.map((c) => c[1]);
+    expect(tiersRecorded).not.toContain("tier1_firecrawl");
+    expect(tiersRecorded).not.toContain("tier2_crawl4ai");
+    expect(tiersRecorded).toContain("tier3_rawfetch");
+  });
+
+  it("counts both skips with their reason", async () => {
+    await fetchPage(URL_UNDER_TEST);
+    const skipped = incCounterMock.mock.calls.filter(
+      (c) => (c[1] as { outcome?: string })?.outcome === "skipped",
+    );
+    expect(skipped.map((c) => c[1])).toEqual(
+      expect.arrayContaining([
+        {
+          tier: "tier1_firecrawl",
+          outcome: "skipped",
+          reason: "not_configured",
+        },
+        {
+          tier: "tier2_crawl4ai",
+          outcome: "skipped",
+          reason: "not_configured",
+        },
+      ]),
+    );
+  });
+});
+
+// Negative control. Without this, every assertion above would still pass if
+// the cascade never ran at all, or if fetchPage short-circuited before the
+// tiers for some unrelated reason.
+describe("negative control — tier1 configured", () => {
+  beforeEach(() => {
+    tierConfiguredMock.mockReturnValue({
+      tier1: true,
+      tier2: false,
+      tier3: true,
+    });
+  });
+
+  it("does attempt Firecrawl, and books the failed attempt", async () => {
+    await fetchPage(URL_UNDER_TEST);
+    expect(
+      fetchTargets.filter((u) => u.startsWith(FIRECRAWL_URL)).length,
+    ).toBeGreaterThan(0);
+    expect(recordTierAttemptMock.mock.calls.map((c) => c[1])).toContain(
+      "tier1_firecrawl",
+    );
+  });
+});

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1,5 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// These suites exercise the operator-override and stats passes, which are
+// orthogonal to whether a tier is configured at all. Pin a fully-configured
+// baseline so every pre-existing assertion keeps meaning what it meant before
+// `not_configured` existed — CRAWL4AI_URL is unset in the test env, which would
+// otherwise skip tier2 in every case here and hide what these cases check.
+// The not_configured pass has its own cases, which drive this mock explicitly.
+vi.mock("../src/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/config.js")>()),
+  tierConfigured: vi.fn(() => ({ tier1: true, tier2: true, tier3: true })),
+}));
+
 vi.mock("../src/cache.js", () => ({
   cacheGet: vi.fn(),
   cacheSet: vi.fn(),
@@ -10,6 +21,7 @@ vi.mock("../src/domains.js", () => ({
 }));
 
 import { cacheGet } from "../src/cache.js";
+import { tierConfigured } from "../src/config.js";
 import type { DomainRecord } from "../src/domain-db.js";
 import { getOperatorTierSkips } from "../src/domains.js";
 import { computeTierSkips } from "../src/routing.js";
@@ -237,5 +249,122 @@ describe("computeTierSkips", () => {
   it("returns no skips when no record exists and no operator overrides", async () => {
     cacheGetMock.mockResolvedValue(null);
     expect(await computeTierSkips("https://example.com/p")).toEqual([]);
+  });
+});
+
+// The `not_configured` pass. Unlike the two passes above, this one is a
+// property of the deployment rather than of the domain, which is why it is
+// seeded before them and cannot be overridden.
+describe("computeTierSkips — not_configured", () => {
+  const tierConfiguredMock = vi.mocked(tierConfigured);
+
+  beforeEach(() => {
+    cacheGetMock.mockReset();
+    cacheGetMock.mockResolvedValue(null);
+    getOpSkipMock.mockReset();
+    getOpSkipMock.mockReturnValue([]);
+    tierConfiguredMock.mockReturnValue({
+      tier1: true,
+      tier2: true,
+      tier3: true,
+    });
+  });
+
+  it("produces zero not_configured skips when every tier is configured", async () => {
+    expect(await computeTierSkips("https://example.com/p")).toEqual([]);
+  });
+
+  it("skips tier1 when Firecrawl is disabled", async () => {
+    tierConfiguredMock.mockReturnValue({
+      tier1: false,
+      tier2: true,
+      tier3: true,
+    });
+    expect(await computeTierSkips("https://example.com/p")).toEqual([
+      { tier: "tier1", reason: "not_configured" },
+    ]);
+  });
+
+  it("skips tier2 when Crawl4AI is unconfigured", async () => {
+    tierConfiguredMock.mockReturnValue({
+      tier1: true,
+      tier2: false,
+      tier3: true,
+    });
+    expect(await computeTierSkips("https://example.com/p")).toEqual([
+      { tier: "tier2", reason: "not_configured" },
+    ]);
+  });
+
+  it("leaves tier3 active in a fully unconfigured deployment", async () => {
+    tierConfiguredMock.mockReturnValue({
+      tier1: false,
+      tier2: false,
+      tier3: true,
+    });
+    const skips = await computeTierSkips("https://example.com/p");
+    expect(skips).toEqual([
+      { tier: "tier1", reason: "not_configured" },
+      { tier: "tier2", reason: "not_configured" },
+    ]);
+    expect(skips.some((s) => s.tier === "tier3")).toBe(false);
+  });
+
+  // The precedence rule. An operator override cannot un-skip an unconfigured
+  // tier, because there is nothing to call — so the reason must stay
+  // not_configured rather than being relabelled by a later pass.
+  it("wins over an operator override for the same tier", async () => {
+    tierConfiguredMock.mockReturnValue({
+      tier1: false,
+      tier2: true,
+      tier3: true,
+    });
+    getOpSkipMock.mockReturnValue(["tier1"]);
+    expect(await computeTierSkips("https://example.com/p")).toEqual([
+      { tier: "tier1", reason: "not_configured" },
+    ]);
+  });
+
+  // Same precedence against the stats pass: an unconfigured tier that also has
+  // a terrible historical success rate is reported as not_configured, since
+  // that is the actionable cause.
+  it("wins over a low_success_rate skip for the same tier", async () => {
+    tierConfiguredMock.mockReturnValue({
+      tier1: false,
+      tier2: true,
+      tier3: true,
+    });
+    cacheGetMock.mockResolvedValue(
+      JSON.stringify(
+        record({
+          tier_stats_30d: {
+            tier1: stat(20, 4, 16), // 20% success rate
+            tier2: stat(0, 0, 0),
+            tier3: stat(0, 0, 0),
+            tier4: stat(0, 0, 0),
+            github: stat(0, 0, 0),
+            solver: stat(0, 0, 0),
+          },
+        }),
+      ),
+    );
+    expect(await computeTierSkips("https://example.com/p")).toEqual([
+      { tier: "tier1", reason: "not_configured" },
+    ]);
+  });
+
+  it("combines a not_configured tier with an operator override on another", async () => {
+    tierConfiguredMock.mockReturnValue({
+      tier1: false,
+      tier2: true,
+      tier3: true,
+    });
+    getOpSkipMock.mockReturnValue(["tier2"]);
+    expect(await computeTierSkips("https://example.com/p")).toEqual(
+      expect.arrayContaining([
+        { tier: "tier1", reason: "not_configured" },
+        { tier: "tier2", reason: "operator_override" },
+      ]),
+    );
   });
 });


### PR DESCRIPTION
Build `searxng-mcp-lite-mode-2026-09` — tracker vikunja#636.

`README.md:160` claimed "SearXNG and Firecrawl are required" while `README.md:16` correctly said only SearXNG is. The stricter claim was wrong: `runTier` converts every tier failure into a miss rather than a fatal, and tier 3 is a raw HTTP fetch plus Readability running wholly in-process. Two real code defects sat behind the doc fix.

## Tier 1 had no unconfigured guard, unlike tier 2

`firecrawlScrape` always attempted `FIRECRAWL_URL`, so a Firecrawl-less deployment paid a failed connection on every fetch — cheap on loopback (ECONNREFUSED), but a routable-but-dead host costs the full 15s `AbortSignal.timeout`.

## Unconfigured tiers polluted the domain capability database

Tier 2's null return still booked a `miss` through `runTier`, so `tier_stats_30d` accumulated failures meaning "not deployed" rather than "tried and failed" — and those same numbers drive `computeTierSkips` routing and `domain_stats` output, so this was never cosmetic.

Three lite-mode fetches, measured before and after against a throwaway Valkey:

| | tier1 | tier2 | tier3 |
|---|---|---|---|
| before (main) | 3 attempts / 3 fail | 3 attempts / 3 fail | 3 / 3 ok |
| after | 0 | 0 | 3 / 3 ok |

At ten attempts those fabricated failures would have crossed the 30% threshold and started skipping tiers on the strength of a service that was never installed.

## Approach

`not_configured` becomes a third `SkipReason` alongside `operator_override` and `low_success_rate`, so unconfigured tiers route through the existing skip machinery — the `searxng.fetch.tier.skipped` event, the `searxng_fetch_total{outcome=skipped}` counter, the routing filter — rather than a parallel gate. **That reuse is the stat fix**: a skipped tier is never recorded as an attempt. `not_configured` takes precedence over both other reasons, since an override cannot un-skip a tier there is nothing to call.

Gated on `FIRECRAWL_ENABLED` / `CRAWL4AI_ENABLED`, both defaulting to `true` and read as `!== "false"`, matching the existing `YOUTUBE_TRANSCRIPT_ENABLED` / `REDDIT_FASTPATH_ENABLED` convention. Deliberately **not** derived from whether `FIRECRAWL_URL` was explicitly set — it defaults to `http://localhost:3002`, so sniffing the env var would have silently disabled tier 1 for anyone already running Firecrawl on the default port. That is a breaking change dressed as a fix.

Also adds a startup capability line and labels the `skipped` counter with its reason.

## The one behaviour change, which is the point of the build

With `CRAWL4AI_URL` unset, tier 2 goes from *attempted → returns null → books a miss* to *skipped → books nothing*. No outbound call changes: `crawl4aiFetch` already returned `null` without touching the network, so fetch results are byte-identical. What changes is the stats and the log line — which is the defect being fixed. A deployment that sets neither switch and *does* have `CRAWL4AI_URL` behaves exactly as v3.19.1.

## Verification

- `pnpm test` 728 passed / 6 skipped, no type errors; `pnpm lint` clean; `pnpm build` clean.
- **No connection attempted to Firecrawl in lite mode**, asserted against a stub listener counting hits — 0 in lite mode, **1 with the switch left on as the negative control**. A passing fetch alone proves nothing here, since a fetch succeeds either way by falling through a failed tier 1.
- The domain-db before/after above, run against a throwaway Valkey container rather than the production cache.
- Five mutants introduced and all five caught: operator pass overwriting `not_configured`, tier 2 ignoring `CRAWL4AI_URL`, switches defaulting off, tier 3 becoming switchable, and the counter losing its `reason` label.

The startup line reports **configuration, never reachability** — nothing is probed, so it cannot delay or fail startup:

```
[searxng-mcp] capabilities on=tier3,cache,reranker off=tier1,tier2,llm,kiwix,hister,solver,wayback,otel,nats
```

## Out of scope

Multi-instance failover, `pageno` and `min_score` came out of the same competitive review and are deliberately excluded — they all land in `src/search.ts`/`src/reranker.ts` and collide with each other. Plan B, tracked at vikunja#144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)