### PR TITLE
Search hardening: domain_stats contract, SearXNG failover, min_score, histogram labels (v3.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,23 @@ interpretable, and fixes the `domain_stats` output-schema contract so it cannot 
 - `ajv` is now an explicit devDependency. It was reachable only as an auto-installed peer of the
   MCP SDK, which is not a dependency the new schema-contract tests should rest on.
 
+### Security
+
+- **Basic-auth credentials in `SEARXNG_URL` are extracted into an `Authorization` header.** Found by
+  the security audit of this build. Node's `fetch` refuses a URL containing userinfo *synchronously*,
+  before any network I/O, and embeds the whole URL — password included — in the resulting
+  `TypeError`'s own message. So a credentialed instance had two problems at once: it could never
+  serve a single search, and the password reached every sink that forwards an error message. That
+  is the stderr failover line, the `search.failover` NATS event, the generic `error` event (which
+  fires on the single-instance path too), the OTel span exported over OTLP, and the error returned
+  to the calling agent. Credentials are now lifted out at parse time, so `SEARXNG_URLS` is
+  credential-free by construction, and error messages are scrubbed at the generic sinks rather than
+  at each call site.
+
+  The test that was supposed to cover this mocked `fetch`'s rejection as a generic `Error`, whose
+  message can never contain a URL — it asserted the right property against the wrong failure shape.
+  The replacement mocks nothing: real `fetch`, real servers, real refused connections.
+
 ### Not included
 - **`pageno`** was descoped and is tracked as vikunja#639. Pool-and-slice is the right design, but
   it makes the pool size depend on the requested page, and the cached value records no pool size —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,115 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.21.0] - 2026-09-03
+
+Search hardening (build `searxng-mcp-search-hardening-2026-09`, vikunja#144; closes vikunja#637).
+Closes the last hard single point of failure, adds a relevance floor, makes the search histogram
+interpretable, and fixes the `domain_stats` output-schema contract so it cannot drift again.
+
+### Added
+- **Multi-instance SearXNG failover** (vikunja#144). `SEARXNG_URL` now accepts an ordered list of
+  interchangeable replicas separated by `,` or `;`. Both separators are taken because the
+  comparable server (`ihor-sokoliuk/mcp-searxng`) documents `;`, and accepting only one would
+  silently collapse that syntax into a single bogus instance. **A scalar value behaves exactly as
+  before** — one request, one host, no health lookup, no added cache traffic, same 10s bound.
+  Three properties worth knowing:
+  - The timeout budget is **total, not per instance** (`SEARXNG_TOTAL_TIMEOUT_MS`, default 10000,
+    with `SEARXNG_ATTEMPT_TIMEOUT_MS` as a per-instance ceiling). Iterating N replicas at 10s each
+    would make a total outage take *longer* to report the more replicas you added.
+  - Health state lives in the cache rather than in process memory, so one process's discovery of a
+    dead instance informs the next call. It deprioritises, never removes: a failed instance goes to
+    the back for `SEARXNG_UNHEALTHY_TTL_SECONDS` (default 30), and if every instance is marked down
+    the full list is still tried. Fail-soft — a cache outage degrades to "try every instance in
+    configured order", never to an error.
+  - Failover is **loud**: a `search.failover` NATS event plus a throttled stderr line. A silent
+    failover is indistinguishable from a healthy primary, which is how a half-dead deployment goes
+    unnoticed for weeks.
+
+  Fan-out is deliberately not implemented — it needs meta reconciliation with no obvious right
+  answer (if two instances return different `answers`/`infoboxes`, which wins?), and `searxSearch`
+  already merges across expanded query variants.
+- **`min_score`** on `search`, `search_and_fetch` and `search_and_summarize`: a relevance floor
+  applied after reranking, absent by default. It filters on the **raw cross-encoder
+  `relevance_score`**, not on the value used for ordering — that sort key is
+  `relevance_score + RERANK_RECENCY_WEIGHT * recencyScore(...)`, which with the default weight of
+  0.15 ranges over 0–1.15, so filtering a "minimum relevance" parameter on it would quietly make it
+  mean "relevant enough *or* recent enough". Filtering runs before the top-N slice, so the floor
+  never costs a result that cleared it.
+
+  Two measured caveats are in the parameter description and the README, because without them the
+  knob is misleading. Probed against the local FlashRank service on "how to configure nginx reverse
+  proxy": nginx reverse-proxy guide 0.998, Apache `mod_proxy` 0.967, nginx install page 0.0028,
+  banana bread recipe 0.0000151. The distribution is strongly bimodal, so anything in roughly
+  0.01–0.9 behaves the same and **0.5 is not a midpoint** (use 0.01–0.1); and a high score means
+  topically *related*, not correct — an Apache page scored 0.967 on an nginx query. Thresholds are
+  model-dependent and not comparable across rerankers. With the reranker unavailable `min_score`
+  becomes a no-op with a throttled warning, since returning unfiltered results silently would imply
+  a floor that was never applied.
+- **A `tool` label on the search histogram and counter.** All three search tools record into one
+  `search` histogram that carried only `profile`, and their normal ranges differ by roughly 3x — a
+  plain `search` is bounded around ~17.5s while `search_and_summarize` routinely reaches ~50s. The
+  observed 7-day maximum of 51.6s was therefore uninterpretable: routine for one tool, alarming for
+  another.
+
+### Fixed
+- **`domain_stats` was dead on every call** from a solver-enabled deployment (vikunja#637), failing
+  with `Additional properties are not allowed ('solver' was unexpected)` since v3.19.0.
+
+  The root cause was not a missing key. The payload is *derived* from `TIER_SLOT_KEYS` in both tool
+  modes, while `AllTiersOutputSchema` hand-listed five of the six slots — so the fix is to derive
+  the schema from the same constant rather than to add `solver` to the list, which would have
+  guaranteed a repeat at the next tier slot. Every slot is now optional: `tier4` requires
+  `WAYBACK_ENABLED` and `solver` requires `SOLVER_ENABLED`, so making them required only inverts
+  which deployments break — `tier4` already carried this defect latently.
+
+  `DomainRecord["tier_stats_30d"]` is now also derived from `TIER_SLOT_KEYS`. It was a third
+  hand-maintained copy of the same closed set, with `newRecord()` as a fourth; as a mapped type the
+  compiler rejects any writer that misses a slot.
+
+  735 tests were green while the tool was 100% dead, because the three `domain_stats` assertions use
+  `toMatchObject`, which is non-exhaustive. The new test does **not** use `.parse()`, and that is
+  the point: server-side the SDK calls zod's `safeParseAsync`, and `z.object()` is *strip*, not
+  *strict* — it silently drops an unrecognised key and succeeds. A `.parse()` test would have passed
+  on the broken build. What actually rejected the call was the client validating against the
+  advertised JSON Schema, so the tests validate real payloads against
+  `toJsonSchemaCompat(...)` using the SDK's own converter and validator.
+- **Search latency is now recorded on the failure path.** The `catch` previously incremented only
+  `errors_total`, so a search that failed after 40s and one that failed instantly were
+  indistinguishable — precisely the question this histogram was consulted about during the 300s
+  stall. Errors carry `outcome: "error"` rather than being folded in unlabelled, so they do not skew
+  the success p99.
+
+  **This does not make the histogram able to see a hang, and does not claim to.** Both the success
+  and failure recordings happen after `await fn()` settles, so a call that never returns still
+  records nothing at all. Closing that gap needs a watchdog timer independent of the awaited
+  promise, which is out of scope here.
+- **Four pre-containerization claims in the README**, each checked against the running container:
+  `schema_version 5` (it is 6, and the same paragraph already described the 5→6 bump); "runs as
+  several concurrent per-agent stdio children" (one shared container since vikunja#149/#321);
+  "stderr is the only telemetry sink wired on the deployed PM2 process" (wrong twice — the
+  deployment is Docker, and OTel and NATS are both wired); and "clean PM2 restart" (the container
+  runs `restart: unless-stopped`). `src/log.ts` carried the same stale claim in its header comment
+  and is fixed too.
+
+### Changed
+- `SEARXNG_URL` entries that are not valid http(s) URLs are dropped with a warning rather than used
+  verbatim. This catches an unset `${SEARXNG_URL}` interpolating to the *literal* placeholder rather
+  than to empty. If no entry survives, the default is used and said so loudly — refusing to boot
+  would turn one bad env var into a total outage. Repeated entries are de-duplicated so a repeat
+  cannot spend the shared timeout budget twice on a host that just failed.
+- `ajv` is now an explicit devDependency. It was reachable only as an auto-installed peer of the
+  MCP SDK, which is not a dependency the new schema-contract tests should rest on.
+
+### Not included
+- **`pageno`** was descoped and is tracked as vikunja#639. Pool-and-slice is the right design, but
+  it makes the pool size depend on the requested page, and the cached value records no pool size —
+  so a page-1 entry cannot be distinguished from an exhausted one. That is a cache-schema change
+  with back-compat implications, not a parameter addition, and it deserves its own audit rather
+  than riding along at the tail of this branch. The ticket carries the live measurements taken
+  during the assessment (SearXNG returns 32 results on page 1 and 20 thereafter, so the current
+  `min(numResults * 3, 20)` cap — not SearXNG's page size — is the binding constraint).
+
 ## [3.20.0] - 2026-09-03
 
 Only SearXNG is required, and the code now says so as well as the README (build

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ For a full local topology including Firecrawl, Crawl4AI, Ollama, Kiwix, the adbl
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `search` | Search via SearXNG with local reranking. Fetches a wider result pool, reranks by relevance, returns top N. SearXNG's native direct answers, infoboxes, spelling corrections, and related suggestions are surfaced above the list and in `structuredContent`. | `query`, `num_results` (1–20), `category`, `time_range`, `domain_profile`, `expand`, `language`, `engines`, `site` |
-| `search_and_fetch` | Search, rerank, then fetch full content of the top result(s) using the fetch cascade (Firecrawl → Crawl4AI → raw HTTP). | `query`, `category`, `time_range`, `fetch_count` (1–3), `domain_profile`, `expand`, `language`, `engines`, `site` |
-| `search_and_summarize` | Search, fetch top results, then synthesize a summary with citations via Ollama (`OLLAMA_SUMMARIZE_MODEL`). Falls back to raw fetched content if Ollama is unavailable. | `query`, `fetch_count` (1–5), `category`, `time_range`, `domain_profile`, `expand`, `language`, `engines`, `site` |
+| `search` | Search via SearXNG with local reranking. Fetches a wider result pool, reranks by relevance, returns top N. SearXNG's native direct answers, infoboxes, spelling corrections, and related suggestions are surfaced above the list and in `structuredContent`. | `query`, `num_results` (1–20), `category`, `time_range`, `domain_profile`, `expand`, `language`, `engines`, `site`, `min_score` |
+| `search_and_fetch` | Search, rerank, then fetch full content of the top result(s) using the fetch cascade (Firecrawl → Crawl4AI → raw HTTP). | `query`, `category`, `time_range`, `fetch_count` (1–3), `domain_profile`, `expand`, `language`, `engines`, `site`, `min_score` |
+| `search_and_summarize` | Search, fetch top results, then synthesize a summary with citations via Ollama (`OLLAMA_SUMMARIZE_MODEL`). Falls back to raw fetched content if Ollama is unavailable. | `query`, `fetch_count` (1–5), `category`, `time_range`, `domain_profile`, `expand`, `language`, `engines`, `site`, `min_score` |
 | `fetch_url` | Fetch and extract readable markdown from any public URL. GitHub hosts take the GitHub fast path; YouTube video URLs return the transcript and Reddit thread URLs return post+comments (both opt-in via robots, see below); all others use the fetch cascade (Firecrawl → Crawl4AI → raw HTTP). Trimmed to a token budget (default ~8,000 chars). | `url`, `domain_profile`, `max_tokens`, `target_selector`, `wait_for_selector` |
 | `crawl_site` | Crawl an entire site and return a manifest of URL/title/snippet for each page. Tries Firecrawl crawl first, falls back to sitemap parsing, then optional BFS. Full page content is cached in Valkey so follow-up `fetch_url` calls are zero-cost. | `url`, `max_pages` (default: `CRAWL_MAX_PAGES_DEFAULT`), `bfs` (bool, opt-in BFS) |
 | `clear_cache` | Purge the search cache, fetch cache, crawl manifest cache, or all. Useful when researching fast-moving topics where cached results may be stale. | `target` (`search`, `fetch`, `crawl`, `all`) |
@@ -244,7 +244,7 @@ Guarantees:
 
 ### Domain capability database
 
-Every fetch records what searxng-mcp learns about the target domain to Valkey under `domain:<hostname>` (90-day TTL, schema_version 5). Captured per record:
+Every fetch records what searxng-mcp learns about the target domain to Valkey under `domain:<hostname>` (90-day TTL, schema_version 6). Captured per record:
 
 - `tier_stats_30d.{tier1,tier2,tier3,tier4,solver,github}.{attempts, ok, fail, last_fail_reason, window_start_ms}` — fetch success rate per tier over a rolling 30-day window. The cutoff is applied at **read time**, shared by tier-routing decisions and `domain_stats` reporting, so the two cannot disagree — a domain fetched once and then left idle reports a genuinely empty window rather than stale numbers surviving until the next write. The `tier4` (Wayback Machine) slot is recorded only when `WAYBACK_ENABLED=true`; the `solver` slot (Byparr challenge-solving tier, see [Challenge detection and solver tier](#challenge-detection-and-solver-tier)) only when `SOLVER_ENABLED=true`. The `github` slot records the [GitHub fast path](#github-urls) (`raw.githubusercontent.com` / `api.github.com` / `github.com` README fetches), which bypasses the tier cascade but is still tracked here. A `schema_version` bump rebuilds existing records fresh — accumulated windows for currently-idle domains are discarded (precedented across the 1→2, 2→3, 3→4, 4→5, 5→6 bumps).
 - `capabilities.metadata_fetch.{attempts, ok, fail, last_fail_reason}` — success/failure of the metadata side-channel fetch (`fetchRawHtmlForMetadata`, used for JSON-LD/og:title sampling). Tracked separately from `tier_stats_30d` since it answers "is this domain reachable at all", not "did full-content delivery succeed".
@@ -274,7 +274,7 @@ pnpm domain-db-maintenance   # SCAN all domain:* records → write a dated JSON 
 pnpm restore-domain-db       # re-seed the domain-db from the newest snapshot after a flush
 ```
 
-- **`domain-db-maintenance`** is a standalone job (run it on a schedule via cron or a PM2 cron-restart — **not** as an in-process timer, since searxng-mcp runs as several concurrent per-agent stdio children that would each fire it). One bounded `SCAN` feeds both outputs: a durable dated snapshot and, when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, gauges (`searxng_domains_tracked`, `searxng_domains_failing`, `searxng_domain_tier_success_ratio{tier}`) force-flushed before exit.
+- **`domain-db-maintenance`** is a standalone job — run it on a schedule via cron or a container cron sidecar, **not** as an in-process timer. (The original reason was that searxng-mcp ran as several concurrent per-agent stdio children that would each fire the timer. That is no longer true: since vikunja#149/#321 it is one shared container. The conclusion still holds for a different reason — an in-process timer ties a bounded full-keyspace `SCAN` to the lifetime of the request-serving process, whereas a standalone job can be scheduled, retried and observed on its own.) One bounded `SCAN` feeds both outputs: a durable dated snapshot and, when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, gauges (`searxng_domains_tracked`, `searxng_domains_failing`, `searxng_domain_tier_success_ratio{tier}`) force-flushed before exit.
 - **`restore-domain-db`** re-seeds only keys that are missing or whose live record is strictly staler than the snapshot (compares `last_fetch`) — it never clobbers a fresher-or-equal live record, so it is safe to run against a live, partially-populated Valkey (e.g. in a service boot sequence for automatic flush recovery).
 
 | Env var | Default | Purpose |
@@ -368,10 +368,37 @@ After any tier returns content with raw HTML, a post-extraction pass improves ti
 - **Title cascade** — falls back through `og:title` → `twitter:title` → `<title>` (with publisher-suffix stripping) → first `<h1>` → URL.
 - **Tier-2 Readability comparison** — when Crawl4AI returns markdown, JSDOM+Readability also runs over its raw HTML and is preferred when its text is longer (or unconditionally when Crawl4AI returns less than 500 chars).
 
+### Relevance filtering (`min_score`)
+
+The three search tools accept `min_score` (0–1), a floor applied after reranking. Omit it and nothing changes.
+
+It filters on the **raw cross-encoder `relevance_score`**, not on the value used for ordering. Ranking sorts by `relevance_score + RERANK_RECENCY_WEIGHT * recencyScore(publishedDate)`, which with the default weight of `0.15` ranges over **0–1.15, not 0–1**. Filtering a parameter called "minimum relevance" on that number would quietly make it mean "relevant enough *or* recent enough". Filtering happens before the top-N slice, so the floor never costs you a result that cleared it.
+
+Two things make this knob behave differently from how a 0–1 range suggests. Both were measured against the local FlashRank service on the query *"how to configure nginx reverse proxy"*:
+
+| Document | `relevance_score` |
+|---|---|
+| nginx reverse-proxy guide (`proxy_pass`) | **0.998** |
+| Apache `mod_proxy` reverse proxying | **0.967** |
+| nginx install page (topical, wrong subject) | **0.0028** |
+| banana bread recipe | **0.0000151** |
+
+- **The distribution is strongly bimodal.** Relevant results cluster near 1.0, irrelevant ones near 0, with very little in between — so any threshold in roughly 0.01–0.9 behaves near-identically. Useful values are around **0.01–0.1**; `0.5` is not a meaningful midpoint.
+- **A high score means topically related, not correct.** The Apache document scored 0.967 on an nginx query. `min_score` is a topicality floor and cannot be trusted as a correctness filter.
+
+Thresholds are model-dependent and not comparable across rerankers. When the reranker is unavailable there are no scores to filter on, so `min_score` becomes a **no-op with a throttled warning** — returning unfiltered results silently would let you believe a floor had been applied, and returning nothing would turn a reranker outage into "no results found".
+
 ### Resilience
 
-- **Cache never hangs a search.** The Valkey client is bounded by `CACHE_COMMAND_TIMEOUT_MS`/`CACHE_CONNECT_TIMEOUT_MS`/`CACHE_MAX_RETRIES_PER_REQUEST` (see [Configuration](#configuration)). A stalled or CPU-spiked cache backend now rejects the command instead of hanging forever — the existing fail-soft handling degrades that rejection to a cache miss (serve live) rather than throwing. Cache connect failures, client errors, and per-command errors emit a throttled `[searxng-mcp]` stderr line (deduped per key so a sustained outage leaves a periodic breadcrumb, not a flood) — stderr is the only telemetry sink wired on the deployed PM2 process.
-- **Process crash handlers** — `uncaughtException` logs then exits 1 (clean PM2 restart); `unhandledRejection` logs and continues rather than crashing the shared process silently.
+- **Multi-instance SearXNG failover.** `SEARXNG_URL` accepts a list of interchangeable replicas (`,` or `;` separated), tried in order. A single value behaves exactly as before — one request, one host, no health lookup, no extra cache traffic. Three things about the multi-instance path are worth knowing:
+  - The timeout budget is **total, not per instance**. `SEARXNG_TOTAL_TIMEOUT_MS` bounds the whole call and is decremented as candidates fail, so adding a replica cannot make a total outage take longer to report.
+  - Health state lives in the **cache, not in process memory**, so one process's discovery of a dead instance informs the next call. It is a hint, not a circuit breaker: a failed instance is moved to the back of the order for `SEARXNG_UNHEALTHY_TTL_SECONDS`, never removed, and if every instance is marked down the full list is tried anyway. A cache outage degrades to "try every instance in configured order" — never to an error.
+  - **Failover is loud.** Each fall-through emits a `search.failover` NATS event and a throttled stderr line. A silent failover is indistinguishable from a healthy primary, which is how a half-dead deployment goes unnoticed for weeks.
+
+  Fan-out (querying replicas in parallel and merging) is deliberately **not** implemented: it needs meta reconciliation with no obvious right answer — if two instances return different `answers`/`infoboxes`, which wins? `searxSearch` already merges across expanded query variants, so the marginal recall gain is small.
+
+- **Cache never hangs a search.** The Valkey client is bounded by `CACHE_COMMAND_TIMEOUT_MS`/`CACHE_CONNECT_TIMEOUT_MS`/`CACHE_MAX_RETRIES_PER_REQUEST` (see [Configuration](#configuration)). A stalled or CPU-spiked cache backend now rejects the command instead of hanging forever — the existing fail-soft handling degrades that rejection to a cache miss (serve live) rather than throwing. Cache connect failures, client errors, and per-command errors emit a throttled `[searxng-mcp]` stderr line (deduped per key so a sustained outage leaves a periodic breadcrumb, not a flood) — stderr is always on, and is the sink that never depends on configuration. On the forge deployment OTel and NATS are also wired (`OTEL_EXPORTER_OTLP_ENDPOINT` and `NATS_URL` are both set, and the startup capability line reports `otel,nats` in its on-list), so stderr is the floor rather than the whole story.
+- **Process crash handlers** — `uncaughtException` logs then exits 1, so the supervisor restarts cleanly (Docker's `restart: unless-stopped` on the forge deployment); `unhandledRejection` logs and continues rather than crashing the shared process silently.
 - **Graceful-degradation warnings** — the reranker fallback and the Ollama/LLM expand + summarize fallbacks emit one throttled stderr line each when they silently degrade quality (reranker unavailable, LLM backend unreachable).
 - **Version is single-sourced** from `package.json` at runtime (`src/version.ts`) — the `McpServer` version, OTel tracer/meter version, and outbound `USER_AGENT` all track it, so they can't drift independently.
 
@@ -592,7 +619,10 @@ All service URLs are configurable via environment variables.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `SEARXNG_URL` | `http://localhost:8081` | SearXNG instance URL |
+| `SEARXNG_URL` | `http://localhost:8081` | SearXNG instance URL. Accepts a **list** of interchangeable replicas separated by `,` or `;` (e.g. `http://searxng-a:8080,http://searxng-b:8080`) — tried in order, with failover. A single value behaves exactly as before: one request, one host, no health lookup. Entries that are not valid http(s) URLs are dropped with a warning; if none survive the default is used rather than the server refusing to start. |
+| `SEARXNG_TOTAL_TIMEOUT_MS` | `10000` | Total timeout budget for one search **across all instances**, not per instance. Iterating N replicas at the per-attempt timeout each would make a total outage take longer to report the more replicas you add. |
+| `SEARXNG_ATTEMPT_TIMEOUT_MS` | `10000` | Per-instance ceiling, further capped by whatever remains of `SEARXNG_TOTAL_TIMEOUT_MS`. |
+| `SEARXNG_UNHEALTHY_TTL_SECONDS` | `30` | How long a failed instance is deprioritised for. A hint that reorders candidates, not a circuit breaker — an unhealthy instance is moved to the back, never removed, and if every instance is marked down the full list is still tried. Stored in the cache so the hint is shared across processes; a cache outage degrades to "try every instance in configured order". |
 | `FIRECRAWL_URL` | `http://localhost:3002` | Firecrawl instance URL |
 | `FIRECRAWL_ENABLED` | `true` | Set to `false` when no Firecrawl is deployed — tier 1 is then skipped with `reason: not_configured` instead of attempting a connection on every fetch |
 | `RERANKER_URL` | `http://localhost:8787` | Reranker instance URL |

--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ All service URLs are configurable via environment variables.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `SEARXNG_URL` | `http://localhost:8081` | SearXNG instance URL. Accepts a **list** of interchangeable replicas separated by `,` or `;` (e.g. `http://searxng-a:8080,http://searxng-b:8080`) — tried in order, with failover. A single value behaves exactly as before: one request, one host, no health lookup. Entries that are not valid http(s) URLs are dropped with a warning; if none survive the default is used rather than the server refusing to start. |
+| `SEARXNG_URL` | `http://localhost:8081` | SearXNG instance URL. Accepts a **list** of interchangeable replicas separated by `,` or `;` (e.g. `http://searxng-a:8080,http://searxng-b:8080`) — tried in order, with failover. A single value behaves exactly as before: one request, one host, no health lookup. Entries that are not valid http(s) URLs are dropped with a warning; if none survive the default is used rather than the server refusing to start. Basic-auth credentials may be embedded (`http://user:pass@host:8080`) — they are lifted out of the URL at startup and sent as an `Authorization: Basic` header, and never appear in logs, events, cache keys or error messages. |
 | `SEARXNG_TOTAL_TIMEOUT_MS` | `10000` | Total timeout budget for one search **across all instances**, not per instance. Iterating N replicas at the per-attempt timeout each would make a total outage take longer to report the more replicas you add. |
 | `SEARXNG_ATTEMPT_TIMEOUT_MS` | `10000` | Per-instance ceiling, further capped by whatever remains of `SEARXNG_TOTAL_TIMEOUT_MS`. |
 | `SEARXNG_UNHEALTHY_TTL_SECONDS` | `30` | How long a failed instance is deprioritised for. A hint that reorders candidates, not a circuit breaker — an unhealthy instance is moved to the back, never removed, and if every instance is marked down the full list is still tried. Stored in the cache so the hint is shared across processes; a cache outage degrades to "try every instance in configured order". |
@@ -802,6 +802,8 @@ stdio has no network surface. The HTTP transport binds `127.0.0.1` by default an
 CI runs `pnpm audit` on every push. The lockfile (`pnpm-lock.yaml`) is committed for reproducible, auditable builds.
 
 ### Credential handling
+
+Basic-auth credentials embedded in `SEARXNG_URL` are extracted at startup and sent as an `Authorization` header; the URL used for the request, for cache keys, for log lines, for NATS events and for error messages is always the credential-free origin. This matters more than it looks: Node's `fetch` refuses a URL containing userinfo outright and puts the whole URL — password included — into the resulting `TypeError`'s message, so leaving credentials in the URL would both break every request and leak the password into any sink that forwards an error message.
 
 No credentials are stored or logged by the server. API keys (`FIRECRAWL_API_KEY`, `GITHUB_TOKEN`, `CRAWL4AI_API_TOKEN`) are read from environment variables and used only in outbound requests to their respective services.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tadmstr/searxng-mcp",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "description": "MCP server for SearXNG — private web search for Claude Code",
   "main": "build/src/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/jsdom": "^28.0.3",
     "@types/node": "^22.20.1",
     "@vitest/coverage-v8": "^4.1.10",
+    "ajv": "^8.20.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { redactUrlCredentials } from "./log.js";
 import type { TierSlot } from "./types.js";
 
 const SEARXNG_URL_DEFAULT = "http://localhost:8081";
@@ -34,14 +35,18 @@ export function parseSearxngUrls(
     try {
       const u = new URL(entry);
       if (u.protocol !== "http:" && u.protocol !== "https:") {
-        warn(`SEARXNG_URL entry is not http(s), ignoring: ${entry}`);
+        warn(
+          `SEARXNG_URL entry is not http(s), ignoring: ${redactUrlCredentials(entry)}`,
+        );
         continue;
       }
       // Normalise away a trailing slash so `${base}/search` cannot become
       // `//search`, which some reverse proxies 404 rather than normalising.
       valid.push(u.toString().replace(/\/$/, ""));
     } catch {
-      warn(`SEARXNG_URL entry is not a valid URL, ignoring: ${entry}`);
+      warn(
+        `SEARXNG_URL entry is not a valid URL, ignoring: ${redactUrlCredentials(entry)}`,
+      );
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,16 +21,47 @@ const SEARXNG_URL_DEFAULT = "http://localhost:8081";
  * nonsense host. If nothing survives, fall back to the default and say so
  * loudly; refusing to boot would turn one bad env var into a total outage.
  */
-export function parseSearxngUrls(
+export interface SearxInstance {
+  /**
+   * The endpoint with any userinfo REMOVED. Safe to hand to `fetch()`, safe to
+   * log, safe to use as a cache key.
+   */
+  url: string;
+  /**
+   * `Basic <base64>` when the configured entry carried userinfo, else absent.
+   * Sent as an explicit header instead of being left in the URL.
+   */
+  authHeader?: string;
+}
+
+/**
+ * Parse `SEARXNG_URL` into instances, splitting any embedded basic-auth
+ * credentials out of the URL and into an `Authorization` header.
+ *
+ * THE SPLIT IS NOT COSMETIC — IT IS THE ONLY WAY A CREDENTIALED URL WORKS.
+ * The WHATWG Fetch spec forbids constructing a request from a URL containing
+ * userinfo, and Node's `fetch` enforces it:
+ *
+ *     fetch("http://user:pw@host/x")
+ *     -> TypeError: Request cannot be constructed from a URL that includes
+ *        credentials: http://user:pw@host/x
+ *
+ * That rejection is synchronous, happens before any network I/O, and embeds the
+ * full URL — password included — as the error's own `.message`. So leaving
+ * userinfo in the URL both (a) broke every search against such an instance and
+ * (b) fed the password into every sink that forwards an error message. Neither
+ * was caught by mocking `fetch`'s rejection as a generic `Error`.
+ */
+export function parseSearxngInstances(
   raw: string | undefined,
   warn: (msg: string) => void = () => {},
-): string[] {
+): SearxInstance[] {
   const entries = (raw ?? SEARXNG_URL_DEFAULT)
     .split(/[,;]/)
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 
-  const valid: string[] = [];
+  const valid: SearxInstance[] = [];
   for (const entry of entries) {
     try {
       const u = new URL(entry);
@@ -40,9 +71,22 @@ export function parseSearxngUrls(
         );
         continue;
       }
+
+      // Lift userinfo out of the URL before it can reach fetch() or any sink.
+      // `username`/`password` are percent-encoded by URL, so decode before
+      // base64 or a credential containing e.g. '@' would be sent wrong.
+      let authHeader: string | undefined;
+      if (u.username || u.password) {
+        const user = decodeURIComponent(u.username);
+        const pass = decodeURIComponent(u.password);
+        authHeader = `Basic ${Buffer.from(`${user}:${pass}`).toString("base64")}`;
+        u.username = "";
+        u.password = "";
+      }
+
       // Normalise away a trailing slash so `${base}/search` cannot become
       // `//search`, which some reverse proxies 404 rather than normalising.
-      valid.push(u.toString().replace(/\/$/, ""));
+      valid.push({ url: u.toString().replace(/\/$/, ""), authHeader });
     } catch {
       warn(
         `SEARXNG_URL entry is not a valid URL, ignoring: ${redactUrlCredentials(entry)}`,
@@ -50,23 +94,58 @@ export function parseSearxngUrls(
     }
   }
 
-  // De-duplicate: a repeated instance would be retried as though it were a
-  // distinct replica, burning the shared timeout budget on a host already known
-  // to have just failed.
-  const deduped = [...new Set(valid)];
+  // De-duplicate on the credential-free URL: a repeated instance would be
+  // retried as though it were a distinct replica, burning the shared timeout
+  // budget on a host already known to have just failed. First entry wins, so a
+  // credentialed entry is not silently replaced by a later bare one.
+  const seen = new Set<string>();
+  const deduped: SearxInstance[] = [];
+  for (const instance of valid) {
+    if (seen.has(instance.url)) continue;
+    seen.add(instance.url);
+    deduped.push(instance);
+  }
 
   if (deduped.length === 0) {
     warn(
       `SEARXNG_URL had no usable entries, falling back to ${SEARXNG_URL_DEFAULT}`,
     );
-    return [SEARXNG_URL_DEFAULT];
+    return [{ url: SEARXNG_URL_DEFAULT }];
   }
   return deduped;
 }
 
-export const SEARXNG_URLS = parseSearxngUrls(process.env.SEARXNG_URL, (m) =>
-  console.error(`[searxng-mcp] ${m}`),
+/** Convenience wrapper: just the credential-free endpoints, in order. */
+export function parseSearxngUrls(
+  raw: string | undefined,
+  warn: (msg: string) => void = () => {},
+): string[] {
+  return parseSearxngInstances(raw, warn).map((i) => i.url);
+}
+
+export const SEARXNG_INSTANCES = parseSearxngInstances(
+  process.env.SEARXNG_URL,
+  (m) => console.error(`[searxng-mcp] ${m}`),
 );
+
+/**
+ * Credential-free endpoints. Everything downstream — candidate ordering, cache
+ * keys, logs, events — deals only in these, so a credential cannot reach those
+ * paths by construction rather than by remembering to redact.
+ */
+export const SEARXNG_URLS = SEARXNG_INSTANCES.map((i) => i.url);
+
+const SEARXNG_AUTH_BY_URL = new Map(
+  SEARXNG_INSTANCES.filter((i) => i.authHeader).map((i) => [
+    i.url,
+    i.authHeader as string,
+  ]),
+);
+
+/** The `Authorization` header for an instance, if it was configured with one. */
+export function searxAuthHeader(url: string): string | undefined {
+  return SEARXNG_AUTH_BY_URL.get(url);
+}
 
 /**
  * The primary instance. Retained as a named export because it is what the

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,74 @@
 import type { TierSlot } from "./types.js";
 
-export const SEARXNG_URL = process.env.SEARXNG_URL ?? "http://localhost:8081";
+const SEARXNG_URL_DEFAULT = "http://localhost:8081";
+
+/**
+ * Parse `SEARXNG_URL` as an ordered list of interchangeable replicas.
+ *
+ * Accepts both `,` and `;` as separators — neither is legal in a URL authority,
+ * and the comparable server (`ihor-sokoliuk/mcp-searxng`) uses `;`, so taking
+ * both avoids a silent single-instance fallback for anyone copying that syntax.
+ *
+ * A SCALAR VALUE MUST BEHAVE EXACTLY AS BEFORE. That is every existing
+ * deployment, so it is the case this function is written around: one entry in,
+ * one entry out, no health lookup, one request. See `getSearxCandidates`.
+ *
+ * Unparseable entries are dropped with a warning rather than taken literally.
+ * An unset `${SEARXNG_URL}` in a manifest interpolates to the *literal* string
+ * `"${SEARXNG_URL}"` rather than to empty, and `new URL()` is what catches it —
+ * without this the server would come up and fail every search against a
+ * nonsense host. If nothing survives, fall back to the default and say so
+ * loudly; refusing to boot would turn one bad env var into a total outage.
+ */
+export function parseSearxngUrls(
+  raw: string | undefined,
+  warn: (msg: string) => void = () => {},
+): string[] {
+  const entries = (raw ?? SEARXNG_URL_DEFAULT)
+    .split(/[,;]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  const valid: string[] = [];
+  for (const entry of entries) {
+    try {
+      const u = new URL(entry);
+      if (u.protocol !== "http:" && u.protocol !== "https:") {
+        warn(`SEARXNG_URL entry is not http(s), ignoring: ${entry}`);
+        continue;
+      }
+      // Normalise away a trailing slash so `${base}/search` cannot become
+      // `//search`, which some reverse proxies 404 rather than normalising.
+      valid.push(u.toString().replace(/\/$/, ""));
+    } catch {
+      warn(`SEARXNG_URL entry is not a valid URL, ignoring: ${entry}`);
+    }
+  }
+
+  // De-duplicate: a repeated instance would be retried as though it were a
+  // distinct replica, burning the shared timeout budget on a host already known
+  // to have just failed.
+  const deduped = [...new Set(valid)];
+
+  if (deduped.length === 0) {
+    warn(
+      `SEARXNG_URL had no usable entries, falling back to ${SEARXNG_URL_DEFAULT}`,
+    );
+    return [SEARXNG_URL_DEFAULT];
+  }
+  return deduped;
+}
+
+export const SEARXNG_URLS = parseSearxngUrls(process.env.SEARXNG_URL, (m) =>
+  console.error(`[searxng-mcp] ${m}`),
+);
+
+/**
+ * The primary instance. Retained as a named export because it is what the
+ * startup capability line and any single-endpoint caller report; failover
+ * iterates `SEARXNG_URLS`.
+ */
+export const SEARXNG_URL = SEARXNG_URLS[0];
 export const FIRECRAWL_URL =
   process.env.FIRECRAWL_URL ?? "http://localhost:3002";
 export const FIRECRAWL_API_KEY =
@@ -44,6 +112,32 @@ export const CACHE_CONNECT_TIMEOUT_MS = positiveIntEnv(
   "CACHE_CONNECT_TIMEOUT_MS",
   3000,
 );
+// SearXNG failover tuning. Named to match the CACHE_*_TIMEOUT_MS convention
+// above, and defaulted so a single-instance deployment is bit-identical to the
+// pre-failover `AbortSignal.timeout(10000)`: one candidate, budget 10s,
+// per-attempt ceiling 10s, so exactly one 10s-bounded request.
+//
+// TOTAL is the whole-call budget, not per instance. Iterating N candidates at
+// 10s each would make the worst case N*10s with no ceiling — the caller would
+// see a search that hangs longer the more replicas you configure, which is the
+// opposite of what adding replicas is for.
+export const SEARXNG_TOTAL_TIMEOUT_MS = positiveIntEnv(
+  "SEARXNG_TOTAL_TIMEOUT_MS",
+  10_000,
+);
+export const SEARXNG_ATTEMPT_TIMEOUT_MS = positiveIntEnv(
+  "SEARXNG_ATTEMPT_TIMEOUT_MS",
+  10_000,
+);
+// How long a failed instance is deprioritised for. Short by design: this is a
+// hint to reorder candidates, not a circuit breaker. An instance that recovers
+// should be picked up again quickly, and a stale marker must never be able to
+// take a healthy instance out of rotation for long.
+export const SEARXNG_UNHEALTHY_TTL_SECONDS = positiveIntEnv(
+  "SEARXNG_UNHEALTHY_TTL_SECONDS",
+  30,
+);
+
 export const CACHE_MAX_RETRIES_PER_REQUEST = positiveIntEnv(
   "CACHE_MAX_RETRIES_PER_REQUEST",
   2,

--- a/src/domain-db.ts
+++ b/src/domain-db.ts
@@ -126,14 +126,14 @@ export interface DomainRecord {
   first_seen: string;
   last_fetch: string;
   capabilities: DomainCapabilities;
-  tier_stats_30d: {
-    tier1: TierStat;
-    tier2: TierStat;
-    tier3: TierStat;
-    tier4: TierStat;
-    github: TierStat;
-    solver: TierStat;
-  };
+  // Derived from TIER_SLOT_KEYS, not restated. Written out as an object literal
+  // this was a third hand-maintained copy of the same closed set — with
+  // `newRecord` below as a fourth and `AllTiersOutputSchema` in tools.ts as a
+  // fifth. The fifth is the one that drifted (vikunja#637). As a mapped type
+  // the compiler now rejects any writer that misses a slot, so adding one to
+  // the constant surfaces as a build error naming the exact sites to update,
+  // rather than as a record that is silently short a slot at runtime.
+  tier_stats_30d: Record<TierSlotKey, TierStat>;
   preferred_strategy?: PreferredStrategy;
   notes?: string;
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -158,6 +158,25 @@ export const events = {
   }): void {
     publishEvent("crawl.completed", p);
   },
+  /**
+   * A search fell through from one SearXNG instance to another. Emitted once
+   * per failed instance, so a call that exhausts three replicas emits three
+   * events ordered by `attempt`.
+   *
+   * This exists because a successful failover is otherwise invisible: results
+   * come back normally, and nothing distinguishes a healthy primary from one
+   * that has been dead for a week behind a working replica.
+   */
+  searxFailover(p: {
+    from: string;
+    to: string | null;
+    attempt: number;
+    error_type: string;
+    message: string;
+    exhausted: boolean;
+  }): void {
+    publishEvent("search.failover", p);
+  },
   error(p: {
     stage: string;
     url?: string;

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -1,0 +1,134 @@
+/**
+ * Ordered SearXNG candidate selection with cross-process health hints.
+ *
+ * `SEARXNG_URL` may name several interchangeable replicas. This module decides
+ * what order to try them in, and remembers — across processes — which ones just
+ * failed, so a dead primary is not re-tried on the front of every single search
+ * until its TTL lapses.
+ *
+ * Three properties this is built around:
+ *
+ * 1. **A single instance takes no new code path.** With one candidate there is
+ *    nothing to order and nothing to learn: if the only instance is unhealthy
+ *    we must try it regardless. So the health lookup is skipped entirely, and a
+ *    scalar `SEARXNG_URL` issues exactly one request to exactly one host, with
+ *    no added cache round-trip on the hot path. This is the configuration every
+ *    existing deployment runs.
+ *
+ * 2. **Health state lives in the cache, not in a module-level Map.** The value
+ *    of the marker is that one process's discovery informs the next call, and
+ *    in-process state cannot do that.
+ *
+ * 3. **It is fail-soft, like the rest of the cache layer.** A cache outage must
+ *    degrade to "try every instance in configured order" — never to an error,
+ *    and never to an empty candidate list. Losing the cache costs the ordering
+ *    optimisation, not the ability to search.
+ *
+ * Deliberately NOT a circuit breaker: an unhealthy instance is deprioritised,
+ * never removed. If every instance is marked unhealthy the full list is still
+ * returned in configured order, because "everything looks down" is exactly when
+ * you most want to actually try.
+ */
+
+import { cacheGet, cacheSet } from "./cache.js";
+import { SEARXNG_UNHEALTHY_TTL_SECONDS, SEARXNG_URLS } from "./config.js";
+import { logThrottled } from "./log.js";
+
+/**
+ * Cache key for an instance's unhealthy marker.
+ *
+ * Keyed on origin rather than the full URL so a path suffix cannot fragment the
+ * marker, and built via `URL` so any userinfo in the configured value is
+ * dropped rather than written into a cache key.
+ */
+export function unhealthyKey(url: string): string {
+  let origin: string;
+  try {
+    origin = new URL(url).origin;
+  } catch {
+    origin = url;
+  }
+  return `searxng:unhealthy:${origin}`;
+}
+
+/**
+ * Candidates in the order they should be tried: healthy first, then those
+ * currently marked unhealthy, each group preserving configured order.
+ *
+ * Never returns an empty array.
+ */
+export async function getSearxCandidates(
+  instances: readonly string[] = SEARXNG_URLS,
+): Promise<string[]> {
+  // Single instance: nothing to reorder. Skipping the lookup keeps the
+  // hot path free of a cache round-trip that could not change the outcome.
+  if (instances.length <= 1) return [...instances];
+
+  const healthy: string[] = [];
+  const unhealthy: string[] = [];
+
+  for (const url of instances) {
+    let marked = false;
+    try {
+      marked = (await cacheGet(unhealthyKey(url))) !== null;
+    } catch {
+      // cacheGet is already fail-soft, but a throw here must not lose the
+      // instance — treat an unreadable marker as "no information", i.e. healthy.
+      marked = false;
+    }
+    (marked ? unhealthy : healthy).push(url);
+  }
+
+  // All marked down: return configured order rather than an arbitrary one. The
+  // markers carry no recency ordering, so "least recently failed" is not
+  // available, and configured order is at least the operator's stated
+  // preference.
+  if (healthy.length === 0) return [...instances];
+
+  return [...healthy, ...unhealthy];
+}
+
+/**
+ * Record that `url` just failed. Best-effort: a write failure costs the
+ * ordering hint for the next call and nothing more.
+ */
+export async function markUnhealthy(url: string): Promise<void> {
+  try {
+    await cacheSet(unhealthyKey(url), "1", SEARXNG_UNHEALTHY_TTL_SECONDS);
+  } catch {
+    // Never throw from a health hint.
+  }
+}
+
+/**
+ * Clear the marker for an instance that has just answered successfully, so a
+ * recovered replica returns to the front of the order without waiting out the
+ * TTL. Only meaningful with more than one instance.
+ */
+export async function markHealthy(url: string): Promise<void> {
+  try {
+    // Writing a 1-second expiry rather than deleting keeps this to the two
+    // cache primitives already exposed, and the marker is a hint whose exact
+    // expiry does not need to be precise.
+    if ((await cacheGet(unhealthyKey(url))) !== null) {
+      await cacheSet(unhealthyKey(url), "1", 1);
+    }
+  } catch {
+    // Never throw from a health hint.
+  }
+}
+
+/**
+ * One stderr line when a search falls through to a non-primary instance.
+ *
+ * Throttled per instance-pair. A silent failover is indistinguishable from a
+ * healthy primary, which is how a half-dead deployment goes unnoticed for
+ * weeks — but an unthrottled line would emit once per search for as long as
+ * the primary stays down.
+ */
+export function logFailover(from: string, to: string, reason: string): void {
+  logThrottled(
+    `searxng-failover:${from}->${to}`,
+    `SearXNG failover: ${from} failed (${reason}), served by ${to}`,
+  );
+}

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -32,7 +32,7 @@
 
 import { cacheGet, cacheSet } from "./cache.js";
 import { SEARXNG_UNHEALTHY_TTL_SECONDS, SEARXNG_URLS } from "./config.js";
-import { logThrottled } from "./log.js";
+import { logThrottled, redactUrlCredentials } from "./log.js";
 
 /**
  * Cache key for an instance's unhealthy marker.
@@ -42,13 +42,29 @@ import { logThrottled } from "./log.js";
  * dropped rather than written into a cache key.
  */
 export function unhealthyKey(url: string): string {
-  let origin: string;
+  return `searxng:unhealthy:${instanceLabel(url)}`;
+}
+
+/**
+ * How an instance is named ANYWHERE it leaves this process — cache keys, stderr
+ * lines, NATS events, and error messages handed back to the caller.
+ *
+ * `origin` drops userinfo, so credentials in a configured URL
+ * (`http://user:pass@searxng.internal:8080`, a normal shape for an instance
+ * behind basic auth) cannot reach a sink. The cache key was written this way
+ * from the start; the log and event paths were not, and guarding one sink while
+ * leaving three is how a redaction gets quietly bypassed. `src/log.ts` already
+ * carries `redactUrlCredentials` for the same reason on the cache URL.
+ *
+ * Falls back to the same redaction for anything `URL` cannot parse, so an
+ * unparseable value is never echoed verbatim either.
+ */
+export function instanceLabel(url: string): string {
   try {
-    origin = new URL(url).origin;
+    return new URL(url).origin;
   } catch {
-    origin = url;
+    return redactUrlCredentials(url);
   }
-  return `searxng:unhealthy:${origin}`;
 }
 
 /**
@@ -127,8 +143,10 @@ export async function markHealthy(url: string): Promise<void> {
  * the primary stays down.
  */
 export function logFailover(from: string, to: string, reason: string): void {
+  const a = instanceLabel(from);
+  const b = instanceLabel(to);
   logThrottled(
-    `searxng-failover:${from}->${to}`,
-    `SearXNG failover: ${from} failed (${reason}), served by ${to}`,
+    `searxng-failover:${a}->${b}`,
+    `SearXNG failover: ${a} failed (${reason}), served by ${b}`,
   );
 }

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -32,7 +32,11 @@
 
 import { cacheGet, cacheSet } from "./cache.js";
 import { SEARXNG_UNHEALTHY_TTL_SECONDS, SEARXNG_URLS } from "./config.js";
-import { logThrottled, redactUrlCredentials } from "./log.js";
+import {
+  logThrottled,
+  redactUrlCredentials,
+  redactUrlCredentialsInText,
+} from "./log.js";
 
 /**
  * Cache key for an instance's unhealthy marker.
@@ -65,6 +69,29 @@ export function instanceLabel(url: string): string {
   } catch {
     return redactUrlCredentials(url);
   }
+}
+
+/**
+ * Re-wrap an arbitrary thrown value as an Error whose message carries no URL
+ * credentials, preserving the original `name` so `error_type` stays useful.
+ *
+ * Needed because the message is where a credential actually escapes.
+ * `instanceLabel` redacts the instance NAME, but Node's `fetch` rejects a
+ * credentialed URL with a `TypeError` whose message embeds the whole URL —
+ * so the sinks that forward `err.message` leaked what the label-redaction had
+ * carefully kept out.
+ *
+ * The original error is deliberately NOT attached as `cause`: anything that
+ * later serialises the cause chain would reintroduce the unredacted text, which
+ * is the same "one more sink nobody thought of" failure being fixed here.
+ */
+export function toRedactedError(err: unknown): Error {
+  const message = redactUrlCredentialsInText(
+    err instanceof Error ? err.message : String(err),
+  );
+  const wrapped = new Error(message);
+  if (err instanceof Error) wrapped.name = err.name;
+  return wrapped;
 }
 
 /**

--- a/src/log.ts
+++ b/src/log.ts
@@ -63,3 +63,30 @@ export function redactUrlCredentials(url: string): string {
     return "<url>";
   }
 }
+
+/**
+ * Strip userinfo from every URL-shaped substring of arbitrary text.
+ *
+ * `redactUrlCredentials` above takes a string that IS a URL. This takes a
+ * string that merely CONTAINS one — which is the shape a credential actually
+ * escapes in. Node's `fetch` rejects a credentialed URL with
+ *
+ *     TypeError: Request cannot be constructed from a URL that includes
+ *     credentials: http://user:pw@host/search?q=x
+ *
+ * so the secret arrives embedded in an error message, not as a bare URL. Any
+ * sink that forwards `err.message` — a log line, a NATS event, an OTel span, an
+ * error returned to the caller — leaks it unless the whole message is scrubbed.
+ *
+ * Applied at the generic sinks rather than at each call site: this class of leak
+ * has already been introduced twice in this subsystem by guarding one path and
+ * missing the others, and error text can originate from any library.
+ */
+export function redactUrlCredentialsInText(text: string): string {
+  // scheme:// then a userinfo segment (no '/', '@' or whitespace) ending at '@'.
+  // Requires a ':' so a bare `http://host@` style is left alone.
+  return text.replace(
+    /\b([a-z][a-z0-9+.-]*:\/\/)[^\s/@]*:[^\s/@]*@/gi,
+    "$1<redacted>@",
+  );
+}

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,8 +1,15 @@
 // Minimal stderr logging with the shared `[searxng-mcp]` prefix. stderr is the
-// only telemetry sink wired on the running PM2 process (OTel/NATS are opt-in and
-// usually unset), so the failure/degradation paths log here directly rather than
-// relying on those counters. `logThrottled` dedupes noisy repeats (e.g. a cache
-// that is down for minutes) to one line per interval per key.
+// one sink that is always on and never depends on configuration, so the
+// failure/degradation paths log here directly rather than relying on counters
+// that may not be exported anywhere.
+//
+// This comment previously said stderr was the ONLY telemetry sink wired on the
+// running PM2 process. Both halves were wrong: the deployment is Docker, not
+// PM2, and OTel and NATS are in fact wired there — the startup capability line
+// reports `otel,nats` in its on-list. stderr is the floor, not the whole story.
+//
+// `logThrottled` dedupes noisy repeats (e.g. a cache that is down for minutes)
+// to one line per interval per key.
 
 const PREFIX = "[searxng-mcp]";
 

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -8,6 +8,7 @@ import type {
   Span,
   Tracer,
 } from "@opentelemetry/api";
+import { redactUrlCredentialsInText } from "./log.js";
 import { VERSION } from "./version.js";
 
 type SpanStatusCode = 1 | 2; // 1 = OK, 2 = ERROR
@@ -122,10 +123,22 @@ export async function withSpan<T>(
       const result = await fn(span);
       return result;
     } catch (err) {
+      // Scrubbed before it reaches the exporter. An error message can carry a
+      // credentialed URL (Node's fetch embeds one in its own TypeError), and a
+      // span is exported off-host over OTLP — so this is a sink like any other.
+      // The thrown error is left untouched; only what leaves the process is
+      // redacted.
       if (err instanceof Error) {
-        span.recordException(err);
+        const safe = new Error(redactUrlCredentialsInText(err.message));
+        safe.name = err.name;
+        span.recordException(safe);
       }
-      span.setStatus({ code: 2, message: (err as Error)?.message });
+      span.setStatus({
+        code: 2,
+        message: redactUrlCredentialsInText(
+          err instanceof Error ? err.message : String(err),
+        ),
+      });
       throw err;
     } finally {
       span.end();

--- a/src/reranker.ts
+++ b/src/reranker.ts
@@ -18,6 +18,7 @@ async function rerank(
   results: SearxResult[],
   topN: number,
   applyRecency: boolean,
+  minScore?: number,
 ): Promise<SearxResult[]> {
   if (results.length === 0) return results;
 
@@ -48,11 +49,27 @@ async function rerank(
           ? r.relevance_score +
             RERANK_RECENCY_WEIGHT * recencyScore(result.publishedDate)
           : r.relevance_score;
-      return { result, score: combined };
+      // `relevance` is carried alongside `score` rather than being discarded
+      // here, because the two are NOT interchangeable and `min_score` must
+      // filter on the raw one. See the filter below.
+      return { result, score: combined, relevance: r.relevance_score };
     });
 
-  scored.sort((a, b) => b.score - a.score);
-  return scored.slice(0, topN).map((s) => s.result);
+  // Filter BEFORE sort-and-slice. Slicing first would return fewer than `topN`
+  // results even when enough qualifying ones existed further down the pool.
+  //
+  // Filtering on `relevance` (raw cross-encoder) and NOT on `score` (which adds
+  // RERANK_RECENCY_WEIGHT * recencyScore) is deliberate. The combined value
+  // ranges over 0..1.15 with the default weight of 0.15, so a parameter named
+  // "minimum relevance" applied to it would silently let a low-relevance but
+  // recent document past a threshold the caller believed was about relevance.
+  const kept =
+    minScore === undefined
+      ? scored
+      : scored.filter((s) => s.relevance >= minScore);
+
+  kept.sort((a, b) => b.score - a.score);
+  return kept.slice(0, topN).map((s) => s.result);
 }
 
 export async function rerankWithFallback(
@@ -60,14 +77,19 @@ export async function rerankWithFallback(
   results: SearxResult[],
   topN: number,
   timeRange?: string,
+  minScore?: number,
 ): Promise<SearxResult[]> {
   return withSpan(
     "rerank",
-    { "rerank.candidates": results.length, "rerank.top_n": topN },
+    {
+      "rerank.candidates": results.length,
+      "rerank.top_n": topN,
+      "rerank.min_score": minScore,
+    },
     async () => {
       const applyRecency = !timeRange; // skip when caller already filtered by date
       try {
-        return await rerank(query, results, topN, applyRecency);
+        return await rerank(query, results, topN, applyRecency, minScore);
       } catch (err) {
         // Reranker unavailable — fall back to SearXNG order. Silent otherwise;
         // one throttled line makes "why did ranking quality drop" answerable.
@@ -75,6 +97,18 @@ export async function rerankWithFallback(
           "degrade:reranker",
           `reranker unavailable — using SearXNG result order: ${err instanceof Error ? err.message : String(err)}`,
         );
+        // `min_score` becomes a documented NO-OP here, and says so. There are
+        // no scores to filter on in this path, so the alternatives were: return
+        // everything silently, which would let a caller believe a relevance
+        // floor was applied when none was; or return nothing, which turns a
+        // reranker outage into an empty result set. Both are worse than
+        // unfiltered-and-announced.
+        if (minScore !== undefined) {
+          logThrottled(
+            "degrade:reranker:min_score",
+            `min_score=${minScore} ignored — reranker unavailable, so no relevance scores exist to filter on; returning unfiltered SearXNG order`,
+          );
+        }
         return results.slice(0, topN);
       }
     },

--- a/src/search.ts
+++ b/src/search.ts
@@ -2,10 +2,18 @@ import { cacheGet, cacheSet, searchCacheKey } from "./cache.js";
 import {
   CACHE_TTL_SECONDS,
   EXPAND_QUERIES_DEFAULT,
-  SEARXNG_URL,
+  SEARXNG_ATTEMPT_TIMEOUT_MS,
+  SEARXNG_TOTAL_TIMEOUT_MS,
 } from "./config.js";
 import { normalizeHostname, recordSearchAppearance } from "./domain-db.js";
 import { applyDomainFilters } from "./domains.js";
+import { events } from "./events.js";
+import {
+  getSearxCandidates,
+  logFailover,
+  markHealthy,
+  markUnhealthy,
+} from "./instances.js";
 import { withSpan } from "./observability.js";
 import { expandQuery } from "./ollama.js";
 import type {
@@ -106,17 +114,66 @@ export async function searxSearchSingle(
       // soft rather than erroring.
       if (engines) params.set("engines", engines);
 
-      const res = await fetch(`${SEARXNG_URL}/search?${params}`, {
-        signal: AbortSignal.timeout(10000),
-      });
-      if (!res.ok)
-        throw new Error(`SearXNG error: ${res.status} ${res.statusText}`);
+      const candidates = await getSearxCandidates();
+      const multi = candidates.length > 1;
 
-      const data = (await res.json()) as SearxResponse;
-      return {
-        results: data.results.slice(0, fetchCount),
-        meta: normalizeSearxMeta(data),
-      };
+      // ONE budget for the whole call, decremented as candidates fail. Giving
+      // each candidate its own 10s would make the worst case N*10s: adding a
+      // replica would make a total outage take longer to report, which is the
+      // opposite of the point. With a single candidate this reduces to exactly
+      // the previous `AbortSignal.timeout(10000)`.
+      const deadline = Date.now() + SEARXNG_TOTAL_TIMEOUT_MS;
+      let lastError: unknown;
+
+      for (let attempt = 0; attempt < candidates.length; attempt++) {
+        const base = candidates[attempt];
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) {
+          lastError ??= new Error(
+            `SearXNG timeout budget (${SEARXNG_TOTAL_TIMEOUT_MS}ms) exhausted before trying ${base}`,
+          );
+          break;
+        }
+        const attemptMs = Math.min(SEARXNG_ATTEMPT_TIMEOUT_MS, remaining);
+
+        try {
+          const res = await fetch(`${base}/search?${params}`, {
+            signal: AbortSignal.timeout(attemptMs),
+          });
+          if (!res.ok)
+            throw new Error(`SearXNG error: ${res.status} ${res.statusText}`);
+
+          const data = (await res.json()) as SearxResponse;
+          // Only touched when there is something to clear, and only in the
+          // multi-instance case, so the single-instance path stays free of
+          // extra cache traffic.
+          if (multi && attempt > 0) await markHealthy(base);
+          return {
+            results: data.results.slice(0, fetchCount),
+            meta: normalizeSearxMeta(data),
+          };
+        } catch (err) {
+          lastError = err;
+          const next = candidates[attempt + 1] ?? null;
+          if (multi) {
+            await markUnhealthy(base);
+            const reason = err instanceof Error ? err.message : String(err);
+            events.searxFailover({
+              from: base,
+              to: next,
+              attempt,
+              error_type: err instanceof Error ? err.name : "unknown",
+              message: reason,
+              exhausted: next === null,
+            });
+            if (next) logFailover(base, next, reason);
+          }
+        }
+      }
+
+      throw lastError instanceof Error
+        ? lastError
+        : new Error(`SearXNG request failed: ${String(lastError)}`);
     },
   );
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -10,6 +10,7 @@ import { applyDomainFilters } from "./domains.js";
 import { events } from "./events.js";
 import {
   getSearxCandidates,
+  instanceLabel,
   logFailover,
   markHealthy,
   markUnhealthy,
@@ -130,7 +131,7 @@ export async function searxSearchSingle(
         const remaining = deadline - Date.now();
         if (remaining <= 0) {
           lastError ??= new Error(
-            `SearXNG timeout budget (${SEARXNG_TOTAL_TIMEOUT_MS}ms) exhausted before trying ${base}`,
+            `SearXNG timeout budget (${SEARXNG_TOTAL_TIMEOUT_MS}ms) exhausted before trying ${instanceLabel(base)}`,
           );
           break;
         }
@@ -159,8 +160,9 @@ export async function searxSearchSingle(
             await markUnhealthy(base);
             const reason = err instanceof Error ? err.message : String(err);
             events.searxFailover({
-              from: base,
-              to: next,
+              // Redacted at the sink: these leave the process onto NATS.
+              from: instanceLabel(base),
+              to: next === null ? null : instanceLabel(next),
               attempt,
               error_type: err instanceof Error ? err.name : "unknown",
               message: reason,

--- a/src/search.ts
+++ b/src/search.ts
@@ -4,6 +4,7 @@ import {
   EXPAND_QUERIES_DEFAULT,
   SEARXNG_ATTEMPT_TIMEOUT_MS,
   SEARXNG_TOTAL_TIMEOUT_MS,
+  searxAuthHeader,
 } from "./config.js";
 import { normalizeHostname, recordSearchAppearance } from "./domain-db.js";
 import { applyDomainFilters } from "./domains.js";
@@ -14,6 +15,7 @@ import {
   logFailover,
   markHealthy,
   markUnhealthy,
+  toRedactedError,
 } from "./instances.js";
 import { withSpan } from "./observability.js";
 import { expandQuery } from "./ollama.js";
@@ -138,8 +140,12 @@ export async function searxSearchSingle(
         const attemptMs = Math.min(SEARXNG_ATTEMPT_TIMEOUT_MS, remaining);
 
         try {
+          // Credentials travel as a header, never in the URL — see
+          // parseSearxngInstances. `base` is already credential-free.
+          const auth = searxAuthHeader(base);
           const res = await fetch(`${base}/search?${params}`, {
             signal: AbortSignal.timeout(attemptMs),
+            ...(auth ? { headers: { Authorization: auth } } : {}),
           });
           if (!res.ok)
             throw new Error(`SearXNG error: ${res.status} ${res.statusText}`);
@@ -154,17 +160,23 @@ export async function searxSearchSingle(
             meta: normalizeSearxMeta(data),
           };
         } catch (err) {
-          lastError = err;
+          // Scrub HERE, once, rather than at each sink below. The message can
+          // itself contain a credentialed URL (fetch's own TypeError does), and
+          // it flows to the NATS event, the stderr line, the OTel span and the
+          // caller — guarding some of those and not others is the exact mistake
+          // this finding was.
+          const scrubbed = toRedactedError(err);
+          lastError = scrubbed;
           const next = candidates[attempt + 1] ?? null;
           if (multi) {
             await markUnhealthy(base);
-            const reason = err instanceof Error ? err.message : String(err);
+            const reason = scrubbed.message;
             events.searxFailover({
               // Redacted at the sink: these leave the process onto NATS.
               from: instanceLabel(base),
               to: next === null ? null : instanceLabel(next),
               attempt,
-              error_type: err instanceof Error ? err.name : "unknown",
+              error_type: scrubbed.name,
               message: reason,
               exhausted: next === null,
             });

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -226,6 +226,7 @@ export async function handleSearch({
   language,
   engines,
   site,
+  min_score,
 }: {
   query: string;
   num_results: number;
@@ -236,6 +237,7 @@ export async function handleSearch({
   language?: string;
   engines?: string;
   site?: string | string[];
+  min_score?: number;
 }) {
   return instrumentSearchTool(
     "search",
@@ -257,6 +259,7 @@ export async function handleSearch({
         raw,
         num_results,
         time_range,
+        min_score,
       );
       return {
         ranked,
@@ -285,6 +288,7 @@ export async function handleSearchAndFetch({
   language,
   engines,
   site,
+  min_score,
 }: {
   query: string;
   category?: string;
@@ -295,6 +299,7 @@ export async function handleSearchAndFetch({
   language?: string;
   engines?: string;
   site?: string | string[];
+  min_score?: number;
 }) {
   return instrumentSearchTool(
     "search_and_fetch",
@@ -331,7 +336,13 @@ export async function handleSearchAndFetch({
           },
         };
       }
-      const ranked = await rerankWithFallback(query, raw, 5, time_range);
+      const ranked = await rerankWithFallback(
+        query,
+        raw,
+        5,
+        time_range,
+        min_score,
+      );
       const searchText = formatResults(ranked);
       const maxCharsPerPage = Math.floor(8000 / fetch_count);
       const toFetch = ranked.slice(0, fetch_count);
@@ -377,6 +388,7 @@ export async function handleSearchAndSummarize({
   language,
   engines,
   site,
+  min_score,
 }: {
   query: string;
   fetch_count: number;
@@ -387,6 +399,7 @@ export async function handleSearchAndSummarize({
   language?: string;
   engines?: string;
   site?: string | string[];
+  min_score?: number;
 }) {
   return instrumentSearchTool(
     "search_and_summarize",
@@ -428,6 +441,7 @@ export async function handleSearchAndSummarize({
         raw,
         fetch_count,
         time_range,
+        min_score,
       );
       const searchText = formatResults(ranked);
       const toFetch = ranked.slice(0, fetch_count);
@@ -747,6 +761,43 @@ const SiteSchema = z
     "Restrict results to one domain or a list of domains (e.g. 'github.com'). Best-effort — applied as a site: query operator; most engines honor it but some ignore it.",
   );
 
+/**
+ * `min_score` — a relevance floor applied after reranking.
+ *
+ * The description is long on purpose. Three things about this parameter are
+ * counter-intuitive enough that omitting them would make it actively
+ * misleading, and all three were measured against the live FlashRank service
+ * rather than assumed:
+ *
+ * 1. WHICH SCORE. `rerank()` sorts on `relevance_score + RERANK_RECENCY_WEIGHT
+ *    * recencyScore(...)`, which with the default weight of 0.15 ranges over
+ *    0..1.15, not 0..1. This filters on the RAW `relevance_score`, so a recent
+ *    but irrelevant document cannot be pushed past the floor.
+ *
+ * 2. THE DISTRIBUTION IS BIMODAL, so the knob is far less sensitive than a
+ *    0..1 range suggests. Measured on "how to configure nginx reverse proxy":
+ *    nginx reverse-proxy guide 0.998, Apache mod_proxy 0.967, nginx install
+ *    page 0.0028, banana bread recipe 0.0000151. Anything in roughly 0.01..0.9
+ *    behaves near-identically. 0.5 is NOT a meaningful midpoint.
+ *
+ * 3. A HIGH SCORE MEANS TOPICALLY RELATED, NOT CORRECT. The Apache document
+ *    scored 0.967 on an nginx query. This is a topicality floor and cannot be
+ *    trusted as a correctness filter.
+ */
+const MinScoreSchema = z.coerce
+  .number()
+  .min(0)
+  .max(1)
+  .optional()
+  .describe(
+    "Drop results whose reranker relevance score is below this threshold (0-1, omit for no filtering). " +
+      "Filters on the RAW cross-encoder relevance score, not the recency-adjusted score used for ordering. " +
+      "Scores are strongly bimodal — relevant results cluster near 1.0 and irrelevant ones near 0, with little in between — so any value in roughly 0.01-0.9 behaves about the same; 0.01-0.1 is the useful range and 0.5 is not a midpoint. " +
+      "A high score means topically related, NOT correct: an Apache mod_proxy page scores 0.967 on an nginx query. " +
+      "Thresholds are model-dependent and not comparable across rerankers. " +
+      "No-op (with a logged warning) when the reranker is unavailable, since no scores exist to filter on.",
+  );
+
 // Output schema for the `search` tool — surfaces SearXNG's native answers /
 // infoboxes / corrections / suggestions alongside a minimal result list so
 // callers can check for a direct answer programmatically.
@@ -803,6 +854,7 @@ export function registerTools(server: McpServer): void {
         language: LanguageSchema,
         engines: EnginesSchema,
         site: SiteSchema,
+        min_score: MinScoreSchema,
       },
       outputSchema: SearchOutputSchema,
     },
@@ -838,6 +890,7 @@ export function registerTools(server: McpServer): void {
       language: LanguageSchema,
       engines: EnginesSchema,
       site: SiteSchema,
+      min_score: MinScoreSchema,
     },
     handleSearchAndFetch,
   );
@@ -902,6 +955,7 @@ export function registerTools(server: McpServer): void {
       language: LanguageSchema,
       engines: EnginesSchema,
       site: SiteSchema,
+      min_score: MinScoreSchema,
     },
     handleSearchAndSummarize,
   );

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3,7 +3,11 @@ import { z } from "zod";
 import { cacheClear } from "./cache.js";
 import { newRequestId, withRequestId } from "./context.js";
 import { crawlSite, formatCrawlManifest } from "./crawl.js";
-import { getDomainRecord } from "./domain-db.js";
+import {
+  getDomainRecord,
+  TIER_SLOT_KEYS,
+  type TierSlotKey,
+} from "./domain-db.js";
 import {
   aggregateDomainStats,
   enumerateDomains,
@@ -553,13 +557,38 @@ const TierStatsOutputSchema = z.object({
   success_rate: z.number().nullable(),
 });
 
-const AllTiersOutputSchema = z.object({
-  tier1: TierStatsOutputSchema,
-  tier2: TierStatsOutputSchema,
-  tier3: TierStatsOutputSchema,
-  tier4: TierStatsOutputSchema,
-  github: TierStatsOutputSchema,
-});
+/**
+ * The per-slot tier block, DERIVED from `TIER_SLOT_KEYS` rather than hand-listed.
+ *
+ * This is the fix for vikunja#637, and the derivation is the point of it. Both
+ * payload builders (`aggregateDomainStats`, `summarizeDomainRecord`) already
+ * emit their `tiers` object via `Object.fromEntries(TIER_SLOT_KEYS.map(...))`.
+ * When this schema was a hand-written literal, the two lists were free to
+ * diverge — and they did: v3.19.0 added a sixth slot (`solver`) to the constant
+ * and the payload grew it, while the schema stayed at five. Zod emits
+ * `additionalProperties: false`, so every `domain_stats` call on a
+ * solver-enabled deployment failed structured-output validation outright.
+ *
+ * Deriving from the same constant makes that class of drift unrepresentable:
+ * `TierSlotKey` is itself `(typeof TIER_SLOT_KEYS)[number]`, so the mapped type
+ * below and the runtime keys have one source. Adding a slot to the constant
+ * cannot leave this schema behind.
+ *
+ * Every slot is OPTIONAL, and that is deliberate rather than defensive. A slot
+ * is only written once its tier has run: `tier4` requires `WAYBACK_ENABLED`,
+ * `solver` requires `SOLVER_ENABLED`. Marking them required does not fix the
+ * bug, it inverts which deployments it breaks — `tier4` carried this identical
+ * defect latently for every deployment whose records predate Wayback.
+ */
+type AllTiersShape = {
+  [K in TierSlotKey]: z.ZodOptional<typeof TierStatsOutputSchema>;
+};
+
+const AllTiersOutputSchema = z.object(
+  Object.fromEntries(
+    TIER_SLOT_KEYS.map((slot) => [slot, TierStatsOutputSchema.optional()]),
+  ) as AllTiersShape,
+);
 
 const SingleDomainOutputSchema = z.object({
   domain: z.string(),
@@ -591,7 +620,10 @@ const AggregateOutputSchema = z.object({
   truncated: z.boolean(),
 });
 
-const DomainStatsOutputSchema = z.object({
+// Exported solely so tests can validate real payloads against the *declared*
+// contract rather than a restatement of it. A test that rebuilds the schema
+// locally proves nothing — this is the object actually handed to registerTool.
+export const DomainStatsOutputSchema = z.object({
   mode: z.enum(["single", "aggregate"]),
   hostname: z.string().nullable(),
   found: z.boolean(),

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -18,6 +18,7 @@ import {
 import { events } from "./events.js";
 import { fetchPage } from "./fetch.js";
 import type { FetchTuning } from "./fetch-utils.js";
+import { redactUrlCredentialsInText } from "./log.js";
 import { incCounter, recordHistogram, withSpan } from "./observability.js";
 import { formatSummaryResult, summarizePages } from "./ollama.js";
 import { rerankWithFallback } from "./reranker.js";
@@ -103,10 +104,15 @@ async function withSearchEvents<T>(
       stage: "search",
       error_type: err instanceof Error ? err.name : "unknown",
     });
+    // Scrubbed: this is a generic sink reached by errors from any source, and
+    // it fires even on the single-instance path where the failover-specific
+    // redaction above never runs.
     events.error({
       stage: "search",
       error_type: err instanceof Error ? err.name : "unknown",
-      message: err instanceof Error ? err.message : String(err),
+      message: redactUrlCredentialsInText(
+        err instanceof Error ? err.message : String(err),
+      ),
     });
     throw err;
   }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -46,7 +46,15 @@ interface SearchEventCtx {
   num_results: number;
 }
 
+/**
+ * The three tools that share the `search` histogram. Naming the union rather
+ * than taking a bare string keeps a typo out of the label set — a stray value
+ * would not fail anything at runtime, it would quietly create a fourth series.
+ */
+type SearchToolName = "search" | "search_and_fetch" | "search_and_summarize";
+
 async function withSearchEvents<T>(
+  toolName: SearchToolName,
   ctx: SearchEventCtx,
   fn: () => Promise<{
     ranked: SearxResult[];
@@ -60,11 +68,14 @@ async function withSearchEvents<T>(
     const { ranked, result, rerankApplied } = await fn();
     const latency_ms = Date.now() - t0;
     incCounter("search", {
+      tool: toolName,
       profile: ctx.profile ?? "default",
       expand: ctx.expand ? "true" : "false",
     });
     recordHistogram("search", latency_ms / 1000, {
+      tool: toolName,
       profile: ctx.profile ?? "default",
+      outcome: "ok",
     });
     events.searchCompleted({
       result_count: ranked.length,
@@ -74,7 +85,21 @@ async function withSearchEvents<T>(
     });
     return result;
   } catch (err) {
+    // Record latency on the failure path too. Previously only `errors_total`
+    // was incremented here, so a search that failed after 40s and one that
+    // failed instantly were indistinguishable in the metrics — which is
+    // precisely the question asked of this histogram during the 300s stall.
+    //
+    // `outcome` keeps the two populations separable: folding error latencies
+    // into the success distribution unlabelled would corrupt the p99 that the
+    // histogram exists to report.
+    recordHistogram("search", (Date.now() - t0) / 1000, {
+      tool: toolName,
+      profile: ctx.profile ?? "default",
+      outcome: "error",
+    });
     incCounter("errors", {
+      tool: toolName,
       stage: "search",
       error_type: err instanceof Error ? err.name : "unknown",
     });
@@ -85,6 +110,29 @@ async function withSearchEvents<T>(
     });
     throw err;
   }
+}
+
+/**
+ * `instrumentTool` + `withSearchEvents` for the three search tools, so the tool
+ * name is written once per call site. Passing it separately to each would let
+ * the span name and the metric label drift apart silently.
+ *
+ * NOTE: this does NOT make the histogram able to see a hang. Both the success
+ * and failure recordings happen after `await fn()` settles, so a call that
+ * never returns still records nothing at all. Closing that needs a watchdog
+ * timer independent of the awaited promise, which is deliberately out of scope
+ * here — see CHANGELOG.
+ */
+async function instrumentSearchTool<T>(
+  toolName: SearchToolName,
+  ctx: SearchEventCtx,
+  fn: () => Promise<{
+    ranked: SearxResult[];
+    result: T;
+    rerankApplied: boolean;
+  }>,
+): Promise<T> {
+  return instrumentTool(toolName, () => withSearchEvents(toolName, ctx, fn));
 }
 
 const DomainProfileSchema = z
@@ -189,42 +237,41 @@ export async function handleSearch({
   engines?: string;
   site?: string | string[];
 }) {
-  return instrumentTool("search", () =>
-    withSearchEvents(
-      { query, profile: domain_profile, expand, time_range, num_results },
-      async () => {
-        const { results: raw, meta } = await searxSearch(
-          query,
-          category ?? "general",
-          num_results,
-          time_range,
-          domain_profile,
-          expand,
-          language,
-          engines,
-          site,
-        );
-        const ranked = await rerankWithFallback(
-          query,
-          raw,
-          num_results,
-          time_range,
-        );
-        return {
-          ranked,
-          rerankApplied: true,
-          result: {
-            content: [
-              {
-                type: "text" as const,
-                text: withMeta(meta, formatResults(ranked)),
-              },
-            ],
-            structuredContent: buildSearchStructured(meta, ranked),
-          },
-        };
-      },
-    ),
+  return instrumentSearchTool(
+    "search",
+    { query, profile: domain_profile, expand, time_range, num_results },
+    async () => {
+      const { results: raw, meta } = await searxSearch(
+        query,
+        category ?? "general",
+        num_results,
+        time_range,
+        domain_profile,
+        expand,
+        language,
+        engines,
+        site,
+      );
+      const ranked = await rerankWithFallback(
+        query,
+        raw,
+        num_results,
+        time_range,
+      );
+      return {
+        ranked,
+        rerankApplied: true,
+        result: {
+          content: [
+            {
+              type: "text" as const,
+              text: withMeta(meta, formatResults(ranked)),
+            },
+          ],
+          structuredContent: buildSearchStructured(meta, ranked),
+        },
+      };
+    },
   );
 }
 
@@ -249,48 +296,156 @@ export async function handleSearchAndFetch({
   engines?: string;
   site?: string | string[];
 }) {
-  return instrumentTool("search_and_fetch", () =>
-    withSearchEvents(
-      {
+  return instrumentSearchTool(
+    "search_and_fetch",
+    {
+      query,
+      profile: domain_profile,
+      expand,
+      time_range,
+      num_results: fetch_count,
+    },
+    async () => {
+      const { results: raw, meta } = await searxSearch(
         query,
-        profile: domain_profile,
-        expand,
+        category ?? "general",
+        5,
         time_range,
-        num_results: fetch_count,
-      },
-      async () => {
-        const { results: raw, meta } = await searxSearch(
-          query,
-          category ?? "general",
-          5,
-          time_range,
-          domain_profile,
-          expand,
-          language,
-          engines,
-          site,
-        );
-        if (raw.length === 0) {
-          return {
-            ranked: [],
-            rerankApplied: false,
-            result: {
-              content: [
-                {
-                  type: "text" as const,
-                  text: withMeta(meta, "No results found."),
-                },
-              ],
+        domain_profile,
+        expand,
+        language,
+        engines,
+        site,
+      );
+      if (raw.length === 0) {
+        return {
+          ranked: [],
+          rerankApplied: false,
+          result: {
+            content: [
+              {
+                type: "text" as const,
+                text: withMeta(meta, "No results found."),
+              },
+            ],
+          },
+        };
+      }
+      const ranked = await rerankWithFallback(query, raw, 5, time_range);
+      const searchText = formatResults(ranked);
+      const maxCharsPerPage = Math.floor(8000 / fetch_count);
+      const toFetch = ranked.slice(0, fetch_count);
+      const fetched = await Promise.allSettled(
+        toFetch.map((r) => fetchPage(r.url, maxCharsPerPage, domain_profile)),
+      );
+      const fetchedSections = fetched
+        .map((result, i) => {
+          if (result.status === "fulfilled") {
+            const { title, text } = result.value;
+            return `\n\n--- Full content: ${title} ---\n${text}`;
+          }
+          const err =
+            result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason);
+          return `\n\n--- Could not fetch result ${i + 1}: ${err} ---`;
+        })
+        .join("");
+      return {
+        ranked,
+        rerankApplied: true,
+        result: {
+          content: [
+            {
+              type: "text" as const,
+              text: withMeta(meta, searchText + fetchedSections),
             },
-          };
-        }
-        const ranked = await rerankWithFallback(query, raw, 5, time_range);
-        const searchText = formatResults(ranked);
-        const maxCharsPerPage = Math.floor(8000 / fetch_count);
-        const toFetch = ranked.slice(0, fetch_count);
-        const fetched = await Promise.allSettled(
-          toFetch.map((r) => fetchPage(r.url, maxCharsPerPage, domain_profile)),
+          ],
+        },
+      };
+    },
+  );
+}
+
+export async function handleSearchAndSummarize({
+  query,
+  fetch_count,
+  category,
+  time_range,
+  domain_profile,
+  expand,
+  language,
+  engines,
+  site,
+}: {
+  query: string;
+  fetch_count: number;
+  category?: string;
+  time_range?: string;
+  domain_profile?: string;
+  expand?: boolean;
+  language?: string;
+  engines?: string;
+  site?: string | string[];
+}) {
+  return instrumentSearchTool(
+    "search_and_summarize",
+    {
+      query,
+      profile: domain_profile,
+      expand,
+      time_range,
+      num_results: fetch_count,
+    },
+    async () => {
+      const { results: raw, meta } = await searxSearch(
+        query,
+        category ?? "general",
+        fetch_count + 2,
+        time_range,
+        domain_profile,
+        expand,
+        language,
+        engines,
+        site,
+      );
+      if (raw.length === 0) {
+        return {
+          ranked: [],
+          rerankApplied: false,
+          result: {
+            content: [
+              {
+                type: "text" as const,
+                text: withMeta(meta, "No results found."),
+              },
+            ],
+          },
+        };
+      }
+      const ranked = await rerankWithFallback(
+        query,
+        raw,
+        fetch_count,
+        time_range,
+      );
+      const searchText = formatResults(ranked);
+      const toFetch = ranked.slice(0, fetch_count);
+      const fetched = await Promise.allSettled(
+        toFetch.map((r) => fetchPage(r.url, 4000, domain_profile, true)),
+      );
+      const successfulPages = fetched
+        .map((r) => (r.status === "fulfilled" ? r.value : null))
+        .filter(
+          (r): r is { title: string; url: string; text: string } => r !== null,
         );
+      const summaryResult = await withSpan(
+        "summarize_llm",
+        { "summary.pages": successfulPages.length },
+        () => summarizePages(query, successfulPages),
+      );
+
+      if (!summaryResult.summary) {
         const fetchedSections = fetched
           .map((result, i) => {
             if (result.status === "fulfilled") {
@@ -316,127 +471,16 @@ export async function handleSearchAndFetch({
             ],
           },
         };
-      },
-    ),
-  );
-}
-
-export async function handleSearchAndSummarize({
-  query,
-  fetch_count,
-  category,
-  time_range,
-  domain_profile,
-  expand,
-  language,
-  engines,
-  site,
-}: {
-  query: string;
-  fetch_count: number;
-  category?: string;
-  time_range?: string;
-  domain_profile?: string;
-  expand?: boolean;
-  language?: string;
-  engines?: string;
-  site?: string | string[];
-}) {
-  return instrumentTool("search_and_summarize", () =>
-    withSearchEvents(
-      {
-        query,
-        profile: domain_profile,
-        expand,
-        time_range,
-        num_results: fetch_count,
-      },
-      async () => {
-        const { results: raw, meta } = await searxSearch(
-          query,
-          category ?? "general",
-          fetch_count + 2,
-          time_range,
-          domain_profile,
-          expand,
-          language,
-          engines,
-          site,
-        );
-        if (raw.length === 0) {
-          return {
-            ranked: [],
-            rerankApplied: false,
-            result: {
-              content: [
-                {
-                  type: "text" as const,
-                  text: withMeta(meta, "No results found."),
-                },
-              ],
-            },
-          };
-        }
-        const ranked = await rerankWithFallback(
-          query,
-          raw,
-          fetch_count,
-          time_range,
-        );
-        const searchText = formatResults(ranked);
-        const toFetch = ranked.slice(0, fetch_count);
-        const fetched = await Promise.allSettled(
-          toFetch.map((r) => fetchPage(r.url, 4000, domain_profile, true)),
-        );
-        const successfulPages = fetched
-          .map((r) => (r.status === "fulfilled" ? r.value : null))
-          .filter(
-            (r): r is { title: string; url: string; text: string } =>
-              r !== null,
-          );
-        const summaryResult = await withSpan(
-          "summarize_llm",
-          { "summary.pages": successfulPages.length },
-          () => summarizePages(query, successfulPages),
-        );
-
-        if (!summaryResult.summary) {
-          const fetchedSections = fetched
-            .map((result, i) => {
-              if (result.status === "fulfilled") {
-                const { title, text } = result.value;
-                return `\n\n--- Full content: ${title} ---\n${text}`;
-              }
-              const err =
-                result.reason instanceof Error
-                  ? result.reason.message
-                  : String(result.reason);
-              return `\n\n--- Could not fetch result ${i + 1}: ${err} ---`;
-            })
-            .join("");
-          return {
-            ranked,
-            rerankApplied: true,
-            result: {
-              content: [
-                {
-                  type: "text" as const,
-                  text: withMeta(meta, searchText + fetchedSections),
-                },
-              ],
-            },
-          };
-        }
-        const output = formatSummaryResult(summaryResult);
-        return {
-          ranked,
-          rerankApplied: true,
-          result: {
-            content: [{ type: "text" as const, text: withMeta(meta, output) }],
-          },
-        };
-      },
-    ),
+      }
+      const output = formatSummaryResult(summaryResult);
+      return {
+        ranked,
+        rerankApplied: true,
+        result: {
+          content: [{ type: "text" as const, text: withMeta(meta, output) }],
+        },
+      };
+    },
   );
 }
 

--- a/tests/domain-stats-output-contract.test.ts
+++ b/tests/domain-stats-output-contract.test.ts
@@ -1,0 +1,277 @@
+/**
+ * The `domain_stats` structured-output contract (vikunja#637).
+ *
+ * WHY THIS FILE EXISTS, AND WHY IT DOES NOT USE `.parse()`
+ *
+ * v3.19.0 added a sixth tier slot (`solver`) to `TIER_SLOT_KEYS`. Both payload
+ * builders derive their `tiers` object from that constant, so both grew the
+ * slot. `AllTiersOutputSchema` hand-listed five. Every `domain_stats` call on a
+ * solver-enabled deployment then failed with:
+ *
+ *     Additional properties are not allowed ('solver' was unexpected)
+ *
+ * ...and 735 tests stayed green throughout, because the three existing
+ * assertions in tools.test.ts use `toMatchObject`, which is non-exhaustive.
+ *
+ * The obvious remedy — "parse a real payload with the declared zod schema" —
+ * DOES NOT WORK, and getting that wrong would leave this whole class of defect
+ * just as invisible as it was before. Two facts about the real validation path:
+ *
+ *   1. Server-side, the SDK calls `safeParseAsync(outputSchema, payload)`.
+ *      zod's `z.object()` is *strip*, not *strict*: an unrecognised key is
+ *      silently removed and the parse SUCCEEDS. The server never rejected
+ *      anything. Verified against zod 3.25 — `S.parse({known, bogus})` returns
+ *      `{known}` without throwing.
+ *   2. Client-side, the SDK advertises `toJsonSchemaCompat(outputSchema)` in
+ *      tools/list, and that conversion emits `additionalProperties: false`.
+ *      THAT is what rejected the call. The error we saw in production came
+ *      from the client's JSON Schema validator, not from zod.
+ *
+ * So the contract that actually binds is the *derived JSON Schema*, and that is
+ * what these tests validate against — using the SDK's own converter and the
+ * SDK's own validator, i.e. the exact artefact and the exact code path a client
+ * uses. A `.parse()` test here would have passed on the broken build.
+ */
+
+import { toJsonSchemaCompat } from "@modelcontextprotocol/sdk/server/zod-json-schema-compat.js";
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv-provider.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+vi.mock("../src/cache.js", () => ({
+  cacheClear: vi.fn().mockResolvedValue(0),
+  cacheGet: vi.fn().mockResolvedValue(null),
+  cacheSet: vi.fn().mockResolvedValue(undefined),
+  cacheAtomicUpdate: vi.fn().mockResolvedValue(undefined),
+  getValkey: vi.fn().mockResolvedValue(null),
+  searchCacheKey: vi.fn().mockReturnValue("key"),
+}));
+
+import { cacheGet, getValkey } from "../src/cache.js";
+import { type DomainRecord, TIER_SLOT_KEYS } from "../src/domain-db.js";
+import { DomainStatsOutputSchema, handleDomainStats } from "../src/tools.js";
+
+// The advertised contract, derived exactly as McpServer derives it for
+// tools/list (see server/mcp.js — `toJsonSchemaCompat(obj, { strictUnions:
+// true, pipeStrategy: 'output' })`). Options must stay in step with that call.
+const ADVERTISED_SCHEMA = toJsonSchemaCompat(DomainStatsOutputSchema, {
+  strictUnions: true,
+  pipeStrategy: "output",
+});
+
+const validator = new AjvJsonSchemaValidator();
+
+async function validateAsClient(payload: unknown) {
+  const validate = await validator.getValidator(ADVERTISED_SCHEMA);
+  return validate(payload);
+}
+
+interface TiersNode {
+  properties: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+/**
+ * The `tiers` subschema as advertised. Only `record` carries the expanded
+ * definition — `aggregate.tiers` is emitted as a `$ref` to it, which is exactly
+ * why both tool modes broke together in #637 and why fixing one fixes both.
+ * That relationship is asserted below rather than assumed.
+ */
+function advertisedTiers(): TiersNode {
+  const schema = ADVERTISED_SCHEMA as unknown as {
+    properties: {
+      record: { anyOf: [{ properties: { tiers: TiersNode } }] };
+      aggregate: { anyOf: [{ properties: { tiers: { $ref?: string } } }] };
+    };
+  };
+  return schema.properties.record.anyOf[0].properties.tiers;
+}
+
+const NOW = Date.now();
+
+function stat(attempts: number, ok: number, fail: number) {
+  return { attempts, ok, fail, window_start_ms: NOW };
+}
+
+/**
+ * `slots` is spelled as an explicit list rather than defaulted to "all", so a
+ * test that wants a *partial* record cannot get a complete one by accident.
+ */
+function mkRecord(
+  domain: string,
+  slots: readonly (typeof TIER_SLOT_KEYS)[number][],
+  overrides: Partial<DomainRecord["tier_stats_30d"]> = {},
+): DomainRecord {
+  return {
+    schema_version: 6,
+    domain,
+    first_seen: "2026-05-01T00:00:00Z",
+    last_fetch: "2026-06-01T00:00:00Z",
+    capabilities: {},
+    tier_stats_30d: {
+      ...Object.fromEntries(slots.map((s) => [s, stat(0, 0, 0)])),
+      ...overrides,
+    } as DomainRecord["tier_stats_30d"],
+  };
+}
+
+describe("domain_stats advertised output schema", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── The schema is derived, not restated ───────────────────────────────────
+
+  it("advertises exactly the slots in TIER_SLOT_KEYS, no more and no fewer", () => {
+    expect(Object.keys(advertisedTiers().properties).sort()).toEqual(
+      [...TIER_SLOT_KEYS].sort(),
+    );
+  });
+
+  it("covers both tool modes from one definition — aggregate.tiers $refs record.tiers", () => {
+    // #637 broke `single` and `aggregate` simultaneously because they share
+    // this one node. If a future change gives them separate definitions, the
+    // single-definition assumption the rest of this file rests on is void.
+    const aggregateTiers = (
+      ADVERTISED_SCHEMA as unknown as {
+        properties: {
+          aggregate: { anyOf: [{ properties: { tiers: { $ref?: string } } }] };
+        };
+      }
+    ).properties.aggregate.anyOf[0].properties.tiers;
+
+    expect(aggregateTiers.$ref).toBe(
+      "#/properties/record/anyOf/0/properties/tiers",
+    );
+  });
+
+  it("keeps additionalProperties:false — the strictness that makes this suite meaningful", () => {
+    // If this ever flips to true the payload/schema drift becomes unobservable
+    // again and every other test in this file silently stops proving anything.
+    expect(advertisedTiers().additionalProperties).toBe(false);
+  });
+
+  it("marks no slot required — tier4 needs WAYBACK_ENABLED, solver needs SOLVER_ENABLED", () => {
+    // Requiring them does not fix #637, it inverts which deployments it breaks.
+    const required = advertisedTiers().required ?? [];
+    for (const slot of TIER_SLOT_KEYS) {
+      expect(required).not.toContain(slot);
+    }
+  });
+
+  // ── Real payloads, validated the way a client validates them ──────────────
+
+  it("accepts a real single-mode payload carrying every slot", async () => {
+    vi.mocked(cacheGet).mockResolvedValueOnce(
+      JSON.stringify(
+        mkRecord("docs.example.com", TIER_SLOT_KEYS, {
+          tier1: stat(10, 9, 1),
+        }),
+      ),
+    );
+    const result = await handleDomainStats({ hostname: "docs.example.com" });
+
+    // Guard the guard: if the payload stopped carrying all six slots this test
+    // would pass for the wrong reason, since absent slots are legal.
+    expect(
+      Object.keys(result.structuredContent.record?.tiers ?? {}).sort(),
+    ).toEqual([...TIER_SLOT_KEYS].sort());
+
+    const r = await validateAsClient(result.structuredContent);
+    expect(r.valid, JSON.stringify(r.errors ?? r.error)).toBe(true);
+  });
+
+  it("accepts a real aggregate-mode payload carrying every slot", async () => {
+    vi.mocked(getValkey).mockResolvedValueOnce({
+      scan: vi.fn().mockResolvedValueOnce(["0", ["domain:good.com"]]),
+      mget: vi
+        .fn()
+        .mockResolvedValueOnce([
+          JSON.stringify(
+            mkRecord("good.com", TIER_SLOT_KEYS, { tier1: stat(10, 9, 1) }),
+          ),
+        ]),
+    } as unknown as NonNullable<Awaited<ReturnType<typeof getValkey>>>);
+
+    const result = await handleDomainStats({});
+    expect(
+      Object.keys(result.structuredContent.aggregate?.tiers ?? {}).sort(),
+    ).toEqual([...TIER_SLOT_KEYS].sort());
+
+    const r = await validateAsClient(result.structuredContent);
+    expect(r.valid, JSON.stringify(r.errors ?? r.error)).toBe(true);
+  });
+
+  it("accepts the found=false payload", async () => {
+    vi.mocked(cacheGet).mockResolvedValueOnce(null);
+    const result = await handleDomainStats({ hostname: "missing.example.com" });
+    const r = await validateAsClient(result.structuredContent);
+    expect(r.valid, JSON.stringify(r.errors ?? r.error)).toBe(true);
+  });
+
+  it("accepts a record predating Wayback and the solver — slots absent, not null", async () => {
+    // The deployment shape `tier4`/`solver` being `required` would have broken.
+    vi.mocked(cacheGet).mockResolvedValueOnce(
+      JSON.stringify(mkRecord("old.example.com", ["tier1", "tier2", "tier3"])),
+    );
+    const result = await handleDomainStats({ hostname: "old.example.com" });
+    const r = await validateAsClient(result.structuredContent);
+    expect(r.valid, JSON.stringify(r.errors ?? r.error)).toBe(true);
+  });
+
+  // ── Negative controls ─────────────────────────────────────────────────────
+  //
+  // Without these the suite above cannot fail: a schema that accepted anything
+  // would satisfy every positive assertion.
+
+  it("rejects a slot that is not in TIER_SLOT_KEYS", async () => {
+    vi.mocked(cacheGet).mockResolvedValueOnce(
+      JSON.stringify(mkRecord("bogus.example.com", TIER_SLOT_KEYS)),
+    );
+    const result = await handleDomainStats({ hostname: "bogus.example.com" });
+    const tampered = structuredClone(result.structuredContent) as {
+      record: { tiers: Record<string, unknown> };
+    };
+    tampered.record.tiers.tier9 = stat(1, 1, 0);
+
+    const r = await validateAsClient(tampered);
+    expect(r.valid).toBe(false);
+  });
+
+  it("reproduces vikunja#637: a hand-listed five-slot schema rejects the real payload", async () => {
+    // This is the regression itself, held in place. If someone reverts the
+    // derivation to a literal that omits a slot, THIS is the shape that breaks
+    // — and it breaks here rather than in production.
+    const TierStats = z.object({
+      attempts: z.number(),
+      ok: z.number(),
+      fail: z.number(),
+      success_rate: z.number().nullable(),
+    });
+    const handListedFive = z.object(
+      Object.fromEntries(
+        TIER_SLOT_KEYS.slice(0, 5).map((s) => [s, TierStats]),
+      ) as Record<string, typeof TierStats>,
+    );
+    const staleSchema = toJsonSchemaCompat(
+      z.object({ tiers: handListedFive }),
+      { strictUnions: true, pipeStrategy: "output" },
+    );
+
+    vi.mocked(cacheGet).mockResolvedValueOnce(
+      JSON.stringify(mkRecord("docs.example.com", TIER_SLOT_KEYS)),
+    );
+    const result = await handleDomainStats({ hostname: "docs.example.com" });
+
+    const validateStale = await validator.getValidator(staleSchema);
+    const stale = await validateStale({
+      tiers: result.structuredContent.record?.tiers,
+    });
+    expect(stale.valid).toBe(false);
+
+    // ...and the schema actually shipped accepts the very same payload.
+    const live = await validateAsClient(result.structuredContent);
+    expect(live.valid, JSON.stringify(live.errors ?? live.error)).toBe(true);
+  });
+});

--- a/tests/integration/searxng-credentials-live.test.ts
+++ b/tests/integration/searxng-credentials-live.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Credentialed `SEARXNG_URL`, exercised against REAL `fetch` and REAL servers.
+ *
+ * This file exists because the previous credential test mocked `fetch` to
+ * reject with `new Error("ECONNREFUSED")` — a synthetic message that never
+ * contains a URL. It asserted the right property against the wrong failure
+ * shape, and so it passed while the real behaviour leaked.
+ *
+ * What the mock could not reproduce: the WHATWG Fetch spec forbids building a
+ * request from a URL containing userinfo, and Node enforces it synchronously,
+ * before any network I/O:
+ *
+ *     TypeError: Request cannot be constructed from a URL that includes
+ *     credentials: http://user:pw@host/search?q=x
+ *
+ * The password is in the error's OWN message. So every sink that forwards
+ * `err.message` leaked it, and — separately — a credentialed instance could
+ * never have served a single search.
+ *
+ * NOTHING IN THIS FILE MOCKS `fetch`. That is the point of it.
+ */
+
+import { createServer, type Server } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const SECRET = "hunter2";
+const USER = "searxuser";
+
+const SEARX_BODY = {
+  query: "q",
+  results: [
+    {
+      title: "Authenticated result",
+      url: "https://example.com/authed",
+      content: "served behind basic auth",
+      engines: ["stub"],
+    },
+  ],
+  answers: [],
+  infoboxes: [],
+  corrections: [],
+  suggestions: [],
+};
+
+interface Stub {
+  url: string;
+  authHeaders: (string | undefined)[];
+  close: () => Promise<void>;
+}
+
+/** A real server that records the Authorization header it was sent. */
+async function startAuthStub(requireAuth = true): Promise<Stub> {
+  const authHeaders: (string | undefined)[] = [];
+  const expected = `Basic ${Buffer.from(`${USER}:${SECRET}`).toString("base64")}`;
+  const server: Server = createServer((req, res) => {
+    authHeaders.push(req.headers.authorization);
+    if (requireAuth && req.headers.authorization !== expected) {
+      res.writeHead(401, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "unauthorized" }));
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(SEARX_BODY));
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const addr = server.address();
+  if (typeof addr === "string" || addr === null) throw new Error("bind failed");
+  return {
+    url: `http://127.0.0.1:${addr.port}`,
+    authHeaders,
+    close: () => new Promise<void>((r) => server.close(() => r())),
+  };
+}
+
+/** A port with nothing listening, so a real connection is refused. */
+async function deadPort(): Promise<number> {
+  const s = await startAuthStub();
+  const port = Number(new URL(s.url).port);
+  await s.close();
+  return port;
+}
+
+const ENV = ["SEARXNG_URL", "SEARXNG_TOTAL_TIMEOUT_MS"];
+const clearEnv = () => {
+  for (const k of ENV) delete process.env[k];
+};
+
+async function loadSearch() {
+  vi.doMock("../../src/cache.js", () => ({
+    cacheGet: vi.fn().mockResolvedValue(null),
+    cacheSet: vi.fn().mockResolvedValue(undefined),
+    searchCacheKey: vi.fn().mockReturnValue("k"),
+    getValkey: vi.fn().mockResolvedValue(null),
+    cacheClear: vi.fn(),
+    cacheAtomicUpdate: vi.fn(),
+  }));
+  const searxFailover = vi.fn();
+  const errorEvent = vi.fn();
+  vi.doMock("../../src/events.js", () => ({
+    events: new Proxy(
+      { searxFailover, error: errorEvent },
+      {
+        get: (t, p) => (p in t ? t[p as "searxFailover" | "error"] : vi.fn()),
+      },
+    ),
+  }));
+  const { searxSearchSingle } = await import("../../src/search.js");
+  return { searxSearchSingle, searxFailover, errorEvent };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  clearEnv();
+});
+afterEach(clearEnv);
+
+describe("credentialed SEARXNG_URL — real fetch", () => {
+  it("ACTUALLY WORKS: credentials are sent as a header, and the search succeeds", async () => {
+    // The regression this proves absent: with userinfo left in the URL, Node's
+    // fetch refuses the request outright, so a credentialed instance could
+    // never serve a search at all. This is the functional half of the fix.
+    const stub = await startAuthStub();
+    const { host } = new URL(stub.url);
+    process.env.SEARXNG_URL = `http://${USER}:${SECRET}@${host}`;
+
+    const { searxSearchSingle } = await loadSearch();
+    const out = await searxSearchSingle("q", "general", 5);
+
+    expect(out.results[0].title).toBe("Authenticated result");
+    expect(stub.authHeaders).toHaveLength(1);
+    expect(stub.authHeaders[0]).toBe(
+      `Basic ${Buffer.from(`${USER}:${SECRET}`).toString("base64")}`,
+    );
+    await stub.close();
+  });
+
+  it("percent-encoded credentials are decoded before being encoded", async () => {
+    // A password containing '@' or ':' must be given as %40/%3A in the URL.
+    // Base64-ing the still-encoded form would send the wrong secret.
+    const pass = "p@ss:word";
+    const stubPass = encodeURIComponent(pass);
+    const authHeaders: (string | undefined)[] = [];
+    const server = createServer((req, res) => {
+      authHeaders.push(req.headers.authorization);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(SEARX_BODY));
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const port = (server.address() as { port: number }).port;
+    process.env.SEARXNG_URL = `http://${USER}:${stubPass}@127.0.0.1:${port}`;
+
+    const { searxSearchSingle } = await loadSearch();
+    await searxSearchSingle("q", "general", 5);
+
+    const decoded = Buffer.from(
+      String(authHeaders[0]).replace("Basic ", ""),
+      "base64",
+    ).toString();
+    expect(decoded).toBe(`${USER}:${pass}`);
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it("no credentials in the error thrown to the caller when the host is dead", async () => {
+    const port = await deadPort();
+    process.env.SEARXNG_URL = `http://${USER}:${SECRET}@127.0.0.1:${port}`;
+
+    const { searxSearchSingle } = await loadSearch();
+    let message = "";
+    let ok = false;
+    try {
+      await searxSearchSingle("q", "general", 5);
+      ok = true;
+    } catch (e) {
+      message = e instanceof Error ? e.message : String(e);
+    }
+    expect(ok).toBe(false);
+    expect(message).not.toContain(SECRET);
+  });
+
+  it("no credentials in the generic error event, on the SINGLE-instance path", async () => {
+    // `events.error` fires regardless of instance count, so the failover-only
+    // redaction never runs here. This is the sink the original fix missed.
+    const port = await deadPort();
+    process.env.SEARXNG_URL = `http://${USER}:${SECRET}@127.0.0.1:${port}`;
+
+    vi.doMock("../../src/observability.js", () => ({
+      withSpan: vi.fn().mockImplementation((_n, _a, fn) => fn()),
+      incCounter: vi.fn(),
+      recordHistogram: vi.fn(),
+    }));
+    vi.doMock("../../src/reranker.js", () => ({
+      rerankWithFallback: vi.fn().mockImplementation((_q, r) => r),
+    }));
+    const errorEvent = vi.fn();
+    vi.doMock("../../src/events.js", () => ({
+      events: new Proxy(
+        { error: errorEvent },
+        { get: (t, p) => (p in t ? t[p as "error"] : vi.fn()) },
+      ),
+    }));
+    vi.doMock("../../src/cache.js", () => ({
+      cacheGet: vi.fn().mockResolvedValue(null),
+      cacheSet: vi.fn().mockResolvedValue(undefined),
+      searchCacheKey: vi.fn().mockReturnValue("k"),
+      getValkey: vi.fn().mockResolvedValue(null),
+      cacheClear: vi.fn(),
+      cacheAtomicUpdate: vi.fn(),
+    }));
+
+    const { handleSearch } = await import("../../src/tools.js");
+    await expect(
+      handleSearch({ query: "q", num_results: 3 }),
+    ).rejects.toThrow();
+
+    expect(errorEvent).toHaveBeenCalled();
+    expect(JSON.stringify(errorEvent.mock.calls)).not.toContain(SECRET);
+  });
+
+  it("no credentials in the failover event or stderr line, multi-instance", async () => {
+    const p1 = await deadPort();
+    const p2 = await deadPort();
+    process.env.SEARXNG_URL = `http://${USER}:${SECRET}@127.0.0.1:${p1},http://${USER}:${SECRET}@127.0.0.1:${p2}`;
+
+    const { resetLogThrottle } = await import("../../src/log.js");
+    resetLogThrottle();
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { searxSearchSingle, searxFailover } = await loadSearch();
+    await expect(searxSearchSingle("q", "general", 5)).rejects.toThrow();
+
+    expect(searxFailover).toHaveBeenCalled();
+    expect(JSON.stringify(searxFailover.mock.calls)).not.toContain(SECRET);
+
+    const logged = spy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).not.toContain(SECRET);
+    spy.mockRestore();
+  });
+});

--- a/tests/integration/searxng-failover-live.test.ts
+++ b/tests/integration/searxng-failover-live.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Failover against REAL HTTP servers, not a mocked `fetch`.
+ *
+ * forge runs exactly one SearXNG container, so preflight called for a stub
+ * returning valid SearXNG JSON rather than skipping the multi-instance test.
+ * That stub is `startStubSearxng` below: a `node:http` server that answers
+ * `/search` with a real SearXNG-shaped JSON body.
+ *
+ * This covers what the mocked-fetch suite cannot:
+ *   - a genuinely refused connection (real ECONNREFUSED, not a synthetic throw)
+ *   - real `AbortSignal.timeout` interaction with a real socket
+ *   - the actual URL the client builds, observed at the server end
+ *   - real JSON parsing of a real response body
+ *
+ * Ports are bound with 0 so the OS assigns them. Picking a port and checking it
+ * is free beforehand is not a reservation — something can take it in between.
+ */
+
+import { createServer, type Server } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const SEARX_BODY = {
+  query: "q",
+  results: [
+    {
+      title: "Stub result",
+      url: "https://example.com/stub",
+      content: "from the stub instance",
+      engines: ["stub"],
+    },
+  ],
+  answers: [],
+  infoboxes: [],
+  corrections: [],
+  suggestions: [],
+};
+
+interface Stub {
+  url: string;
+  paths: string[];
+  close: () => Promise<void>;
+}
+
+/** A real HTTP server answering /search with valid SearXNG JSON. */
+async function startStubSearxng(
+  handler?: (path: string) => { status: number; body?: unknown } | undefined,
+): Promise<Stub> {
+  const paths: string[] = [];
+  const server: Server = createServer((req, res) => {
+    paths.push(req.url ?? "");
+    const override = handler?.(req.url ?? "");
+    if (override) {
+      res.writeHead(override.status, { "content-type": "application/json" });
+      res.end(JSON.stringify(override.body ?? {}));
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(SEARX_BODY));
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address();
+  if (typeof addr === "string" || addr === null) {
+    throw new Error("stub failed to bind");
+  }
+  return {
+    url: `http://127.0.0.1:${addr.port}`,
+    paths,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+/** A URL with nothing listening: bind to get a port, then release it. */
+async function deadUrl(): Promise<string> {
+  const s = await startStubSearxng();
+  const url = s.url;
+  await s.close();
+  return url;
+}
+
+const ENV = [
+  "SEARXNG_URL",
+  "SEARXNG_TOTAL_TIMEOUT_MS",
+  "SEARXNG_ATTEMPT_TIMEOUT_MS",
+];
+
+function clearEnv() {
+  for (const k of ENV) delete process.env[k];
+}
+
+async function loadSearch() {
+  vi.doMock("../../src/cache.js", () => ({
+    cacheGet: vi.fn().mockResolvedValue(null),
+    cacheSet: vi.fn().mockResolvedValue(undefined),
+    searchCacheKey: vi.fn().mockReturnValue("k"),
+    getValkey: vi.fn().mockResolvedValue(null),
+    cacheClear: vi.fn(),
+    cacheAtomicUpdate: vi.fn(),
+  }));
+  vi.doMock("../../src/observability.js", () => ({
+    withSpan: vi.fn().mockImplementation((_n, _a, fn) => fn()),
+    incCounter: vi.fn(),
+    recordHistogram: vi.fn(),
+  }));
+  const searxFailover = vi.fn();
+  vi.doMock("../../src/events.js", () => ({
+    events: new Proxy(
+      { searxFailover },
+      { get: (t, p) => (p in t ? t[p as "searxFailover"] : vi.fn()) },
+    ),
+  }));
+  const { searxSearchSingle } = await import("../../src/search.js");
+  return { searxSearchSingle, searxFailover };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  clearEnv();
+});
+afterEach(clearEnv);
+
+describe("failover against real SearXNG stubs", () => {
+  it("single live instance returns its results", async () => {
+    const live = await startStubSearxng();
+    process.env.SEARXNG_URL = live.url;
+
+    const { searxSearchSingle } = await loadSearch();
+    const out = await searxSearchSingle("q", "general", 5);
+
+    expect(out.results[0].title).toBe("Stub result");
+    expect(live.paths).toHaveLength(1);
+    expect(live.paths[0]).toContain("/search?");
+    await live.close();
+  });
+
+  it("[dead, live] recovers over a real refused connection", async () => {
+    const dead = await deadUrl();
+    const live = await startStubSearxng();
+    process.env.SEARXNG_URL = `${dead},${live.url}`;
+
+    const { searxSearchSingle, searxFailover } = await loadSearch();
+    const out = await searxSearchSingle("q", "general", 5);
+
+    expect(out.results[0].url).toBe("https://example.com/stub");
+    expect(live.paths).toHaveLength(1);
+    expect(searxFailover).toHaveBeenCalledTimes(1);
+    expect(searxFailover.mock.calls[0][0]).toMatchObject({
+      from: dead,
+      to: live.url,
+      exhausted: false,
+    });
+    await live.close();
+  });
+
+  it("[live, dead] never opens a connection to the dead instance", async () => {
+    const live = await startStubSearxng();
+    const dead = await deadUrl();
+    process.env.SEARXNG_URL = `${live.url},${dead}`;
+
+    const { searxSearchSingle, searxFailover } = await loadSearch();
+    await searxSearchSingle("q", "general", 5);
+
+    expect(live.paths).toHaveLength(1);
+    expect(searxFailover).not.toHaveBeenCalled();
+    await live.close();
+  });
+
+  it("fails over from a real 502 to a healthy replica", async () => {
+    const bad = await startStubSearxng(() => ({
+      status: 502,
+      body: { error: "bad gateway" },
+    }));
+    const live = await startStubSearxng();
+    process.env.SEARXNG_URL = `${bad.url},${live.url}`;
+
+    const { searxSearchSingle } = await loadSearch();
+    const out = await searxSearchSingle("q", "general", 5);
+
+    expect(out.results[0].title).toBe("Stub result");
+    expect(bad.paths).toHaveLength(1);
+    expect(live.paths).toHaveLength(1);
+    await bad.close();
+    await live.close();
+  });
+
+  it("forwards the query and category to the instance that serves it", async () => {
+    // Proves failover hands the SAME request on, rather than a degraded one.
+    const dead = await deadUrl();
+    const live = await startStubSearxng();
+    process.env.SEARXNG_URL = `${dead},${live.url}`;
+
+    const { searxSearchSingle } = await loadSearch();
+    await searxSearchSingle("nginx reverse proxy", "it", 5, "month");
+
+    const params = new URLSearchParams(live.paths[0].split("?")[1]);
+    expect(params.get("q")).toBe("nginx reverse proxy");
+    expect(params.get("categories")).toBe("it");
+    expect(params.get("time_range")).toBe("month");
+    expect(params.get("format")).toBe("json");
+    await live.close();
+  });
+
+  it("throws when every real instance is dead", async () => {
+    process.env.SEARXNG_URL = `${await deadUrl()},${await deadUrl()}`;
+    const { searxSearchSingle, searxFailover } = await loadSearch();
+
+    await expect(searxSearchSingle("q", "general", 5)).rejects.toThrow();
+    expect(searxFailover).toHaveBeenCalledTimes(2);
+    expect(searxFailover.mock.calls[1][0]).toMatchObject({ exhausted: true });
+  });
+
+  it("respects the total budget against instances that hang", async () => {
+    // A hung socket, not a refused one — this is the case the shared deadline
+    // exists for, and the one a per-instance timeout would multiply.
+    const hang1 = createServer(() => {
+      /* accept and never respond */
+    });
+    const hang2 = createServer(() => {});
+    await new Promise<void>((r) => hang1.listen(0, "127.0.0.1", r));
+    await new Promise<void>((r) => hang2.listen(0, "127.0.0.1", r));
+    const p1 = (hang1.address() as { port: number }).port;
+    const p2 = (hang2.address() as { port: number }).port;
+
+    process.env.SEARXNG_URL = `http://127.0.0.1:${p1},http://127.0.0.1:${p2}`;
+    process.env.SEARXNG_TOTAL_TIMEOUT_MS = "400";
+    process.env.SEARXNG_ATTEMPT_TIMEOUT_MS = "300";
+
+    const { searxSearchSingle } = await loadSearch();
+    const t0 = Date.now();
+    await expect(searxSearchSingle("q", "general", 5)).rejects.toThrow();
+    const elapsed = Date.now() - t0;
+
+    // 2 x 300ms unbudgeted would be ~600ms; the budget caps it at 400ms.
+    expect(elapsed).toBeLessThan(560);
+    expect(elapsed).toBeGreaterThanOrEqual(350);
+
+    hang1.closeAllConnections();
+    hang2.closeAllConnections();
+    await new Promise<void>((r) => hang1.close(() => r()));
+    await new Promise<void>((r) => hang2.close(() => r()));
+  });
+});

--- a/tests/min-score.test.ts
+++ b/tests/min-score.test.ts
@@ -1,0 +1,237 @@
+/**
+ * `min_score` — a relevance floor applied after reranking.
+ *
+ * The two things worth testing here are both about WHICH number is compared
+ * and WHAT HAPPENS WHEN THERE IS NO NUMBER:
+ *
+ * 1. It filters on the RAW `relevance_score`, not on the value `rerank()`
+ *    sorts by. That sort key is `relevance_score + RERANK_RECENCY_WEIGHT *
+ *    recencyScore(publishedDate)`, which with the default weight of 0.15 ranges
+ *    over 0..1.15. Filtering a parameter called "minimum relevance" on a
+ *    recency-inflated number would let a recent-but-irrelevant document through
+ *    a threshold the caller believed was about relevance. `filters on raw
+ *    relevance, not the recency-inflated sort score` is the test that pins it.
+ *
+ * 2. When the reranker is down there are no scores at all, so the filter cannot
+ *    be applied. It becomes a no-op AND SAYS SO. Returning unfiltered results
+ *    silently would let a caller believe a floor had been applied.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/observability.js", () => ({
+  withSpan: vi.fn().mockImplementation((_n, _a, fn) => fn()),
+  incCounter: vi.fn(),
+  recordHistogram: vi.fn(),
+}));
+
+import { resetLogThrottle } from "../src/log.js";
+import { rerankWithFallback } from "../src/reranker.js";
+import type { SearxResult } from "../src/types.js";
+
+const result = (title: string, publishedDate?: string): SearxResult => ({
+  title,
+  url: `https://example.com/${title}`,
+  content: `content for ${title}`,
+  engines: ["stub"],
+  ...(publishedDate ? { publishedDate } : {}),
+});
+
+/** Mock the reranker HTTP endpoint with a fixed score per document index. */
+function stubReranker(scores: number[]) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      results: scores.map((relevance_score, index) => ({
+        index,
+        relevance_score,
+      })),
+    }),
+  } as Response);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+const errSpy = () => vi.spyOn(console, "error").mockImplementation(() => {});
+
+beforeEach(() => {
+  resetLogThrottle();
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("min_score — default behaviour", () => {
+  it("omitting it changes nothing", async () => {
+    stubReranker([0.9, 0.5, 0.001]);
+    const input = [result("a"), result("b"), result("c")];
+
+    const withOut = await rerankWithFallback("q", input, 10);
+    expect(withOut.map((r) => r.title)).toEqual(["a", "b", "c"]);
+  });
+
+  it("a threshold of 0 keeps everything", async () => {
+    stubReranker([0.9, 0.5, 0.0]);
+    const input = [result("a"), result("b"), result("c")];
+
+    const out = await rerankWithFallback("q", input, 10, undefined, 0);
+    expect(out).toHaveLength(3);
+  });
+});
+
+describe("min_score — filtering", () => {
+  it("drops results below the threshold", async () => {
+    // The measured live distribution: relevant near 1.0, irrelevant near 0.
+    stubReranker([0.998, 0.967, 0.0028, 0.0000151]);
+    const input = [
+      result("nginx"),
+      result("apache"),
+      result("install"),
+      result("banana"),
+    ];
+
+    const out = await rerankWithFallback("q", input, 10, undefined, 0.01);
+    expect(out.map((r) => r.title)).toEqual(["nginx", "apache"]);
+  });
+
+  it("returns an empty list when nothing clears the floor", async () => {
+    stubReranker([0.001, 0.002]);
+    const input = [result("a"), result("b")];
+
+    expect(await rerankWithFallback("q", input, 10, undefined, 0.9)).toEqual(
+      [],
+    );
+  });
+
+  it("filters BEFORE slicing to topN, so the floor does not cost results", async () => {
+    // This ordering is only observable when a BELOW-threshold result would
+    // otherwise occupy a top-N slot. Sorting is by the recency-adjusted score
+    // while filtering is on raw relevance, so recency is what lets a result the
+    // floor rejects outrank one it accepts:
+    //
+    //   a      raw 0.95, no date  -> sorts 0.95   keep
+    //   fresh  raw 0.30, today    -> sorts ~0.45  DROP (raw 0.30 < 0.4)
+    //   c      raw 0.42, no date  -> sorts 0.42   keep
+    //
+    // Filter-then-slice returns [a, c]. Slice-then-filter takes [a, fresh]
+    // first and then drops fresh, returning just [a] — a result lost to a
+    // floor it actually cleared.
+    //
+    // An earlier version of this test used a low-relevance, undated result,
+    // which sorted last anyway and so passed under BOTH orderings.
+    stubReranker([0.95, 0.3, 0.42]);
+    const today = new Date().toISOString();
+    const input = [result("a"), result("fresh", today), result("c")];
+
+    const out = await rerankWithFallback("q", input, 2, undefined, 0.4);
+    expect(out.map((r) => r.title)).toEqual(["a", "c"]);
+  });
+
+  it("is inclusive at the boundary", async () => {
+    stubReranker([0.5, 0.4999]);
+    const input = [result("at"), result("below")];
+
+    const out = await rerankWithFallback("q", input, 10, undefined, 0.5);
+    expect(out.map((r) => r.title)).toEqual(["at"]);
+  });
+});
+
+describe("min_score — which score it compares", () => {
+  it("filters on raw relevance, not the recency-inflated sort score", async () => {
+    // THE central test of this phase.
+    //
+    // "fresh" scores 0.30 raw and is published today, so with the default
+    // RERANK_RECENCY_WEIGHT of 0.15 its combined sort score is ~0.45 — above a
+    // 0.40 threshold. Its RAW relevance is 0.30, below it.
+    //
+    // Filtering on the combined score would keep "fresh"; filtering on raw
+    // relevance drops it. If this test ever flips, a "minimum relevance"
+    // parameter has silently started meaning "minimum relevance or recent
+    // enough", which is the trap the plan called out.
+    stubReranker([0.3, 0.95]);
+    const today = new Date().toISOString();
+    const input = [result("fresh", today), result("relevant")];
+
+    const out = await rerankWithFallback("q", input, 10, undefined, 0.4);
+    expect(out.map((r) => r.title)).toEqual(["relevant"]);
+  });
+
+  it("still ORDERS by the recency-adjusted score", async () => {
+    // Filtering on raw relevance must not disturb ranking: recency still wins
+    // the sort among results that clear the floor.
+    stubReranker([0.6, 0.65]);
+    const today = new Date().toISOString();
+    const input = [result("recent", today), result("stale")];
+
+    // Both clear 0.5. "recent" gets +0.15*~1.0 => ~0.75 vs "stale" 0.65.
+    const out = await rerankWithFallback("q", input, 10, undefined, 0.5);
+    expect(out.map((r) => r.title)).toEqual(["recent", "stale"]);
+  });
+
+  it("does not apply recency at all when time_range is set", async () => {
+    // Pre-existing behaviour, pinned because min_score now shares this path.
+    stubReranker([0.6, 0.65]);
+    const today = new Date().toISOString();
+    const input = [result("recent", today), result("stale")];
+
+    const out = await rerankWithFallback("q", input, 10, "month", 0.5);
+    expect(out.map((r) => r.title)).toEqual(["stale", "recent"]);
+  });
+});
+
+describe("min_score — degraded reranker", () => {
+  it("becomes a no-op rather than emptying the result set", async () => {
+    // Returning [] here would turn a reranker outage into "no results found".
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("down")));
+    const spy = errSpy();
+    const input = [result("a"), result("b"), result("c")];
+
+    const out = await rerankWithFallback("q", input, 10, undefined, 0.9);
+    expect(out.map((r) => r.title)).toEqual(["a", "b", "c"]);
+    spy.mockRestore();
+  });
+
+  it("announces the no-op instead of silently returning unfiltered results", async () => {
+    // A silent unfiltered response is the worst option: the caller believes a
+    // relevance floor was applied when none was.
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("down")));
+    const spy = errSpy();
+
+    await rerankWithFallback("q", [result("a")], 10, undefined, 0.9);
+
+    const logged = spy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).toContain("min_score=0.9 ignored");
+    expect(logged).toContain("reranker unavailable");
+    spy.mockRestore();
+  });
+
+  it("says nothing extra about min_score when it was not requested", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("down")));
+    const spy = errSpy();
+
+    await rerankWithFallback("q", [result("a")], 10);
+
+    const logged = spy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).toContain("reranker unavailable");
+    expect(logged).not.toContain("min_score");
+    spy.mockRestore();
+  });
+
+  it("throttles the no-op warning rather than logging per call", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("down")));
+    const spy = errSpy();
+
+    for (let i = 0; i < 5; i++) {
+      await rerankWithFallback("q", [result("a")], 10, undefined, 0.9);
+    }
+
+    const lines = spy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((l) => l.includes("min_score"));
+    expect(lines).toHaveLength(1);
+    spy.mockRestore();
+  });
+});

--- a/tests/observability-redaction.test.ts
+++ b/tests/observability-redaction.test.ts
@@ -1,0 +1,96 @@
+/**
+ * `withSpan` must not export URL credentials to the collector.
+ *
+ * A span leaves the host over OTLP, so it is a sink like any other. Node's
+ * `fetch` rejects a credentialed URL with a `TypeError` whose message embeds
+ * the whole URL, password included, and `withSpan`'s catch block forwards
+ * `err.message` into both `recordException` and `setStatus`.
+ *
+ * This test drives the REAL `withSpan` with a tracer injected through the
+ * module's own init path. An earlier attempt mocked `withSpan` and had the mock
+ * perform the redaction itself — it stayed green with the production redaction
+ * deleted, which made it worthless. The `statuses.length` guard below exists so
+ * that a tracer that failed to inject fails the test rather than passing it
+ * vacuously.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const SECRET = "hunter2";
+
+beforeEach(() => {
+  vi.resetModules();
+});
+afterEach(() => {
+  delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+});
+
+describe("withSpan credential redaction", () => {
+  it("redacts credentials from both the recorded exception and the span status", async () => {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://127.0.0.1:4318";
+
+    const statuses: unknown[] = [];
+    const exceptions: Error[] = [];
+    const span = {
+      setAttributes: () => {},
+      recordException: (e: Error) => exceptions.push(e),
+      setStatus: (st: unknown) => statuses.push(st),
+      end: () => {},
+    };
+    const noopMeter = {
+      createCounter: () => ({ add: () => {} }),
+      createHistogram: () => ({ record: () => {} }),
+    };
+
+    vi.doMock("@opentelemetry/api", () => ({
+      trace: {
+        getTracer: () => ({
+          startActiveSpan: (_n: string, fn: (s: unknown) => unknown) =>
+            fn(span),
+        }),
+        getActiveSpan: () => undefined,
+      },
+      metrics: { getMeter: () => noopMeter },
+    }));
+    vi.doMock("@opentelemetry/sdk-node", () => ({
+      NodeSDK: class {
+        start() {}
+        shutdown() {
+          return Promise.resolve();
+        }
+      },
+    }));
+    vi.doMock("@opentelemetry/exporter-trace-otlp-http", () => ({
+      OTLPTraceExporter: class {},
+    }));
+    vi.doMock("@opentelemetry/exporter-metrics-otlp-http", () => ({
+      OTLPMetricExporter: class {},
+    }));
+    vi.doMock("@opentelemetry/sdk-metrics", () => ({
+      PeriodicExportingMetricReader: class {},
+    }));
+
+    const obs = await import("../src/observability.js");
+    await obs.initObservability();
+
+    // The exact shape Node's fetch produces for a credentialed URL.
+    const leaky = new TypeError(
+      `Request cannot be constructed from a URL that includes credentials: http://admin:${SECRET}@searxng.internal:8080/search?q=x`,
+    );
+    await expect(
+      obs.withSpan("t", {}, async () => {
+        throw leaky;
+      }),
+    ).rejects.toThrow();
+
+    // Guard the guard: without an injected tracer, withSpan no-ops and nothing
+    // is recorded, so the two assertions below would pass having tested nothing.
+    expect(statuses.length).toBeGreaterThan(0);
+    expect(exceptions.length).toBeGreaterThan(0);
+
+    expect(JSON.stringify(statuses)).not.toContain(SECRET);
+    expect(exceptions.map((e) => e.message).join(" ")).not.toContain(SECRET);
+    // The useful part of the message survives — this is redaction, not deletion.
+    expect(JSON.stringify(statuses)).toContain("searxng.internal:8080");
+  });
+});

--- a/tests/search-histogram-labels.test.ts
+++ b/tests/search-histogram-labels.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Labels on the shared `search` histogram, and latency on the failure path.
+ *
+ * All three search tools record into ONE histogram. Before this it carried only
+ * `profile`, so a duration could not be attributed to the tool that produced
+ * it — and the three have very different normal ranges (a plain `search` is
+ * bounded around ~17.5s; `search_and_summarize` routinely runs to ~50s because
+ * it adds up to five fetches and an Ollama call). The 7-day maximum of 51.6s
+ * was therefore uninterpretable: routine for one tool, alarming for another.
+ *
+ * The failure path recorded no duration at all, only `errors_total`, so a
+ * search that failed after 40s looked exactly like one that failed instantly.
+ *
+ * NOT covered here, deliberately: a *hang*. Both recordings happen after
+ * `await fn()` settles, so a call that never returns still records nothing.
+ * That is a real remaining gap and needs a watchdog, not a label.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/cache.js", () => ({
+  cacheClear: vi.fn().mockResolvedValue(0),
+  cacheGet: vi.fn().mockResolvedValue(null),
+  cacheSet: vi.fn().mockResolvedValue(undefined),
+  cacheAtomicUpdate: vi.fn().mockResolvedValue(undefined),
+  getValkey: vi.fn().mockResolvedValue(null),
+  searchCacheKey: vi.fn().mockReturnValue("key"),
+}));
+
+vi.mock("../src/search.js", () => ({
+  searxSearch: vi.fn().mockResolvedValue({
+    results: [
+      {
+        title: "R1",
+        url: "https://example.com/1",
+        content: "c",
+        engines: ["google"],
+      },
+    ],
+    meta: { answers: [], infoboxes: [], corrections: [], suggestions: [] },
+  }),
+}));
+
+vi.mock("../src/reranker.js", () => ({
+  rerankWithFallback: vi
+    .fn()
+    .mockImplementation((_q, results) => Promise.resolve(results)),
+}));
+
+vi.mock("../src/fetch.js", () => ({
+  fetchPage: vi.fn().mockResolvedValue({
+    title: "P",
+    url: "https://example.com/1",
+    text: "text",
+  }),
+}));
+
+vi.mock("../src/ollama.js", () => ({
+  summarizePages: vi.fn().mockResolvedValue({ summary: "s", citations: [] }),
+  formatSummaryResult: vi.fn().mockReturnValue("## Summary"),
+}));
+
+vi.mock("../src/observability.js", () => ({
+  incCounter: vi.fn(),
+  recordHistogram: vi.fn(),
+  withSpan: vi.fn().mockImplementation((_n, _a, fn) => fn()),
+}));
+
+vi.mock("../src/context.js", () => ({
+  newRequestId: vi.fn().mockReturnValue("req"),
+  withRequestId: vi.fn().mockImplementation((_id, fn) => fn()),
+}));
+
+import { incCounter, recordHistogram } from "../src/observability.js";
+import { searxSearch } from "../src/search.js";
+import {
+  handleSearch,
+  handleSearchAndFetch,
+  handleSearchAndSummarize,
+} from "../src/tools.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/** The single `recordHistogram("search", ...)` call, or a clear failure. */
+function soleSearchHistogram() {
+  const calls = vi
+    .mocked(recordHistogram)
+    .mock.calls.filter((c) => c[0] === "search");
+  expect(calls).toHaveLength(1);
+  return { seconds: calls[0][1], attrs: calls[0][2] };
+}
+
+describe("search histogram — tool label", () => {
+  const cases = [
+    ["search", () => handleSearch({ query: "q", num_results: 3 })],
+    [
+      "search_and_fetch",
+      () => handleSearchAndFetch({ query: "q", fetch_count: 1 }),
+    ],
+    [
+      "search_and_summarize",
+      () => handleSearchAndSummarize({ query: "q", fetch_count: 1 }),
+    ],
+  ] as const;
+
+  for (const [toolName, invoke] of cases) {
+    it(`records the histogram labelled tool=${toolName}`, async () => {
+      await invoke();
+      expect(soleSearchHistogram().attrs).toMatchObject({
+        tool: toolName,
+        outcome: "ok",
+      });
+    });
+
+    it(`records the counter labelled tool=${toolName}`, async () => {
+      await invoke();
+      const calls = vi
+        .mocked(incCounter)
+        .mock.calls.filter((c) => c[0] === "search");
+      expect(calls).toHaveLength(1);
+      expect(calls[0][1]).toMatchObject({ tool: toolName });
+    });
+  }
+
+  it("gives the three tools three DIFFERENT labels", async () => {
+    // The point of the label is discrimination. Asserting each tool's value in
+    // isolation would still pass if every one of them emitted "search".
+    const seen: string[] = [];
+    for (const [, invoke] of cases) {
+      vi.clearAllMocks();
+      await invoke();
+      seen.push(soleSearchHistogram().attrs?.tool as string);
+    }
+    expect(new Set(seen).size).toBe(3);
+  });
+});
+
+describe("search histogram — failure path", () => {
+  it("records a duration when the search throws, not just an error count", async () => {
+    vi.mocked(searxSearch).mockRejectedValueOnce(new Error("searxng down"));
+
+    // Pin the clock so the assertion is on a REAL elapsed value. Asserting
+    // `any(Number)` would pass against a hardcoded zero, which is the exact
+    // failure this phase is meant to make visible.
+    const now = vi
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(41_000);
+
+    await expect(handleSearch({ query: "q", num_results: 3 })).rejects.toThrow(
+      "searxng down",
+    );
+    now.mockRestore();
+
+    const { seconds, attrs } = soleSearchHistogram();
+    expect(seconds).toBe(40);
+    expect(attrs).toMatchObject({ tool: "search", outcome: "error" });
+  });
+
+  it("labels the error counter with the tool", async () => {
+    vi.mocked(searxSearch).mockRejectedValueOnce(new Error("boom"));
+    await expect(
+      handleSearchAndFetch({ query: "q", fetch_count: 1 }),
+    ).rejects.toThrow("boom");
+
+    const errCalls = vi
+      .mocked(incCounter)
+      .mock.calls.filter((c) => c[0] === "errors");
+    expect(errCalls).toHaveLength(1);
+    expect(errCalls[0][1]).toMatchObject({
+      tool: "search_and_fetch",
+      stage: "search",
+    });
+  });
+
+  it("separates ok from error via outcome rather than merging the two", async () => {
+    // Without `outcome`, error latencies would land in the same series as
+    // successes and skew the p99 the histogram exists to report.
+    await handleSearch({ query: "q", num_results: 3 });
+    const ok = soleSearchHistogram().attrs?.outcome;
+
+    vi.clearAllMocks();
+    vi.mocked(searxSearch).mockRejectedValueOnce(new Error("x"));
+    await expect(
+      handleSearch({ query: "q", num_results: 3 }),
+    ).rejects.toThrow();
+    const err = soleSearchHistogram().attrs?.outcome;
+
+    expect(ok).toBe("ok");
+    expect(err).toBe("error");
+  });
+});

--- a/tests/searxng-failover.test.ts
+++ b/tests/searxng-failover.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Multi-instance SearXNG failover (vikunja#144).
+ *
+ * `SEARXNG_URL` was consumed in exactly one place and was the last hard single
+ * point of failure: SearXNG down meant search down, with no degradation path.
+ *
+ * The load-bearing property throughout is that A SCALAR `SEARXNG_URL` MUST
+ * BEHAVE EXACTLY AS BEFORE — that is every existing deployment. Several tests
+ * here exist only to pin that: one request, one host, no health lookup, and the
+ * same 10s bound as the pre-failover `AbortSignal.timeout(10000)`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ENV = [
+  "SEARXNG_URL",
+  "SEARXNG_TOTAL_TIMEOUT_MS",
+  "SEARXNG_ATTEMPT_TIMEOUT_MS",
+  "SEARXNG_UNHEALTHY_TTL_SECONDS",
+];
+
+function clearEnv() {
+  for (const k of ENV) delete process.env[k];
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  clearEnv();
+});
+afterEach(clearEnv);
+
+// ── Config parsing ──────────────────────────────────────────────────────────
+
+describe("parseSearxngUrls", () => {
+  async function parse(raw: string | undefined) {
+    const { parseSearxngUrls } = await import("../src/config.js");
+    const warnings: string[] = [];
+    const urls = parseSearxngUrls(raw, (m) => warnings.push(m));
+    return { urls, warnings };
+  }
+
+  it("treats a scalar value as a single instance", async () => {
+    const { urls, warnings } = await parse("http://searxng:8080");
+    expect(urls).toEqual(["http://searxng:8080"]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("defaults to localhost:8081 when unset", async () => {
+    expect((await parse(undefined)).urls).toEqual(["http://localhost:8081"]);
+  });
+
+  it("splits on commas and on semicolons", async () => {
+    // Semicolon is what the comparable server (ihor-sokoliuk/mcp-searxng) uses;
+    // accepting only commas would silently collapse that syntax to one bogus
+    // instance rather than erroring.
+    expect((await parse("http://a:8080,http://b:8080")).urls).toEqual([
+      "http://a:8080",
+      "http://b:8080",
+    ]);
+    expect((await parse("http://a:8080;http://b:8080")).urls).toEqual([
+      "http://a:8080",
+      "http://b:8080",
+    ]);
+  });
+
+  it("trims whitespace and drops empty entries", async () => {
+    expect((await parse(" http://a:8080 , , http://b:8080 ,")).urls).toEqual([
+      "http://a:8080",
+      "http://b:8080",
+    ]);
+  });
+
+  it("strips a trailing slash so the path cannot become //search", async () => {
+    expect((await parse("http://a:8080/")).urls).toEqual(["http://a:8080"]);
+  });
+
+  it("de-duplicates repeated instances", async () => {
+    // A repeat would be retried as a distinct replica, spending the shared
+    // budget on a host that just failed.
+    expect(
+      (await parse("http://a:8080,http://a:8080/,http://b:8080")).urls,
+    ).toEqual(["http://a:8080", "http://b:8080"]);
+  });
+
+  it("drops an unset placeholder rather than treating it as a host", async () => {
+    // An unset ${SEARXNG_URL} interpolates to the LITERAL string, not to empty
+    // — that un-substituted literal IS the input under test. Built by
+    // concatenation so the value is identical while the source carries no
+    // `${...}` for biome's noTemplateCurlyInString rule to flag.
+    const placeholder = "$" + "{SEARXNG_URL}";
+    expect(placeholder.startsWith("$" + "{")).toBe(true);
+    expect(placeholder.endsWith("}")).toBe(true);
+    const { urls, warnings } = await parse(placeholder);
+    expect(urls).toEqual(["http://localhost:8081"]);
+    expect(warnings.join(" ")).toContain("not a valid URL");
+  });
+
+  it("drops a non-http scheme", async () => {
+    const { urls, warnings } = await parse("file:///etc/passwd,http://b:8080");
+    expect(urls).toEqual(["http://b:8080"]);
+    expect(warnings.join(" ")).toContain("not http(s)");
+  });
+
+  it("falls back to the default rather than refusing to boot when all entries are bad", async () => {
+    // One bad env var must not become a total outage.
+    const { urls, warnings } = await parse("nonsense,also-nonsense");
+    expect(urls).toEqual(["http://localhost:8081"]);
+    expect(warnings.join(" ")).toContain("no usable entries");
+  });
+
+  it("keeps a bad entry from taking out the good ones beside it", async () => {
+    expect((await parse("http://a:8080,nonsense,http://b:8080")).urls).toEqual([
+      "http://a:8080",
+      "http://b:8080",
+    ]);
+  });
+});
+
+// ── Candidate ordering ──────────────────────────────────────────────────────
+
+describe("getSearxCandidates", () => {
+  async function load(marked: string[] = []) {
+    const cacheGet = vi
+      .fn()
+      .mockImplementation(async (key: string) =>
+        marked.some((m) => key.includes(m)) ? "1" : null,
+      );
+    const cacheSet = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("../src/cache.js", () => ({
+      cacheGet,
+      cacheSet,
+      searchCacheKey: vi.fn().mockReturnValue("k"),
+      getValkey: vi.fn().mockResolvedValue(null),
+      cacheClear: vi.fn(),
+      cacheAtomicUpdate: vi.fn(),
+    }));
+    const mod = await import("../src/instances.js");
+    return { ...mod, cacheGet, cacheSet };
+  }
+
+  it("skips the health lookup entirely for a single instance", async () => {
+    // Not an optimisation detail — it is the guarantee that the single-instance
+    // hot path gains no cache round-trip, and that the only instance is tried
+    // even when it is known to be down.
+    const { getSearxCandidates, cacheGet } = await load(["a"]);
+    expect(await getSearxCandidates(["http://a:8080"])).toEqual([
+      "http://a:8080",
+    ]);
+    expect(cacheGet).not.toHaveBeenCalled();
+  });
+
+  it("puts healthy instances ahead of ones marked unhealthy", async () => {
+    const { getSearxCandidates } = await load(["a:8080"]);
+    expect(
+      await getSearxCandidates(["http://a:8080", "http://b:8080"]),
+    ).toEqual(["http://b:8080", "http://a:8080"]);
+  });
+
+  it("preserves configured order within each group", async () => {
+    const { getSearxCandidates } = await load(["b:8080"]);
+    expect(
+      await getSearxCandidates([
+        "http://a:8080",
+        "http://b:8080",
+        "http://c:8080",
+      ]),
+    ).toEqual(["http://a:8080", "http://c:8080", "http://b:8080"]);
+  });
+
+  it("returns the full configured list when everything is marked unhealthy", async () => {
+    // "Everything looks down" is exactly when you most want to actually try.
+    const { getSearxCandidates } = await load(["a:8080", "b:8080"]);
+    expect(
+      await getSearxCandidates(["http://a:8080", "http://b:8080"]),
+    ).toEqual(["http://a:8080", "http://b:8080"]);
+  });
+
+  it("degrades to configured order when the cache throws", async () => {
+    vi.doMock("../src/cache.js", () => ({
+      cacheGet: vi.fn().mockRejectedValue(new Error("cache down")),
+      cacheSet: vi.fn().mockResolvedValue(undefined),
+      searchCacheKey: vi.fn(),
+      getValkey: vi.fn(),
+      cacheClear: vi.fn(),
+      cacheAtomicUpdate: vi.fn(),
+    }));
+    const { getSearxCandidates } = await import("../src/instances.js");
+    expect(
+      await getSearxCandidates(["http://a:8080", "http://b:8080"]),
+    ).toEqual(["http://a:8080", "http://b:8080"]);
+  });
+
+  it("keeps credentials out of the cache key", async () => {
+    const { unhealthyKey } = await load();
+    const key = unhealthyKey("http://user:secret@a:8080/path");
+    expect(key).not.toContain("secret");
+    expect(key).not.toContain("user");
+    expect(key).toContain("a:8080");
+  });
+});
+
+// ── Failover behaviour ──────────────────────────────────────────────────────
+
+const SEARX_OK = {
+  results: [
+    { title: "T", url: "https://example.com/1", content: "c", engines: ["g"] },
+  ],
+  answers: [],
+  infoboxes: [],
+  corrections: [],
+  suggestions: [],
+};
+
+function okResponse(body: unknown = SEARX_OK) {
+  return { ok: true, status: 200, json: async () => body } as Response;
+}
+
+describe("searxSearchSingle failover", () => {
+  async function load(
+    urls: string,
+    opts: { marked?: string[]; totalMs?: string } = {},
+  ) {
+    process.env.SEARXNG_URL = urls;
+    if (opts.totalMs) process.env.SEARXNG_TOTAL_TIMEOUT_MS = opts.totalMs;
+
+    const cacheSet = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("../src/cache.js", () => ({
+      cacheGet: vi
+        .fn()
+        .mockImplementation(async (key: string) =>
+          (opts.marked ?? []).some((m) => key.includes(m)) ? "1" : null,
+        ),
+      cacheSet,
+      searchCacheKey: vi.fn().mockReturnValue("k"),
+      getValkey: vi.fn().mockResolvedValue(null),
+      cacheClear: vi.fn(),
+      cacheAtomicUpdate: vi.fn(),
+    }));
+    const searxFailover = vi.fn();
+    vi.doMock("../src/events.js", () => ({
+      events: new Proxy(
+        { searxFailover },
+        { get: (t, p) => (p in t ? t[p as "searxFailover"] : vi.fn()) },
+      ),
+    }));
+    vi.doMock("../src/observability.js", () => ({
+      withSpan: vi.fn().mockImplementation((_n, _a, fn) => fn()),
+      incCounter: vi.fn(),
+      recordHistogram: vi.fn(),
+    }));
+    const { searxSearchSingle } = await import("../src/search.js");
+    return { searxSearchSingle, searxFailover, cacheSet };
+  }
+
+  function hosts(fetchMock: ReturnType<typeof vi.fn>): string[] {
+    return fetchMock.mock.calls.map((c) => new URL(c[0] as string).host);
+  }
+
+  it("single instance: exactly one request, to exactly one host", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const { searxSearchSingle } = await load("http://only:8080");
+
+    await searxSearchSingle("q", "general", 5);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(hosts(fetchMock)).toEqual(["only:8080"]);
+    vi.unstubAllGlobals();
+  });
+
+  it("single instance: does NOT emit a failover event when it fails", async () => {
+    // There is nothing to fail over to; an event here would be pure noise and
+    // would make a plain outage look like a replica problem.
+    const fetchMock = vi.fn().mockRejectedValue(new Error("down"));
+    vi.stubGlobal("fetch", fetchMock);
+    const { searxSearchSingle, searxFailover } = await load("http://only:8080");
+
+    await expect(searxSearchSingle("q", "general", 5)).rejects.toThrow("down");
+    expect(searxFailover).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it("[dead, healthy]: succeeds via the second instance", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+      .mockResolvedValueOnce(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const { searxSearchSingle } = await load(
+      "http://dead:8080,http://live:8080",
+    );
+
+    const out = await searxSearchSingle("q", "general", 5);
+    expect(out.results).toHaveLength(1);
+    expect(hosts(fetchMock)).toEqual(["dead:8080", "live:8080"]);
+    vi.unstubAllGlobals();
+  });
+
+  it("[dead, healthy]: emits a failover event naming both ends", async () => {
+    // A silent failover is indistinguishable from a healthy primary.
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+      .mockResolvedValueOnce(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const { searxSearchSingle, searxFailover } = await load(
+      "http://dead:8080,http://live:8080",
+    );
+
+    await searxSearchSingle("q", "general", 5);
+    expect(searxFailover).toHaveBeenCalledTimes(1);
+    expect(searxFailover.mock.calls[0][0]).toMatchObject({
+      from: "http://dead:8080",
+      to: "http://live:8080",
+      attempt: 0,
+      exhausted: false,
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it("[dead, healthy]: marks the dead instance unhealthy for the next call", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+      .mockResolvedValueOnce(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const { searxSearchSingle, cacheSet } = await load(
+      "http://dead:8080,http://live:8080",
+    );
+
+    await searxSearchSingle("q", "general", 5);
+    expect(
+      cacheSet.mock.calls.some((c) => String(c[0]).includes("dead:8080")),
+    ).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it("[healthy, dead]: never contacts the second instance", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const { searxSearchSingle, searxFailover } = await load(
+      "http://live:8080,http://dead:8080",
+    );
+
+    await searxSearchSingle("q", "general", 5);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(hosts(fetchMock)).toEqual(["live:8080"]);
+    expect(searxFailover).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it("treats a non-2xx response as a failure and fails over", async () => {
+    // A 502 from a proxy in front of a dead SearXNG is the common real shape,
+    // and it resolves rather than rejecting — so it must be handled explicitly.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        statusText: "Bad Gateway",
+      } as Response)
+      .mockResolvedValueOnce(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const { searxSearchSingle } = await load(
+      "http://bad:8080,http://live:8080",
+    );
+
+    const out = await searxSearchSingle("q", "general", 5);
+    expect(out.results).toHaveLength(1);
+    expect(hosts(fetchMock)).toEqual(["bad:8080", "live:8080"]);
+    vi.unstubAllGlobals();
+  });
+
+  it("reorders so a previously-failed instance is tried second", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const { searxSearchSingle } = await load("http://a:8080,http://b:8080", {
+      marked: ["a:8080"],
+    });
+
+    await searxSearchSingle("q", "general", 5);
+    expect(hosts(fetchMock)).toEqual(["b:8080"]);
+    vi.unstubAllGlobals();
+  });
+
+  it("throws the last error when every instance fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("first down"))
+      .mockRejectedValueOnce(new Error("second down"));
+    vi.stubGlobal("fetch", fetchMock);
+    const { searxSearchSingle, searxFailover } = await load(
+      "http://a:8080,http://b:8080",
+    );
+
+    await expect(searxSearchSingle("q", "general", 5)).rejects.toThrow(
+      "second down",
+    );
+    expect(searxFailover).toHaveBeenCalledTimes(2);
+    expect(searxFailover.mock.calls[1][0]).toMatchObject({
+      to: null,
+      exhausted: true,
+    });
+    vi.unstubAllGlobals();
+  });
+});
+
+// ── The timeout budget ──────────────────────────────────────────────────────
+
+describe("failover timeout budget", () => {
+  it("bounds the whole call, rather than N x per-instance", async () => {
+    // The defect this prevents: iterating N candidates at the per-attempt
+    // timeout each makes the worst case N*attempt, so adding a replica makes a
+    // total outage take LONGER to report.
+    process.env.SEARXNG_URL =
+      "http://a:8080,http://b:8080,http://c:8080,http://d:8080";
+    process.env.SEARXNG_TOTAL_TIMEOUT_MS = "300";
+    process.env.SEARXNG_ATTEMPT_TIMEOUT_MS = "200";
+
+    vi.doMock("../src/cache.js", () => ({
+      cacheGet: vi.fn().mockResolvedValue(null),
+      cacheSet: vi.fn().mockResolvedValue(undefined),
+      searchCacheKey: vi.fn().mockReturnValue("k"),
+      getValkey: vi.fn().mockResolvedValue(null),
+      cacheClear: vi.fn(),
+      cacheAtomicUpdate: vi.fn(),
+    }));
+    vi.doMock("../src/observability.js", () => ({
+      withSpan: vi.fn().mockImplementation((_n, _a, fn) => fn()),
+      incCounter: vi.fn(),
+      recordHistogram: vi.fn(),
+    }));
+
+    // Every instance hangs until its own signal aborts.
+    const fetchMock = vi.fn().mockImplementation(
+      (_url: string, init: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener("abort", () =>
+            reject(new Error("TimeoutError")),
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { searxSearchSingle } = await import("../src/search.js");
+    const t0 = Date.now();
+    await expect(searxSearchSingle("q", "general", 5)).rejects.toThrow();
+    const elapsed = Date.now() - t0;
+
+    // 4 instances x 200ms per attempt would be ~800ms. The budget is 300ms.
+    // Generous upper bound so this is not timing-flaky, but still far below
+    // the un-budgeted figure it is distinguishing from.
+    expect(elapsed).toBeLessThan(600);
+    // And it must genuinely have spent the budget rather than bailing at once.
+    expect(elapsed).toBeGreaterThanOrEqual(250);
+    // Not every instance gets contacted — the budget cuts the loop short.
+    expect(fetchMock.mock.calls.length).toBeLessThan(4);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/tests/searxng-failover.test.ts
+++ b/tests/searxng-failover.test.ts
@@ -240,7 +240,13 @@ describe("credential redaction", () => {
     spy.mockRestore();
   });
 
-  it("the NATS failover event and the thrown error carry no credentials", async () => {
+  // NOTE: this test mocks `fetch`'s rejection as a generic Error, so it only
+  // covers the *label* redaction — it cannot reproduce the failure mode where
+  // the credential rides in the error MESSAGE, because Node's real fetch is the
+  // thing that puts it there. That gap is what the audit found. The real-fetch
+  // coverage lives in tests/integration/searxng-credentials-live.test.ts; this
+  // one is kept for the label path and deliberately no longer claims more.
+  it("the NATS failover event carries no credentials in its instance labels", async () => {
     process.env.SEARXNG_URL = `${WITH_CREDS},http://admin:${SECRET}@replica:8080`;
     vi.doMock("../src/cache.js", () => ({
       cacheGet: vi.fn().mockResolvedValue(null),

--- a/tests/searxng-failover.test.ts
+++ b/tests/searxng-failover.test.ts
@@ -199,6 +199,105 @@ describe("getSearxCandidates", () => {
   });
 });
 
+// ── Credential redaction at every sink ──────────────────────────────────────
+//
+// `SEARXNG_URL` can legitimately carry basic-auth credentials — an instance
+// behind basic auth is a normal deployment. The instance URL leaves this
+// process by FOUR routes: the cache key, the stderr failover line, the NATS
+// event, and the error message handed back to the caller. Guarding one and
+// leaving three is how a redaction gets quietly bypassed, so each is asserted
+// separately rather than trusting a single shared helper to be called.
+
+describe("credential redaction", () => {
+  const SECRET = "hunter2";
+  const WITH_CREDS = `http://admin:${SECRET}@primary:8080`;
+
+  it("instanceLabel drops userinfo", async () => {
+    const { instanceLabel } = await import("../src/instances.js");
+    const label = instanceLabel(WITH_CREDS);
+    expect(label).not.toContain(SECRET);
+    expect(label).not.toContain("admin");
+    expect(label).toBe("http://primary:8080");
+  });
+
+  it("instanceLabel redacts rather than echoes an unparseable value", async () => {
+    const { instanceLabel } = await import("../src/instances.js");
+    expect(instanceLabel("not a url")).not.toBe("not a url");
+  });
+
+  it("the stderr failover line carries no credentials", async () => {
+    const { logFailover } = await import("../src/instances.js");
+    const { resetLogThrottle } = await import("../src/log.js");
+    resetLogThrottle();
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    logFailover(WITH_CREDS, "http://replica:8080", "ECONNREFUSED");
+
+    const logged = spy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).toContain("primary:8080");
+    expect(logged).not.toContain(SECRET);
+    expect(logged).not.toContain("admin");
+    spy.mockRestore();
+  });
+
+  it("the NATS failover event and the thrown error carry no credentials", async () => {
+    process.env.SEARXNG_URL = `${WITH_CREDS},http://admin:${SECRET}@replica:8080`;
+    vi.doMock("../src/cache.js", () => ({
+      cacheGet: vi.fn().mockResolvedValue(null),
+      cacheSet: vi.fn().mockResolvedValue(undefined),
+      searchCacheKey: vi.fn().mockReturnValue("k"),
+      getValkey: vi.fn().mockResolvedValue(null),
+      cacheClear: vi.fn(),
+      cacheAtomicUpdate: vi.fn(),
+    }));
+    const searxFailover = vi.fn();
+    vi.doMock("../src/events.js", () => ({
+      events: new Proxy(
+        { searxFailover },
+        { get: (t, p) => (p in t ? t[p as "searxFailover"] : vi.fn()) },
+      ),
+    }));
+    vi.doMock("../src/observability.js", () => ({
+      withSpan: vi.fn().mockImplementation((_n, _a, fn) => fn()),
+      incCounter: vi.fn(),
+      recordHistogram: vi.fn(),
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+    );
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { searxSearchSingle } = await import("../src/search.js");
+    let thrown = "";
+    try {
+      await searxSearchSingle("q", "general", 5);
+    } catch (e) {
+      thrown = e instanceof Error ? e.message : String(e);
+    }
+
+    const payloads = JSON.stringify(searxFailover.mock.calls);
+    expect(searxFailover).toHaveBeenCalled();
+    expect(payloads).toContain("primary:8080");
+    expect(payloads).not.toContain(SECRET);
+    expect(payloads).not.toContain("admin");
+    expect(thrown).not.toContain(SECRET);
+
+    spy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("the config warning for a bad entry carries no credentials", async () => {
+    const { parseSearxngUrls } = await import("../src/config.js");
+    const warnings: string[] = [];
+    // Not a valid URL (space), but still carrying something secret-shaped.
+    parseSearxngUrls(`http://admin:${SECRET}@bad host:8080`, (m) =>
+      warnings.push(m),
+    );
+    expect(warnings.join(" ")).not.toContain(SECRET);
+  });
+});
+
 // ── Failover behaviour ──────────────────────────────────────────────────────
 
 const SEARX_OK = {


### PR DESCRIPTION
Build `searxng-mcp-search-hardening-2026-09` — tracker vikunja#144, closes vikunja#637.

Five threads that all land in `search.ts` / `reranker.ts` / `tools.ts`, grouped because split apart they would collide on the same functions and fixtures.

**Baseline 729 passed / 6 skipped → 795 passed / 6 skipped.** 66 new tests, lint clean, no type errors.

---

## 1. `domain_stats` was 100% dead — fixed structurally (vikunja#637)

Reproduced live at the start of the session: every call from a solver-enabled deployment failed with `Additional properties are not allowed ('solver' was unexpected)`.

The root cause is not a missing key. The payload is *derived* from `TIER_SLOT_KEYS` in **both** tool modes, while `AllTiersOutputSchema` hand-listed five of six. So the fix is to derive the schema from the same constant — the ticket's own suggestion ("add `solver` to the schema") would have guaranteed a repeat at the next tier slot. Every slot is now optional: `tier4` needs `WAYBACK_ENABLED` and `solver` needs `SOLVER_ENABLED`, so requiring them only inverts which deployments break. `tier4` already carried this defect latently.

**`DomainRecord["tier_stats_30d"]` is now derived too.** It was a *third* hand-maintained copy of the same closed set, with `newRecord()` as a fourth. As a mapped type the compiler now rejects any writer that misses a slot — verified by adding a seventh slot and watching the build fail at `newRecord`'s exact line.

### Why the test does not use `.parse()`

This is the part worth reviewing carefully. The obvious remedy — "parse a real payload with the declared zod schema" — **would have passed on the broken build**:

- Server-side, the SDK calls `safeParseAsync(outputSchema, payload)`. zod's `z.object()` is *strip*, not *strict*: an unrecognised key is silently dropped and the parse **succeeds**. The server never rejected anything.
- Client-side, the SDK advertises `toJsonSchemaCompat(outputSchema)`, and that conversion emits `additionalProperties: false`. **That** is what rejected the call.

So the tests validate real `handleDomainStats` payloads against the derived JSON Schema using the SDK's own converter and validator — the exact artefact and code path a client uses.

## 2. Multi-instance SearXNG failover (vikunja#144)

`SEARXNG_URL` accepts an ordered replica list (`,` or `;`). **A scalar value behaves exactly as before** — one request, one host, no health lookup, same 10s bound. That is every existing deployment, and several tests exist only to pin it.

- **Total timeout budget, not per instance.** N replicas at 10s each would make a total outage take *longer* to report the more replicas you add.
- **Health state in the cache, not a module Map**, so one process's discovery informs the next call. Deprioritise, never remove — if everything is marked down the full list is still tried. Fail-soft: a cache outage degrades to "try every instance in configured order".
- **Loud failover** — `search.failover` NATS event plus a throttled stderr line. A silent failover is indistinguishable from a healthy primary.

Fan-out is deliberately out of scope (meta reconciliation has no obvious right answer).

## 3. `min_score` relevance floor

Filters on the **raw** `relevance_score`, not the sort key. Ranking uses `relevance_score + RERANK_RECENCY_WEIGHT * recencyScore(...)`, which at the default weight ranges 0–1.15 — a "minimum relevance" parameter applied to that would quietly mean "relevant enough *or* recent enough". Filtering runs before the top-N slice so the floor never costs a result that cleared it.

Docs carry the measured FlashRank distribution: the scores are strongly bimodal, so **0.5 is not a midpoint** (use 0.01–0.1), and a high score means topically *related*, not correct (an Apache page scores 0.967 on an nginx query).

Reranker down ⇒ documented no-op with a throttled line. Silent unfiltered results would imply a floor that was never applied; returning nothing would turn a reranker outage into "no results found".

## 4. Search histogram

Added a `tool` label to the shared histogram and counter — the three tools' normal ranges differ ~3x, so the 7-day max of 51.6s was uninterpretable. Error path now records latency with `outcome: "error"` (kept separable so it doesn't skew the success p99).

**This does not make the histogram able to see a hang, and does not claim to.** Both recordings happen after `await` settles. Stated in the code, the tests, and the CHANGELOG.

## 5. Four stale README claims

`schema_version 5` (it's 6), "several concurrent per-agent stdio children" (one shared container since #149/#321), "stderr is the only sink on the deployed PM2 process" (wrong twice — Docker, and OTel+NATS are both wired), "clean PM2 restart" (`restart: unless-stopped`). Each checked against the running container. `src/log.ts` carried the same claim and is fixed too.

---

## Descoped: `pageno` → vikunja#639

Pool-and-slice is the right design, but it makes pool size depend on the requested page while the cached value records **no pool size** — a page-1 entry can't be distinguished from an exhausted one. That's a cache-schema change with back-compat implications, not a parameter addition. The plan named this phase the descope candidate up front. Ticket carries the live measurements (SearXNG returns 32 results on page 1, 20 after — so the code's own `min(numResults*3, 20)` cap is the binding constraint, not SearXNG's page size).

## Verification

| Step | Result |
|---|---|
| Baseline preserved | 795 passed / 6 skipped, lint clean, build OK |
| Schema fix is structural | Added a 7th slot to `TIER_SLOT_KEYS` — schema followed automatically, tests stayed green; build failed at `newRecord` as designed. Reverted. |
| Test is not vacuous | Reverting the schema turns 6 of 10 new contract tests red |
| `domain_stats` end-to-end | Driven through a **real MCP client** against the live domain-db with `SOLVER_ENABLED=true` — both modes validate, all six slots advertised. Same harness against the pre-fix schema reproduces the production error. |
| Failover, both orders + budget | 7 integration tests against **real `node:http` stubs** serving valid SearXNG JSON — real ECONNREFUSED, real 502, real AbortSignal/socket interaction |
| Single-instance unchanged | Exactly one request to exactly one host; no health lookup |
| `min_score` degradation | No-op + throttled line when reranker is down |
| Live search smoke test | Real SearXNG + reranker: `min_score=1.0` → 0 results, `0.99` → 8, confirming the filter is applied and the bimodal caveat is real |

Mutation-tested throughout — 15 mutants across the four phases, all caught. One test (min_score slice ordering) initially passed under **both** orderings; mutation testing caught that it constrained nothing, and it was rewritten. The comment records why.

**Two verification steps are deferred to post-deploy** and cannot be done from this branch: calling `domain_stats` through scoped-mcp against the *deployed* container (it runs the old code, so today it can only reproduce the bug), and confirming the new histogram `tool` label in SigNoz. Both need sysadmin's deploy first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)