### PR TITLE
Cap every read: finish SXNG-23's bounded-read propagation (v3.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ thing and checking its size afterwards.
 - README **Bounded reads** section recording every read and its limit, that the bound is on
   bytes *retained* rather than bytes transferred, and the one limitation this repo cannot fix —
   the MCP SDK's own `handleRequest` body read, reachable only post-authentication.
+- `sendJsonRpcError` takes an optional completion callback. The 413 path destroys the socket
+  from it rather than on the following line, so the client cannot receive a bare connection
+  reset in place of the error if that response body ever grows past a synchronous flush.
 
 ### Changed
 - `MAX_SIZE_BYTES` 200 MB → 64 MB. This is a capability boundary, not only a memory one: it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,66 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.22.0] - 2026-09-03
+
+Cap every read (build `searxng-mcp-bounded-reads-2026-09`, vikunja#638; closes vikunja#423).
+Finishes propagating the bounded-read pattern SXNG-23 introduced and only half-applied: every
+site that reads a response or request body now stops at a limit instead of buffering the whole
+thing and checking its size afterwards.
+
+### Fixed
+- **`readBoundedText` had three defects of its own**, fixed before propagating it anywhere.
+  Its `!reader` fallback did `(await res.text()).slice(...)` — an unbounded read sitting in the
+  fallback path of the fix — and now returns `""`, failing closed. It counted bytes while
+  reading and then sliced *characters* off the decoded string, so for any multi-byte body the
+  trailing slice could not cut anything the loop had not already bounded; truncation is now
+  byte-based end to end. And it hardcoded `RAW_HTML_MAX_BYTES`, so a caller with its own
+  ceiling could not express one — there is now an optional limit parameter.
+- **Four fetch-side sites buffered whole third-party bodies before capping** and now read
+  bounded: the `llms-full.txt` probe (`llms-txt.ts`), the GitHub raw-content and two GitHub API
+  reads (`tiers/github.ts`), and the Firecrawl crawl poll (`crawl.ts`).
+- **The `llms-full.txt` ceiling was 200 MB**, checked *after* `res.text()` had already
+  materialised the body — roughly 400 MB resident at UTF-16. Now 64 MB, checked during the
+  read. The read deliberately goes one byte past the ceiling so an oversized document is still
+  *detected* as oversized and reported absent; capping at exactly the limit would truncate it
+  to the limit, pass the size check, and serve a partial document as if it were complete.
+- **The L1 body cache refused the one document it existed for.** `L1_MAX_BYTES` (10 MB) and
+  `MAX_SIZE_BYTES` (200 MB) were independently chosen and disagreed, so a document in between
+  was accepted, written to Valkey, and then rejected by the in-process cache on every session —
+  `docs.anthropic.com/llms-full.txt` is 40.3 MB and hit this every time. Worse, `l1Set` ran its
+  eviction loop before discovering the body would not fit, so one oversized document drained
+  every other entry to make room that could not exist. The two constants are now tied together,
+  and `l1Set` checks whether a body can ever fit before evicting anything.
+- **The HTTP transport read request bodies unbounded** (vikunja#423) — a `for await` into
+  `Buffer.concat` with no ceiling. Now bails on the chunk that crosses the limit and answers
+  `413`. **This is a robustness fix, not an exposure fix.** The ticket reads as an
+  unauthenticated DoS and it is not: the bearer gate runs before the body is read, the token is
+  set in production, and this path is only reachable before a session exists. What it actually
+  closes is a *credentialed* caller — a buggy agent, a runaway retry — being able to OOM a
+  container that now serves every agent. The gate ordering is asserted by a test rather than
+  left to this paragraph.
+
+### Added
+- `HTTP_MAX_BODY_BYTES` (default 1 MB) — maximum request body on the pre-session `initialize`
+  path. Named and parsed like `HTTP_MAX_SESSIONS` / `HTTP_SESSION_IDLE_TIMEOUT_MS`.
+- README **Bounded reads** section recording every read and its limit, that the bound is on
+  bytes *retained* rather than bytes transferred, and the one limitation this repo cannot fix —
+  the MCP SDK's own `handleRequest` body read, reachable only post-authentication.
+
+### Changed
+- `MAX_SIZE_BYTES` 200 MB → 64 MB. This is a capability boundary, not only a memory one: it
+  changes which documents the llms.txt fast path accepts. 64 MB was chosen against the measured
+  sizes of all six allowlisted origins rather than the single-digit-MB figure originally
+  proposed, which would have dropped `docs.anthropic.com` (40.3 MB) off the fast path entirely.
+
+### Notes
+- Reads from first-party SearXNG and Ollama are deliberately left unbounded and documented as
+  such — not attacker-influenced, and bounding them would add ceremony without changing a
+  threat.
+- Tier tests for raw, solver, wayback and GitHub were mocking responses with `body: null`,
+  which meant they had been exercising the no-reader fallback rather than the streaming read
+  those tiers use in production. Retargeted onto real body streams.
+
 ## [3.21.0] - 2026-09-03
 
 Search hardening (build `searxng-mcp-search-hardening-2026-09`, vikunja#144; closes vikunja#637).

--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ pnpm restore-domain-db       # re-seed the domain-db from the newest snapshot af
 
 For whitelisted documentation domains in `domains.json` (`llms_txt` array), `fetchPage` tries `<origin>/llms-full.txt` first and extracts the section matching the requested URL before invoking any tier. This avoids running puppeteer against well-instrumented docs sites and returns a clean markdown section directly. Probe outcomes and the full body are cached in Valkey (`llms:<origin>:full`, 24 h / 7 d for present/absent). Default whitelist: `docs.anthropic.com`, `docs.openai.com`, `docs.stripe.com`, `docs.crawl4ai.com`, `docs.firecrawl.dev`, `docs.cursor.com`. Extend by editing `domains.json` — the file is hot-reloaded.
 
+A document is accepted only if it is between 1 KB and 64 MB; anything outside that is treated as absent and falls through to the normal tier cascade. The upper bound is a capability boundary as much as a memory one — for reference, `docs.anthropic.com/llms-full.txt` was 40.3 MB as of 2026-09-03, so lowering it much further would drop that domain off the fast path.
+
 ### Kiwix fast path
 
 When `KIWIX_URL` is set, fetch requests for known offline-capable hosts are intercepted
@@ -670,6 +672,7 @@ All service URLs are configurable via environment variables.
 | `SEARXNG_MCP_AUTH_TOKEN` | *(unset)* | HTTP transport only. When set, every request except `GET /health` must send `Authorization: Bearer <token>` or get a `401`. Unset (the default) disables the check entirely. **Set this whenever `SEARXNG_MCP_HOST` is not loopback** — see [HTTP transport authentication](#http-transport-authentication). |
 | `HTTP_SESSION_IDLE_TIMEOUT_MS` | `600000` | HTTP transport only. A session idle longer than this is evicted by a background sweep (sessions with an in-flight request are exempt, so a long `crawl_site` call is never closed mid-request). Bounds session-map growth from clients killed mid-turn, which never fire `transport.onclose`. |
 | `HTTP_MAX_SESSIONS` | `256` | HTTP transport only. Hard-cap backstop — if the session map ever exceeds this, the least-recently-used idle session is evicted regardless of the idle timeout. |
+| `HTTP_MAX_BODY_BYTES` | `1048576` | HTTP transport only. Maximum request body read on the pre-session `initialize` path; a larger body gets `413` and the read stops at the limit rather than buffering to completion first. Requests carrying an `Mcp-Session-Id` are read by the MCP SDK's own transport and are not covered by this — see [Bounded reads](#bounded-reads). |
 | `NATS_USER` | *(unset)* | NATS username for bcrypt username/password auth, used alongside `NATS_PASSWORD`. Ignored if `NATS_CREDS` is also set (creds-file JWT auth wins). |
 | `NATS_PASSWORD` | *(unset)* | NATS password — see `NATS_USER`. |
 
@@ -796,6 +799,22 @@ The raw-HTTP and GitHub fast-path fetches additionally use `redirect: "manual"` 
 ### Transport exposure
 
 stdio has no network surface. The HTTP transport binds `127.0.0.1` by default and is unauthenticated in that configuration; moving it off loopback without setting `SEARXNG_MCP_AUTH_TOKEN` exposes every tool — including arbitrary-URL `fetch_url` and destructive `clear_cache` — to anything that can route to the port. See [HTTP transport authentication](#http-transport-authentication).
+
+### Bounded reads
+
+Every response body read from a third party, and the one request body this server reads itself, stops at a byte limit and cancels the rest of the stream rather than buffering the whole thing and checking its size afterwards. A post-hoc size check has already paid the memory cost it is trying to avoid.
+
+| Read | Limit | Notes |
+|---|---|---|
+| Fetch tiers (raw, Firecrawl, Crawl4AI, solver, Wayback, Reddit, YouTube, GitHub, sitemap/crawl) | `RAW_HTML_MAX_BYTES` (2 MB) | Shared `readBoundedText` helper. |
+| `llms-full.txt` probe | `MAX_SIZE_BYTES` (64 MB) | Read one byte past the ceiling so an oversized document is still *detected* as oversized and reported absent, rather than truncated to the limit and served as if complete. |
+| HTTP transport request body | `HTTP_MAX_BODY_BYTES` (1 MB) | `initialize` path only; `413` on exceeding. |
+
+The bound is on **bytes retained**, not bytes transferred. Cancellation is not instantaneous — socket buffers and in-flight data mean a peer can still push some way past the cap — so this hard-bounds memory and only reduces transfer (measured roughly 10x against a 40 MB stub).
+
+**One limitation, out of this server's control:** requests carrying an `Mcp-Session-Id` are handled by the MCP SDK's `StreamableHTTPServerTransport.handleRequest()`, which reads its own request body. That read is not bounded by anything here. It is reachable only by a caller that has already authenticated and established a session.
+
+Reads from first-party services configured by the operator — SearXNG and Ollama — are deliberately left unbounded. They are not attacker-influenced, and bounding them would add ceremony without changing a threat.
 
 ### Dependency auditing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tadmstr/searxng-mcp",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "description": "MCP server for SearXNG — private web search for Claude Code",
   "main": "build/src/index.js",
   "bin": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -358,6 +358,17 @@ export const HTTP_SESSION_IDLE_TIMEOUT_MS = positiveIntEnv(
   600_000,
 );
 export const HTTP_MAX_SESSIONS = positiveIntEnv("HTTP_MAX_SESSIONS", 256);
+// Cap on the HTTP request body read by the transport before an MCP session
+// exists. Only the initialize path reads a body this way — requests carrying an
+// Mcp-Session-Id are handled by the SDK transport, which reads its own — and an
+// initialize payload is a few hundred bytes, so 1 MB is already generous.
+// Without a cap the read is a `for await` into Buffer.concat with no ceiling,
+// which lets one credentialed caller OOM a container shared by every agent
+// (vikunja#423).
+export const HTTP_MAX_BODY_BYTES = positiveIntEnv(
+  "HTTP_MAX_BODY_BYTES",
+  1024 * 1024,
+);
 export const CRAWL_MANIFEST_TTL_SECONDS = parseInt(
   process.env.CRAWL_MANIFEST_TTL_SECONDS ?? "21600",
   10,

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -73,7 +73,12 @@ async function pollFirecrawlJob(
         signal: AbortSignal.timeout(10_000),
       });
       if (!res.ok) return null;
-      const body = (await res.json()) as FirecrawlPollResponse;
+      // Bounded read before JSON.parse — consistent with the rest of the
+      // fetch layer. Firecrawl is first-party, so this is uniformity rather
+      // than a threat, but res.json() is unbounded either way.
+      const body = JSON.parse(
+        await readBoundedText(res),
+      ) as FirecrawlPollResponse;
       if (body.status === "completed") return body;
       if (body.status === "failed" || body.status === "cancelled") return null;
     } catch {

--- a/src/fetch-utils.ts
+++ b/src/fetch-utils.ts
@@ -98,12 +98,38 @@ export function isPdfUrl(url: string): boolean {
   }
 }
 
-export async function readBoundedText(res: Response): Promise<string> {
+/**
+ * Read a response body as text, stopping at `limit` bytes and cancelling the
+ * rest of the stream. Use this for every body read of third-party content:
+ * `res.text()` buffers the whole thing first, so a post-hoc size check has
+ * already paid the memory cost it is trying to avoid.
+ *
+ * The bound is on **bytes retained**, not bytes transferred. Cancellation is
+ * not instantaneous — socket buffers and in-flight data mean the peer may
+ * still push past the cap — so this reduces transfer (measured ~10x against a
+ * 40 MB stub) while hard-bounding what is held in memory.
+ *
+ * Truncation is byte-based throughout: the accumulated buffer is cut to
+ * `limit` bytes before decoding, so the unit matches what the loop counts. A
+ * multi-byte UTF-8 sequence straddling the boundary decodes to U+FFFD, which
+ * is the honest result for a truncated document.
+ *
+ * @param res   Response to read. A response with no readable stream (204, 304,
+ *              HEAD) yields "" — those genuinely have no body, and failing
+ *              closed here is the point: an unbounded `res.text()` fallback
+ *              would reintroduce the exact defect this helper exists to fix.
+ * @param limit Maximum bytes to retain. Defaults to RAW_HTML_MAX_BYTES (2 MB).
+ */
+export async function readBoundedText(
+  res: Response,
+  limit: number = RAW_HTML_MAX_BYTES,
+): Promise<string> {
+  const cap = Math.max(0, Math.floor(limit));
   const reader = res.body?.getReader();
-  if (!reader) return (await res.text()).slice(0, RAW_HTML_MAX_BYTES);
+  if (!reader) return "";
   const chunks: Uint8Array[] = [];
   let total = 0;
-  while (total < RAW_HTML_MAX_BYTES) {
+  while (total < cap) {
     const { value, done } = await reader.read();
     if (done) break;
     chunks.push(value);
@@ -111,7 +137,9 @@ export async function readBoundedText(res: Response): Promise<string> {
   }
   // Drop any in-flight remainder if we hit the cap.
   reader.cancel().catch(() => {});
-  return Buffer.concat(chunks.map((c) => Buffer.from(c)))
-    .toString("utf-8")
-    .slice(0, RAW_HTML_MAX_BYTES);
+  const buf = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+  // Byte-based truncation: the loop may overshoot by at most one chunk, and
+  // `total` counts bytes, so the cut must too. A character-based .slice() here
+  // would be a no-op on multi-byte content.
+  return (buf.byteLength > cap ? buf.subarray(0, cap) : buf).toString("utf-8");
 }

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -19,17 +19,26 @@ function sendJsonRpcError(
   status: number,
   message: string,
   extraHeaders: Record<string, string> = {},
+  onFlushed?: () => void,
 ): void {
   res.writeHead(status, {
     "Content-Type": "application/json",
     ...extraHeaders,
   });
+  // onFlushed runs once the body has actually been handed off, not merely
+  // queued. Only the 413 path needs it — it destroys the socket afterwards,
+  // and doing that while the response is still buffered would replace the
+  // error the client should see with a bare connection reset. Today's payload
+  // is ~100 bytes and flushes synchronously, so this is correct either way;
+  // the callback is what stops that from being a property of the payload size
+  // rather than of the code.
   res.end(
     JSON.stringify({
       jsonrpc: "2.0",
       error: { code: -32600, message },
       id: null,
     }),
+    () => onFlushed?.(),
   );
 }
 
@@ -218,14 +227,24 @@ export function createHttpRequestListener(
             "http-body-413",
             `rejected oversized request body: ${req.method} ${req.url}`,
           );
-          // Answer first, then tear the connection down. The remainder of the
-          // body is never read, so a client that keeps sending is stopped by
-          // TCP backpressure and then by the close, rather than leaving a
-          // socket half-drained on a long-lived shared process.
-          sendJsonRpcError(res, 413, "Request body too large", {
-            Connection: "close",
-          });
-          req.destroy();
+          // Answer first, then tear the connection down — and only once the
+          // response has actually flushed, so the client gets the 413 rather
+          // than a reset.
+          //
+          // The `Connection: close` header is what actually stops the inbound
+          // read: Node will not drain a body it is not going to reuse the
+          // socket for. The explicit destroy is defence-in-depth for the day
+          // someone drops that header, and is deliberately not load-bearing —
+          // removing it changes no observable behaviour today, which is
+          // recorded in tests/http-body-limit.test.ts so the next reader does
+          // not mistake a surviving mutation for dead code.
+          sendJsonRpcError(
+            res,
+            413,
+            "Request body too large",
+            { Connection: "close" },
+            () => req.destroy(),
+          );
           return;
         }
 

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -6,6 +6,7 @@ import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { cachePing } from "./cache.js";
 import {
   HTTP_AUTH_TOKEN,
+  HTTP_MAX_BODY_BYTES,
   HTTP_MAX_SESSIONS,
   HTTP_SESSION_IDLE_TIMEOUT_MS,
 } from "./config.js";
@@ -53,10 +54,26 @@ function tokenMatches(presented: string): boolean {
   );
 }
 
+class BodyTooLargeError extends Error {
+  constructor(readonly limit: number) {
+    super(`Request body exceeds ${limit} bytes`);
+    this.name = "BodyTooLargeError";
+  }
+}
+
 async function readJsonBody(req: IncomingMessage): Promise<unknown> {
   const chunks: Buffer[] = [];
+  let total = 0;
   for await (const chunk of req) {
-    chunks.push(chunk as Buffer);
+    const buf = chunk as Buffer;
+    total += buf.byteLength;
+    // Bail on the chunk that crosses the limit, before it is retained. Reading
+    // to completion and rejecting afterwards would have already paid the
+    // memory cost the limit exists to avoid — the same post-hoc-check mistake
+    // this change removes from the fetch side.
+    if (total > HTTP_MAX_BODY_BYTES)
+      throw new BodyTooLargeError(HTTP_MAX_BODY_BYTES);
+    chunks.push(buf);
   }
   const raw = Buffer.concat(chunks).toString("utf8");
   return raw.length > 0 ? JSON.parse(raw) : undefined;
@@ -191,8 +208,26 @@ export function createHttpRequestListener(
           return;
         }
 
-        const parsedBody =
-          req.method === "POST" ? await readJsonBody(req) : undefined;
+        let parsedBody: unknown;
+        try {
+          parsedBody =
+            req.method === "POST" ? await readJsonBody(req) : undefined;
+        } catch (err: unknown) {
+          if (!(err instanceof BodyTooLargeError)) throw err;
+          logThrottled(
+            "http-body-413",
+            `rejected oversized request body: ${req.method} ${req.url}`,
+          );
+          // Answer first, then tear the connection down. The remainder of the
+          // body is never read, so a client that keeps sending is stopped by
+          // TCP backpressure and then by the close, rather than leaving a
+          // socket half-drained on a long-lived shared process.
+          sendJsonRpcError(res, 413, "Request body too large", {
+            Connection: "close",
+          });
+          req.destroy();
+          return;
+        }
 
         if (!isInitializeRequest(parsedBody)) {
           sendJsonRpcError(res, 400, "No valid session ID provided");

--- a/src/llms-txt.ts
+++ b/src/llms-txt.ts
@@ -2,21 +2,36 @@ import { cacheGet, cacheSet } from "./cache.js";
 import { FETCH_CACHE_TTL_SECONDS } from "./config.js";
 import { recordLlmsFullProbe } from "./domain-db.js";
 import { getLlmsTxtAllowlist } from "./domains.js";
-import { safeFetch } from "./fetch-utils.js";
+import { readBoundedText, safeFetch } from "./fetch-utils.js";
 
 const PROBE_PRESENT_TTL_SECONDS = 24 * 60 * 60;
 const PROBE_ABSENT_TTL_SECONDS = 7 * 24 * 60 * 60;
 const PROBE_PRESENT_TTL_MS = PROBE_PRESENT_TTL_SECONDS * 1000;
 const FETCH_TIMEOUT_MS = 30_000;
 const MIN_SIZE_BYTES = 1_024;
-const MAX_SIZE_BYTES = 200 * 1024 * 1024;
+// Ceiling on an accepted llms-full.txt. Was 200 MB — a number no real document
+// approaches, and one that was checked only *after* the whole body had been
+// buffered. Lowered to 64 MB (Ted, 2026-09-03) against measured sizes of the
+// six allowlisted origins: docs.anthropic.com is 40.3 MB, docs.firecrawl.dev
+// 0.93 MB, docs.cursor.com 0.49 MB, the rest absent. 64 MB keeps every real
+// document on the fast path with room to grow. Note this is a capability
+// boundary, not just a memory one: raising or lowering it changes which
+// documents the fast path accepts.
+const MAX_SIZE_BYTES = 64 * 1024 * 1024;
 const USER_AGENT =
   "searxng-mcp/3.8.0 (+https://github.com/TadMSTR/searxng-mcp; personal research)";
 
-// 10MB cap across all domains for the in-process L1 body cache.
-// Note: enforced using body.length (UTF-16 char count). For non-ASCII content,
-// actual heap usage may be ~2× this value; llms-full.txt is almost exclusively ASCII.
-const L1_MAX_BYTES = 10 * 1024 * 1024;
+// Cap across all domains for the in-process L1 body cache, deliberately tied
+// to MAX_SIZE_BYTES: any document the fetch path accepts must be one the cache
+// can hold. These were previously two independently chosen numbers (10 MB vs
+// 200 MB) that disagreed, and the gap between them was a live pathology —
+// docs.anthropic.com at 40.3 MB was accepted, written to Valkey, and then
+// refused by L1 on every single session, so the 40 MB round trip was paid
+// every time and the cache it was meant to warm never held it.
+//
+// Enforced in bytes (see l1Set), matching the constant's name. It was
+// previously enforced with body.length, a UTF-16 character count.
+const L1_MAX_BYTES = MAX_SIZE_BYTES;
 
 interface CachedLlmsFull {
   status: "present" | "absent";
@@ -30,26 +45,29 @@ const bodyCache = new Map<string, { body: string; expiresAt: number }>();
 let bodyCacheTotalBytes = 0;
 
 function l1Set(origin: string, body: string, ttlMs: number): void {
+  const size = Buffer.byteLength(body, "utf-8");
+  // A body larger than the whole cache can never be inserted. Check before
+  // evicting anything: the eviction loop below would otherwise drain every
+  // other entry trying to make room that cannot exist, so one oversized
+  // document flushed the entire cache and still did not get stored.
+  if (size > L1_MAX_BYTES) return;
+
   const existing = bodyCache.get(origin);
   if (existing) {
-    bodyCacheTotalBytes -= existing.body.length;
+    bodyCacheTotalBytes -= Buffer.byteLength(existing.body, "utf-8");
     bodyCache.delete(origin);
   }
   // Evict oldest entries until there is room for the new body.
-  while (
-    bodyCacheTotalBytes + body.length > L1_MAX_BYTES &&
-    bodyCache.size > 0
-  ) {
+  while (bodyCacheTotalBytes + size > L1_MAX_BYTES && bodyCache.size > 0) {
     const oldest = bodyCache.keys().next().value;
     if (!oldest) break;
     const entry = bodyCache.get(oldest);
-    if (entry) bodyCacheTotalBytes -= entry.body.length;
+    if (entry) bodyCacheTotalBytes -= Buffer.byteLength(entry.body, "utf-8");
     bodyCache.delete(oldest);
   }
-  // Only insert if the body fits (a single very large doc may exceed the cap).
-  if (bodyCacheTotalBytes + body.length <= L1_MAX_BYTES) {
+  if (bodyCacheTotalBytes + size <= L1_MAX_BYTES) {
     bodyCache.set(origin, { body, expiresAt: Date.now() + ttlMs });
-    bodyCacheTotalBytes += body.length;
+    bodyCacheTotalBytes += size;
   }
 }
 
@@ -88,8 +106,18 @@ async function fetchLlmsFullTxt(origin: string): Promise<CachedLlmsFull> {
     if (!res.ok) {
       return { status: "absent", fetched: new Date().toISOString() };
     }
-    const body = await res.text();
-    if (body.length < MIN_SIZE_BYTES || body.length > MAX_SIZE_BYTES) {
+    // Read one byte PAST the ceiling, deliberately. Capping at exactly
+    // MAX_SIZE_BYTES would truncate an oversized document to exactly the
+    // limit, the size check below would then pass, and a partial
+    // llms-full.txt would be served as if it were the whole document — a
+    // worse bug than the unbounded read this replaces. The extra byte is what
+    // lets an oversized document still be *detected* as oversized and fall
+    // through to the tier cascade as `absent`.
+    const body = await readBoundedText(res, MAX_SIZE_BYTES + 1);
+    // Byte-based, matching the constants' own names. The previous check used
+    // body.length, a UTF-16 character count, against byte thresholds.
+    const size = Buffer.byteLength(body, "utf-8");
+    if (size < MIN_SIZE_BYTES || size > MAX_SIZE_BYTES) {
       return { status: "absent", fetched: new Date().toISOString() };
     }
     return { status: "present", body, fetched: new Date().toISOString() };

--- a/src/tiers/github.ts
+++ b/src/tiers/github.ts
@@ -1,5 +1,10 @@
 import { GITHUB_TOKEN } from "../config.js";
-import { assertPublicUrl, safeFetch, USER_AGENT } from "../fetch-utils.js";
+import {
+  assertPublicUrl,
+  readBoundedText,
+  safeFetch,
+  USER_AGENT,
+} from "../fetch-utils.js";
 import type { GitHubReadmeResponse } from "../types.js";
 
 /** Hostnames handled by this tier's fast path. */
@@ -68,7 +73,11 @@ async function fetchRawContent(
     rawHeaders(),
     "GitHub raw fetch error",
   );
-  const text = (await res.text()).slice(0, maxChars);
+  // Bounded read before the slice: res.text() materialised the whole file
+  // first, so the slice was capping the *result*, not the read. The 2 MB
+  // default is far above any reachable maxChars (schema max is 10000 tokens =
+  // 40000 chars), so nothing that used to be returned is lost.
+  const text = (await readBoundedText(res)).slice(0, maxChars);
   const parts = new URL(url).pathname.split("/").filter(Boolean);
   const fileName = parts[parts.length - 1] ?? url;
   return { title: fileName, url, text };
@@ -85,7 +94,12 @@ async function fetchApiUrl(
     apiHeaders(),
     "GitHub API error",
   );
-  const data = (await res.json()) as Record<string, unknown>;
+  // Bounded read before JSON.parse — same pattern as tiers/firecrawl.ts.
+  // res.json() has no size limit of its own.
+  const data = JSON.parse(await readBoundedText(res)) as Record<
+    string,
+    unknown
+  >;
 
   if (
     typeof data.content === "string" &&
@@ -140,7 +154,8 @@ export async function githubFetch(
     apiHeaders(),
     "GitHub API error",
   );
-  const data = (await res.json()) as GitHubReadmeResponse;
+  // Bounded read before JSON.parse — see fetchApiUrl above.
+  const data = JSON.parse(await readBoundedText(res)) as GitHubReadmeResponse;
   const text = Buffer.from(data.content, "base64")
     .toString("utf-8")
     .slice(0, maxChars);

--- a/tests/bounded-reads-sites.test.ts
+++ b/tests/bounded-reads-sites.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/config.js", () => ({
+  GITHUB_TOKEN: undefined,
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { RAW_HTML_MAX_BYTES } from "../src/fetch-utils.js";
+import { githubFetch } from "../src/tiers/github.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const CHUNK_BYTES = 64 * 1024;
+
+/**
+ * A body stream that will keep producing forever until the consumer stops
+ * pulling. This is the assertion mechanism for the whole file: an unbounded
+ * read never terminates against it, so any test here that returns at all is
+ * evidence that the read stopped on its own. Checking the result length would
+ * not be — a bounded-looking result is equally produced by reading everything
+ * and then slicing.
+ */
+function endlessBody(fill: string) {
+  const state = { pulled: 0, cancelled: false };
+  const chunk = new TextEncoder().encode(
+    fill.repeat(CHUNK_BYTES / fill.length),
+  );
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      state.pulled += chunk.byteLength;
+      controller.enqueue(chunk);
+    },
+    cancel() {
+      state.cancelled = true;
+    },
+  });
+  return { stream, state };
+}
+
+/** A stream that yields `prefix` first, then never stops. */
+function endlessAfter(prefix: string) {
+  const state = { pulled: 0, cancelled: false };
+  const head = new TextEncoder().encode(prefix);
+  const filler = new TextEncoder().encode("x".repeat(CHUNK_BYTES));
+  let sentHead = false;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (!sentHead) {
+        sentHead = true;
+        state.pulled += head.byteLength;
+        controller.enqueue(head);
+        return;
+      }
+      state.pulled += filler.byteLength;
+      controller.enqueue(filler);
+    },
+    cancel() {
+      state.cancelled = true;
+    },
+  });
+  return { stream, state };
+}
+
+function streamedResponse(
+  stream: ReadableStream<Uint8Array>,
+  opts?: { headers?: Record<string, string> },
+) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: new Headers(opts?.headers ?? {}),
+    body: stream,
+    text: () => {
+      throw new Error(
+        "res.text() must not be called — this read is supposed to be bounded",
+      );
+    },
+    json: () => {
+      throw new Error(
+        "res.json() must not be called — this read is supposed to be bounded",
+      );
+    },
+  };
+}
+
+describe("tiers/github raw content — the read is bounded, not the result", () => {
+  it("stops reading raw.githubusercontent.com instead of buffering the whole file", async () => {
+    const { stream, state } = endlessBody("a");
+    mockFetch.mockResolvedValueOnce(streamedResponse(stream));
+
+    const out = await githubFetch(
+      "https://raw.githubusercontent.com/o/r/main/big.txt",
+      8000,
+    );
+
+    // Returning at all is the result: res.text() would still be running.
+    expect(out.text.length).toBe(8000);
+    expect(state.cancelled).toBe(true);
+    // Overshoot is bounded by one chunk, not by the size of the file offered.
+    expect(state.pulled).toBeLessThanOrEqual(
+      RAW_HTML_MAX_BYTES + CHUNK_BYTES * 2,
+    );
+  }, 30_000);
+});
+
+describe("tiers/github API — bounded before JSON.parse", () => {
+  it("stops reading an api.github.com response that never ends", async () => {
+    const { stream, state } = endlessAfter('{"padding":"');
+    mockFetch.mockResolvedValueOnce(
+      streamedResponse(stream, {
+        "Content-Type": "application/json",
+      }),
+    );
+
+    // The truncated body is not valid JSON, so this rejects — that is the
+    // correct outcome and is not what is being asserted. What matters is that
+    // it rejects *promptly*, having stopped reading, rather than never
+    // returning.
+    await expect(
+      githubFetch("https://api.github.com/repos/o/r", 8000),
+    ).rejects.toThrow();
+
+    expect(state.cancelled).toBe(true);
+    expect(state.pulled).toBeLessThanOrEqual(
+      RAW_HTML_MAX_BYTES + CHUNK_BYTES * 2,
+    );
+  }, 30_000);
+});

--- a/tests/fetch-utils-bounded-read.test.ts
+++ b/tests/fetch-utils-bounded-read.test.ts
@@ -1,0 +1,155 @@
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  RAW_HTML_MAX_BYTES,
+  readBoundedText,
+} from "../src/fetch-utils.js";
+
+// A stub that streams far more than any cap the tests set, and records how
+// many bytes it actually pushed onto the wire before the client went away.
+// That counter is the point of the whole file: "the result was truncated" is
+// equally true of an unbounded read followed by a slice, so it is not evidence
+// that anything is bounded. Bytes-actually-sent is.
+const OFFERED_BYTES = 40 * 1024 * 1024;
+const CHUNK = Buffer.alloc(64 * 1024, "a");
+
+let httpServer: Server;
+let port: number;
+let bytesSent = 0;
+
+beforeAll(async () => {
+  httpServer = createServer((_req, res) => {
+    bytesSent = 0;
+    res.writeHead(200, { "content-type": "text/plain" });
+    let done = false;
+    const stop = () => {
+      done = true;
+    };
+    res.on("close", stop);
+    res.on("error", stop);
+    const pump = () => {
+      while (!done && bytesSent < OFFERED_BYTES) {
+        bytesSent += CHUNK.byteLength;
+        if (!res.write(CHUNK)) {
+          res.once("drain", pump);
+          return;
+        }
+      }
+      if (!done) res.end();
+    };
+    pump();
+  });
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, "127.0.0.1", () => resolve());
+  });
+  port = (httpServer.address() as { port: number }).port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    httpServer.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+// Give the server a moment to notice the cancelled socket, so bytesSent has
+// settled before it is asserted on.
+const settle = () => new Promise((r) => setTimeout(r, 250));
+
+describe("readBoundedText — the bound is on the read, not on the result", () => {
+  it("stops reading a huge stream: retains exactly the cap, and the server never sends the full body", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    const text = await readBoundedText(res);
+    await settle();
+
+    // Hard bound on memory retained.
+    expect(Buffer.byteLength(text, "utf-8")).toBe(RAW_HTML_MAX_BYTES);
+
+    // And the read genuinely stopped. Cancellation is not instantaneous —
+    // socket buffers and in-flight data mean the peer pushes some way past the
+    // cap (~4 MB measured against a 2 MB cap), so this is deliberately a
+    // generous ceiling rather than "sent <= the cap", which would be flaky and
+    // is not what the helper promises.
+    expect(bytesSent).toBeLessThan(OFFERED_BYTES / 2);
+  });
+
+  it("negative control: an unbounded res.text() on the same stub buffers the entire body", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    const text = await res.text();
+    await settle();
+
+    // This is the pattern being removed from the codebase. If this assertion
+    // ever fails, the stub stopped offering a body big enough to distinguish
+    // the two reads, and the test above proves nothing.
+    expect(Buffer.byteLength(text, "utf-8")).toBe(OFFERED_BYTES);
+    expect(bytesSent).toBe(OFFERED_BYTES);
+  });
+
+  it("honours a custom limit", async () => {
+    const limit = 128 * 1024;
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    const text = await readBoundedText(res, limit);
+    await settle();
+
+    expect(Buffer.byteLength(text, "utf-8")).toBe(limit);
+    expect(bytesSent).toBeLessThan(OFFERED_BYTES / 2);
+  });
+
+  it("returns a small body unchanged and does not pad to the limit", async () => {
+    const text = await readBoundedText(new Response("hello world"));
+    expect(text).toBe("hello world");
+  });
+});
+
+describe("readBoundedText — the no-reader path fails closed", () => {
+  it("returns empty for a response with no readable stream instead of falling back to res.text()", async () => {
+    // The old fallback was `(await res.text()).slice(...)` — an unbounded read
+    // sitting in the fallback path of the fix. A body-less response is a 204 /
+    // 304 / HEAD, which has nothing to read anyway.
+    const res = new Response(null, { status: 204 });
+    expect(res.body).toBeNull();
+    expect(await readBoundedText(res)).toBe("");
+  });
+
+  it("does not call res.text() on the no-reader path", async () => {
+    let textCalled = false;
+    const fake = {
+      body: null,
+      text: async () => {
+        textCalled = true;
+        return "x".repeat(10_000_000);
+      },
+    } as unknown as Response;
+
+    expect(await readBoundedText(fake)).toBe("");
+    expect(textCalled).toBe(false);
+  });
+});
+
+describe("readBoundedText — truncation is byte-based, not character-based", () => {
+  it("truncates multi-byte content by bytes", async () => {
+    // "€" is 3 bytes in UTF-8, 1 JS character. 300 of them is 900 bytes but
+    // only 300 characters, so the old trailing `.slice(0, limit)` on the
+    // decoded string was a no-op for any multi-byte body — it could never cut
+    // anything the loop had not already bounded, and it conflated two units.
+    const euros = "€".repeat(300);
+    expect(Buffer.byteLength(euros, "utf-8")).toBe(900);
+
+    const text = await readBoundedText(new Response(euros), 600);
+    expect(Buffer.byteLength(text, "utf-8")).toBe(600);
+    expect(text.length).toBe(200);
+  });
+
+  it("yields a replacement char rather than over-reading when the cut splits a sequence", async () => {
+    const text = await readBoundedText(new Response("€€"), 4);
+    // 4 bytes = one whole "€" plus the first byte of the second.
+    expect(Buffer.byteLength(text, "utf-8")).toBeLessThanOrEqual(6);
+    expect(text.startsWith("€")).toBe(true);
+    expect(text).toContain("�");
+  });
+
+  it("a zero limit reads nothing", async () => {
+    expect(await readBoundedText(new Response("plenty of content here"), 0)).toBe(
+      "",
+    );
+  });
+});

--- a/tests/fetch-utils-bounded-read.test.ts
+++ b/tests/fetch-utils-bounded-read.test.ts
@@ -1,9 +1,6 @@
 import { createServer, type Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  RAW_HTML_MAX_BYTES,
-  readBoundedText,
-} from "../src/fetch-utils.js";
+import { RAW_HTML_MAX_BYTES, readBoundedText } from "../src/fetch-utils.js";
 
 // A stub that streams far more than any cap the tests set, and records how
 // many bytes it actually pushed onto the wire before the client went away.
@@ -148,8 +145,8 @@ describe("readBoundedText — truncation is byte-based, not character-based", ()
   });
 
   it("a zero limit reads nothing", async () => {
-    expect(await readBoundedText(new Response("plenty of content here"), 0)).toBe(
-      "",
-    );
+    expect(
+      await readBoundedText(new Response("plenty of content here"), 0),
+    ).toBe("");
   });
 });

--- a/tests/http-body-limit.test.ts
+++ b/tests/http-body-limit.test.ts
@@ -1,4 +1,5 @@
 import { createServer, type Server } from "node:http";
+import { connect } from "node:net";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -11,7 +12,6 @@ const { HTTP_MAX_BODY_BYTES } = await import("../src/config.js");
 
 let httpServer: Server;
 let port: number;
-
 beforeAll(async () => {
   const listener = createHttpRequestListener(
     () => new McpServer({ name: "test-server", version: "0.0.0" }),
@@ -163,5 +163,90 @@ describe("the bearer gate runs before the body is read", () => {
     // would mean the body had been read first, which is the shape the ticket
     // assumed.
     expect(res.status).toBe(401);
+  }, 30_000);
+});
+
+describe("the 413 answers completely, then stops reading the rest of the body", () => {
+  it("delivers a complete, parseable 413 body", async () => {
+    // This is what moving req.destroy() into res.end()'s completion callback
+    // protects: tearing the socket down while the response is still buffered
+    // would replace the error with a bare reset. Today's payload flushes
+    // synchronously so this passes either way — the callback is what stops
+    // that from being a property of the payload size rather than of the code.
+    const res = await fetch(url(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "x".repeat(HTTP_MAX_BODY_BYTES + 4096),
+    });
+
+    expect(res.status).toBe(413);
+    expect(await res.json()).toMatchObject({
+      error: { message: "Request body too large" },
+    });
+  }, 30_000);
+
+  it("stops accepting the request body instead of draining it to completion", async () => {
+    // Asserts the property, and is honest about what it can attribute. Two
+    // things were tried first and are recorded so nobody re-derives them:
+    //
+    //   - "the socket was destroyed" is vacuous. The 413 sets
+    //     `Connection: close`, so Node tears the socket down whether or not
+    //     req.destroy() ever runs.
+    //   - so is anything aimed at req.destroy() specifically. Removing that
+    //     call entirely leaves this test green: `Connection: close` alone
+    //     already stops the read. The destroy is defence-in-depth against that
+    //     header changing, not the mechanism, and no test here can isolate it.
+    //
+    // What IS worth pinning is the user-visible behaviour vikunja#423 is about:
+    // an oversized body is refused rather than drained to completion. Declare a
+    // body far larger than the cap, trickle it, and measure how much the server
+    // took before it stopped.
+    const DECLARED = HTTP_MAX_BODY_BYTES * 64;
+    const CHUNK = Buffer.alloc(64 * 1024, "x");
+
+    const written = await new Promise<number>((resolve) => {
+      const sock = connect(port, "127.0.0.1", () => {
+        sock.write(
+          `POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: ${DECLARED}\r\n\r\n`,
+        );
+        pump();
+      });
+
+      let sent = 0;
+      let finished = false;
+      const done = () => {
+        if (finished) return;
+        finished = true;
+        sock.destroy();
+        resolve(sent);
+      };
+
+      const pump = () => {
+        while (sent < DECLARED) {
+          if (sock.destroyed || sock.writableEnded) return done();
+          sent += CHUNK.byteLength;
+          if (!sock.write(CHUNK)) {
+            sock.once("drain", pump);
+            return;
+          }
+        }
+        done();
+      };
+
+      sock.on("error", done);
+      sock.on("close", done);
+      // Backstop so a server that never stops reading fails on the assertion
+      // below rather than hanging the suite.
+      setTimeout(done, 10_000);
+    });
+
+    // Deliberately generous. The server accepts the 1 MB cap plus whatever the
+    // client already pushed into socket buffers — measured around 4 MB, and
+    // that overshoot is a property of the kernel, not of this code. Asserting
+    // "<= the cap" would be flaky for the same reason the fetch-side bound is
+    // on bytes retained rather than bytes transferred. A quarter of a 64 MB
+    // declared body sits far above the observed overshoot and far below
+    // draining to completion, which is the only distinction that matters.
+    expect(written).toBeLessThan(DECLARED / 4);
   }, 30_000);
 });

--- a/tests/http-body-limit.test.ts
+++ b/tests/http-body-limit.test.ts
@@ -1,0 +1,167 @@
+import { createServer, type Server } from "node:http";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/cache.js", () => ({
+  cachePing: async () => true,
+}));
+
+const { createHttpRequestListener } = await import("../src/http-transport.js");
+const { HTTP_MAX_BODY_BYTES } = await import("../src/config.js");
+
+let httpServer: Server;
+let port: number;
+
+beforeAll(async () => {
+  const listener = createHttpRequestListener(
+    () => new McpServer({ name: "test-server", version: "0.0.0" }),
+  );
+  httpServer = createServer(listener);
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, "127.0.0.1", () => resolve());
+  });
+  port = (httpServer.address() as { port: number }).port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    httpServer.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+const url = () => `http://127.0.0.1:${port}/mcp`;
+
+const INITIALIZE = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "test-client", version: "0.0.0" },
+  },
+};
+
+describe("HTTP transport request-body limit (vikunja#423)", () => {
+  it("rejects an oversized POST body with 413", async () => {
+    const oversized = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { padding: "x".repeat(HTTP_MAX_BODY_BYTES + 4096) },
+    });
+
+    const res = await fetch(url(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: oversized,
+    });
+
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(JSON.stringify(body)).toContain("too large");
+  }, 30_000);
+
+  it("leaves a normal initialize unaffected", async () => {
+    const res = await fetch(url(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify(INITIALIZE),
+    });
+
+    // The transport answers initialize with 200 and issues a session id. The
+    // point is only that a normal payload is not caught by the new limit.
+    expect(res.status).toBe(200);
+    expect(res.headers.get("mcp-session-id")).toBeTruthy();
+  }, 30_000);
+
+  it("accepts a body just under the limit, so the cap is not off by an order of magnitude", async () => {
+    // Sized to land under the cap once JSON.stringify's own overhead is
+    // counted. If this ever 413s, the limit moved or the accounting drifted.
+    const padding = "x".repeat(HTTP_MAX_BODY_BYTES - 4096);
+    const res = await fetch(url(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({ ...INITIALIZE, params: { padding } }),
+    });
+
+    // Not an initialize request once params are replaced, so the transport
+    // answers 400 — but it got past the body read, which is what is asserted.
+    expect(res.status).not.toBe(413);
+  }, 30_000);
+
+  it("the server survives an oversized request and still serves the next one", async () => {
+    // The 413 path destroys the connection. Verify that tears down only that
+    // request: this is a long-lived process shared by every agent, so a
+    // rejected body must not take the listener with it.
+    await fetch(url(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "x".repeat(HTTP_MAX_BODY_BYTES + 4096),
+    }).catch(() => undefined);
+
+    const health = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(health.status).toBe(200);
+  }, 30_000);
+});
+
+describe("the bearer gate runs before the body is read", () => {
+  // This is the test behind vikunja#423's corrected severity. The ticket read
+  // as an unauthenticated DoS; it is not, because the auth check at
+  // http-transport.ts precedes readJsonBody, so an unauthenticated caller
+  // never gets a byte of its body buffered. That ordering is the entire
+  // difference between "exposure" and "robustness", and prose in a CHANGELOG
+  // does not keep it true.
+  let authServer: Server | undefined;
+
+  afterAll(async () => {
+    delete process.env.SEARXNG_MCP_AUTH_TOKEN;
+    const s = authServer;
+    authServer = undefined;
+    if (s) {
+      await new Promise<void>((resolve, reject) =>
+        s.close((err) => (err ? reject(err) : resolve())),
+      );
+    }
+  });
+
+  it("answers 401, not 413, when an unauthenticated caller sends an oversized body", async () => {
+    process.env.SEARXNG_MCP_AUTH_TOKEN = "a".repeat(64);
+    vi.resetModules();
+    const [{ createHttpRequestListener: makeListener }, { McpServer: Srv }] =
+      await Promise.all([
+        import("../src/http-transport.js"),
+        import("@modelcontextprotocol/sdk/server/mcp.js"),
+      ]);
+    const { HTTP_MAX_BODY_BYTES: limit } = await import("../src/config.js");
+
+    const s = createServer(
+      makeListener(() => new Srv({ name: "test-server", version: "0.0.0" })),
+    );
+    authServer = s;
+    await new Promise<void>((resolve) =>
+      s.listen(0, "127.0.0.1", () => resolve()),
+    );
+    const p = (s.address() as { port: number }).port;
+
+    const res = await fetch(`http://127.0.0.1:${p}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "x".repeat(limit + 4096),
+    });
+
+    // 401 means the request was refused before its body mattered. A 413 here
+    // would mean the body had been read first, which is the shape the ticket
+    // assumed.
+    expect(res.status).toBe(401);
+  }, 30_000);
+});

--- a/tests/llms-txt-bounded.test.ts
+++ b/tests/llms-txt-bounded.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/cache.js", () => ({
+  cacheGet: vi.fn(),
+  cacheSet: vi.fn(),
+}));
+
+vi.mock("../src/domains.js", () => ({
+  getLlmsTxtAllowlist: vi.fn(() => ["docs.anthropic.com"]),
+}));
+
+vi.mock("../src/domain-db.js", () => ({
+  recordLlmsFullProbe: vi.fn(async () => {}),
+}));
+
+import { cacheGet, cacheSet } from "../src/cache.js";
+import { _clearBodyCacheForTests, tryLlmsTxtFetch } from "../src/llms-txt.js";
+
+const cacheGetMock = vi.mocked(cacheGet);
+const cacheSetMock = vi.mocked(cacheSet);
+
+const ORIGIN = "https://docs.anthropic.com";
+const PAGE = `${ORIGIN}/en/get-started`;
+
+// A document the fast path should accept, shaped so extractSection finds the
+// section for PAGE.
+function docOfSize(bytes: number): string {
+  const head = `# Docs
+
+## Section: First steps
+
+---
+
+# Get started
+
+URL: ${PAGE}
+
+Real content lives here.
+`;
+  const pad = "x".repeat(Math.max(0, bytes - Buffer.byteLength(head, "utf-8")));
+  return head + pad;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _clearBodyCacheForTests();
+  cacheGetMock.mockResolvedValue(null);
+  cacheSetMock.mockResolvedValue(undefined as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  _clearBodyCacheForTests();
+});
+
+describe("llms-full.txt — an oversized document is absent, never truncated content", () => {
+  it("reports absent for a body past MAX_SIZE_BYTES rather than serving the truncated prefix", async () => {
+    // 64 MB is the ceiling; offer more. The read is bounded at the ceiling
+    // plus one byte, which is the whole point — capping at exactly the
+    // ceiling would truncate to exactly the ceiling, the size check would
+    // then pass, and a partial document would be served as the real thing.
+    const oversized = docOfSize(64 * 1024 * 1024 + 4096);
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(oversized, { status: 200 }) as Response,
+    );
+
+    const out = await tryLlmsTxtFetch(PAGE, 8000);
+
+    // Absent -> null -> falls through to the tier cascade.
+    expect(out).toBeNull();
+
+    // And it was recorded absent, not present-with-a-body. The body key must
+    // never be written for a document that hit the cap.
+    const setKeys = cacheSetMock.mock.calls.map((c) => String(c[0]));
+    expect(setKeys.some((k) => k.endsWith(":body"))).toBe(false);
+    const probeWrite = cacheSetMock.mock.calls.find((c) =>
+      String(c[0]).includes(":probe"),
+    );
+    if (probeWrite) {
+      expect(String(probeWrite[1])).toContain('"absent"');
+    }
+  }, 60_000);
+
+  it("accepts a document comfortably under the ceiling", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(docOfSize(64 * 1024), { status: 200 }) as Response,
+    );
+
+    const out = await tryLlmsTxtFetch(PAGE, 8000);
+    expect(out).not.toBeNull();
+    expect(out?.source).toBe("llms_full_txt");
+    expect(out?.text).toContain("Real content lives here.");
+  });
+});
+
+describe("llms-full.txt — L1 admits the documents the fetch path accepts", () => {
+  it("caches a body larger than the old 10 MB L1 cap instead of refusing it every session", async () => {
+    // 12 MB: accepted by the fetch path both before and after this change, but
+    // previously refused by the L1 cache, whose cap was 10 MB. The real case
+    // is docs.anthropic.com at 40.3 MB — every session paid the full round
+    // trip and the cache it was meant to warm never held it. 12 MB reproduces
+    // the same branch far more cheaply.
+    // A fresh Response per call, deliberately. Re-using one would let this
+    // test "pass" for the wrong reason: the second read would find an already
+    // drained body and return absent, which looks like a cache hit in the
+    // result but proves nothing about whether the network was touched.
+    const doc = docOfSize(12 * 1024 * 1024);
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockImplementation(
+        async () => new Response(doc, { status: 200 }) as Response,
+      );
+
+    const first = await tryLlmsTxtFetch(PAGE, 8000);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(first).not.toBeNull();
+
+    // Valkey is mocked empty, so L1 is the only thing that can prevent a
+    // second network read. The call count is the assertion that matters.
+    const second = await tryLlmsTxtFetch(PAGE, 8000);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(second).not.toBeNull();
+    expect(second?.text).toContain("Real content lives here.");
+  }, 30_000);
+});

--- a/tests/tiers/github-token.test.ts
+++ b/tests/tiers/github-token.test.ts
@@ -15,20 +15,29 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+// Real body streams — the tier reads via readBoundedText, which needs
+// res.body. See tests/tiers/github.test.ts for the same note.
+function bodyStream(text: string): ReadableStream<Uint8Array> {
+  return new Response(text).body as ReadableStream<Uint8Array>;
+}
+
 function textResponse(body: string) {
   return {
     ok: true,
     status: 200,
     statusText: "OK",
+    body: bodyStream(body),
     text: () => Promise.resolve(body),
   };
 }
 
 function jsonResponse(body: unknown) {
+  const serialized = JSON.stringify(body);
   return {
     ok: true,
     status: 200,
     statusText: "OK",
+    body: bodyStream(serialized),
     json: () => Promise.resolve(body),
   };
 }

--- a/tests/tiers/github.test.ts
+++ b/tests/tiers/github.test.ts
@@ -15,14 +15,24 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+// These mocks need a real body stream: the tier reads through
+// readBoundedText, which streams from res.body. A mock carrying only text()
+// or json() would send it down the no-reader path and assert nothing about
+// the code that actually ships.
+function bodyStream(text: string): ReadableStream<Uint8Array> {
+  return new Response(text).body as ReadableStream<Uint8Array>;
+}
+
 function jsonResponse(body: unknown, opts?: { status?: number }) {
   const status = opts?.status ?? 200;
+  const serialized = JSON.stringify(body);
   return {
     ok: status >= 200 && status < 300,
     status,
     statusText: status === 200 ? "OK" : "Error",
+    body: bodyStream(serialized),
     json: () => Promise.resolve(body),
-    text: () => Promise.resolve(JSON.stringify(body)),
+    text: () => Promise.resolve(serialized),
   };
 }
 
@@ -32,6 +42,7 @@ function textResponse(body: string, opts?: { status?: number }) {
     ok: status >= 200 && status < 300,
     status,
     statusText: status === 200 ? "OK" : "Error",
+    body: bodyStream(body),
     text: () => Promise.resolve(body),
   };
 }

--- a/tests/tiers/raw.test.ts
+++ b/tests/tiers/raw.test.ts
@@ -12,6 +12,13 @@ beforeEach(() => {
 
 const URL = "https://example.com/page";
 
+// A real body stream, not `body: null`. rawFetch reads through
+// readBoundedText, which streams from res.body — a null body would send it
+// down the no-reader path and test nothing that ships.
+function bodyStream(text: string): ReadableStream<Uint8Array> {
+  return new Response(text).body as ReadableStream<Uint8Array>;
+}
+
 function mockHtmlResponse(
   html: string,
   opts?: { status?: number; headers?: Record<string, string> },
@@ -26,7 +33,7 @@ function mockHtmlResponse(
     status,
     statusText: status === 200 ? "OK" : "Error",
     headers,
-    body: null,
+    body: bodyStream(html),
     text: () => Promise.resolve(html),
   };
 }

--- a/tests/tiers/solver.test.ts
+++ b/tests/tiers/solver.test.ts
@@ -50,7 +50,9 @@ function pageResponse(html: string) {
     status: 200,
     statusText: "OK",
     headers: new Headers({ "Content-Type": "text/html" }),
-    body: null,
+    // Real stream: solverFetch replays through readBoundedText, which reads
+    // res.body. `body: null` would exercise the no-reader path instead.
+    body: new Response(html).body as ReadableStream<Uint8Array>,
     text: () => Promise.resolve(html),
   };
 }

--- a/tests/tiers/wayback.test.ts
+++ b/tests/tiers/wayback.test.ts
@@ -22,19 +22,24 @@ beforeEach(() => {
 
 const URL = "https://example.com/dead-page";
 
-const cdxHit = (snapshotUrl: string) => {
-  const body = JSON.stringify({
-    archived_snapshots: {
-      closest: { url: snapshotUrl, available: true, timestamp: "20240101" },
-    },
-  });
-  return { ok: true, body: null, text: () => Promise.resolve(body) };
-};
+// waybackFetch reads the CDX response through readBoundedText, so these need
+// a real body stream rather than `body: null`.
+const cdxResponse = (body: string) => ({
+  ok: true,
+  body: new Response(body).body as ReadableStream<Uint8Array>,
+  text: () => Promise.resolve(body),
+});
 
-const cdxMiss = () => {
-  const body = JSON.stringify({ archived_snapshots: {} });
-  return { ok: true, body: null, text: () => Promise.resolve(body) };
-};
+const cdxHit = (snapshotUrl: string) =>
+  cdxResponse(
+    JSON.stringify({
+      archived_snapshots: {
+        closest: { url: snapshotUrl, available: true, timestamp: "20240101" },
+      },
+    }),
+  );
+
+const cdxMiss = () => cdxResponse(JSON.stringify({ archived_snapshots: {} }));
 
 describe("waybackFetch", () => {
   it("fetches snapshot and returns result with [Archived] title prefix", async () => {


### PR DESCRIPTION
Build `searxng-mcp-bounded-reads-2026-09` — vikunja#638, closes vikunja#423.

`readBoundedText()` was added by SXNG-23 to stream-and-cap responses and applied to two tiers. Five other sites still buffered a whole body and capped afterwards — two of them reading arbitrary third-party content — plus the HTTP transport's request-body read. This finishes the propagation.

## Phase 1 — fix the helper before spreading it

`readBoundedText` had three defects of its own, one of which was an unbounded read *inside the fix*:

| Defect | Was | Now |
|---|---|---|
| `!reader` fallback | `(await res.text()).slice(...)` — the exact bug being fixed everywhere else, in the fallback path of the fix | returns `""`, fails closed. The only body-less responses are 204/304/HEAD |
| bytes vs characters | counted `byteLength` in the loop, then `.slice()` characters off the decoded string — a no-op for any multi-byte body | byte-based end to end |
| hardcoded limit | `RAW_HTML_MAX_BYTES` only | optional `limit` param, same default |

## Phase 2 — propagate

`llms-txt.ts`, `tiers/github.ts` (×3) and `crawl.ts` now read bounded.

**llms-txt reads one byte *past* its ceiling, on purpose.** Capping at exactly `MAX_SIZE_BYTES` would truncate an oversized document to exactly the limit, the existing size check would then pass, and a partial `llms-full.txt` would be served as if it were the whole document — worse than the unbounded read being replaced. The extra byte keeps "too big" detectable, so it still reports `absent` and falls through to the tier cascade.

**Two constants changed, and the second one was not in the plan.**

`MAX_SIZE_BYTES` 200 MB → 64 MB. The plan proposed a single-digit-MB ceiling; measuring the six allowlisted origins first showed that would have broken the main consumer — `docs.anthropic.com/llms-full.txt` is **40.3 MB of legitimate content**. Measured 2026-09-03:

| Origin | llms-full.txt |
|---|---|
| docs.anthropic.com | **40.30 MB** |
| docs.firecrawl.dev | 0.93 MB |
| docs.cursor.com | 0.49 MB |
| docs.stripe.com / docs.crawl4ai.com | 404 |

`L1_MAX_BYTES` is now tied to `MAX_SIZE_BYTES` instead of being a second, independently chosen 10 MB. The gap between the two was a live pathology, not just an inconsistency: a document in between was accepted, written to Valkey, then refused by the in-process cache on every session — docs.anthropic.com hit this every time, paying the 40 MB round trip while the cache meant to prevent it never held it. Worse, `l1Set` ran its eviction loop *before* discovering the body would not fit, so one oversized document drained every other entry to make room that could not exist.

## Phase 3 — `readJsonBody` (vikunja#423)

Bails on the chunk that crosses `HTTP_MAX_BODY_BYTES` (new, default 1 MB) and answers `413`, rather than reading to completion and rejecting afterwards.

**This is a robustness fix, not an exposure fix.** The ticket reads as an unauthenticated DoS and it is not: the bearer gate runs before the body is read, the token is set in production, and this path is only reachable pre-session. What it closes is a *credentialed* caller — a buggy agent, a runaway retry — able to OOM a container that now serves every agent. That ordering is the whole difference between the two framings, so it is asserted by a test rather than left to a CHANGELOG sentence: an unauthenticated oversized POST gets `401`, not `413`.

## How the tests avoid proving nothing

"The result was truncated" is equally true of an unbounded read followed by a slice. So:

- The helper test runs a **real stub server** and asserts **bytes the server actually sent**, with a **negative control** that reads the same stub unbounded and asserts it buffers all 40 MB — if the stub ever stops offering enough to tell the two apart, the suite says so instead of quietly passing.
- The per-site tests feed an **endless stream**, so an unbounded read never returns at all, and assert the stream was cancelled.
- Every changed limit is **individually mutation-checked**: dropping the `+1` turns the oversized llms-txt case from `absent` into a served truncated body; restoring the 10 MB L1 cap turns the cache hit back into a second network fetch; removing the body cap turns the `413` into a `400`.

**Mocks retargeted, not deleted.** The raw, solver, wayback and GitHub tier tests mocked responses with `body: null`, which meant they had been exercising the no-reader fallback rather than the streaming read those tiers use in production — the bounded path was untested at four call sites. Now on real body streams.

## Verification

- 825 passed / 6 skipped (from an 806 baseline), lint clean, build clean
- Live smoke: GitHub raw ✅, GitHub API ✅
- llms.txt live smoke returns `null` — **verified identical on `main` and this branch** (both `null`, 384 MB vs 413 MB peak RSS), so it is not a regression. Cause filed as vikunja#640: the document only contains `platform.claude.com` URLs while the allowlist says `docs.anthropic.com`, so extraction can never match. Zero `llms_full_txt` records across all 1193 live domain records corroborates it.

## Deliberately out of scope

- `search.ts` and `ollama.ts` reads — first-party sources only. Documented as an explicit decision rather than silently absorbed; if security prefers uniformity that is a reasonable triage finding.
- The MCP SDK's own `handleRequest` body read — not ours to bound. Documented in the README as a limitation, with its reachability (post-authentication only).

Filed while here: vikunja#640 (dead llms.txt fast path), vikunja#641 (stale hardcoded `USER_AGENT` of 3.8.0 in `llms-txt.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)