### PR TITLE
Consolidated fix pass: restore PDF fetching, fix two backend routes, close ten tickets (v3.24.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,3 +151,25 @@ jobs:
       # which fails if it has drifted from package.json.
       - name: Audit dependencies
         run: pnpm audit --prod
+
+      # The dev tree, gated separately and deliberately so (vikunja#634).
+      #
+      # `--prod` above covers what ships. Nothing covered the build and test
+      # tooling, and that gap was not theoretical: vite carried
+      # GHSA-fx2h-pf6j-xcff (high, server.fs.deny bypass) and
+      # GHSA-v6wh-96g9-6wx3 under vitest while CI stayed green for ten
+      # releases. A dev-only advisory does not reach a user, but it does reach
+      # every maintainer's workstation and this runner.
+      #
+      # A SEPARATE step, not `--prod` widened to the whole tree. Folding them
+      # together changes what a single red gate means: "something we ship is
+      # vulnerable" and "something we build with is vulnerable" warrant
+      # different responses and different urgency, and a merged step would make
+      # the first indistinguishable from the second.
+      #
+      # Same threshold reasoning as the step above — pnpm's default, no
+      # --audit-level. If a dev advisory lands with no fix in range, this step
+      # will block merges; take a narrow, dated, ticket-referenced `--ignore
+      # <CVE>` rather than raising the threshold or deleting the step.
+      - name: Audit dev dependencies
+        run: pnpm audit --dev

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -90,10 +90,20 @@ jobs:
         if: always()
         run: docker logs sxng-publish || true
 
+      # The token arrives through `env`, not `${{ }}` interpolation into the
+      # script body. Interpolation splices the secret into the shell text the
+      # runner executes, which puts it in reach of anything that reads the
+      # rendered command; via env it stays a variable. `--password-stdin` for
+      # the same reason on the argv side — a `--password <token>` would put it
+      # in the process table.
       - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" \
-            | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          set -euo pipefail
+          printf '%s' "$GHCR_TOKEN" \
+            | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
       # Both `v3.24.0` and `3.24.0` are published, deliberately. The git tag
       # carries the `v`; the conventional Docker tag does not; and

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,142 @@
+name: Publish container image
+
+# Same trigger as release.yml, so the image and the npm package are cut from
+# one tag and cannot drift apart (vikunja#681).
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  IMAGE: ghcr.io/tadmstr/searxng-mcp
+
+jobs:
+  publish:
+    name: Build, smoke test, publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # Provenance attestation, matching the `npm publish --provenance`
+      # posture release.yml already has.
+      id-token: write
+      attestations: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # linux/amd64 only. arm64 would need QEMU emulation on this runner, which
+      # roughly triples the job for a platform with no consumer today. Add it
+      # when something actually needs it, not speculatively.
+      #
+      # Built with plain docker, and loaded into the local daemon rather than
+      # pushed. That is what lets the smoke test below run against the exact
+      # image this job will push — a build-then-rebuild-to-push would test one
+      # artefact and publish another.
+      - name: Build image
+        run: docker build -t "$IMAGE:candidate" .
+
+      # The gate. Identical assertions to ci.yml's docker job, run here before
+      # anything is pushed, because a published image is the thing consumers
+      # pull — CI having been green on some earlier commit is not the same
+      # claim. Deliberately duplicated rather than factored out: a shared
+      # script that silently stopped running would leave both jobs green.
+      - name: Smoke test the image
+        run: |
+          set -euo pipefail
+          TOKEN=$(openssl rand -hex 32)
+          docker run -d --name sxng-publish -p 127.0.0.1:3001:3001 \
+            -e SEARXNG_MCP_AUTH_TOKEN="$TOKEN" "$IMAGE:candidate"
+
+          code() { curl -s -o /dev/null -w '%{http_code}' "$@"; }
+          mcp() {
+            code -X POST http://127.0.0.1:3001/mcp \
+              -H 'Content-Type: application/json' \
+              -H 'Accept: application/json, text/event-stream' "$@"
+          }
+
+          # 503 is expected — there is no cache backend here. This only asserts
+          # the route answers at all.
+          for i in $(seq 1 30); do
+            health=$(code http://127.0.0.1:3001/health || true)
+            case "$health" in 200|503) break ;; esac
+            if [ "$i" = 30 ]; then
+              echo "server never came up"; docker logs sxng-publish; exit 1
+            fi
+            sleep 1
+          done
+
+          echo "GET /health (no credentials) -> $health"
+          case "$health" in 200|503) ;; *) exit 1 ;; esac
+
+          unauth=$(mcp -d '{}')
+          echo "POST /mcp (no credentials) -> $unauth"
+          [ "$unauth" = 401 ]
+
+          wrong=$(mcp -H 'Authorization: Bearer not-the-token' -d '{}')
+          echo "POST /mcp (wrong token) -> $wrong"
+          [ "$wrong" = 401 ]
+
+          ok=$(mcp -H "Authorization: Bearer $TOKEN" \
+            -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"0.0.0"}}}')
+          echo "POST /mcp (correct token) -> $ok"
+          [ "$ok" = 200 ]
+
+          uid=$(docker exec sxng-publish id -u)
+          echo "runtime uid -> $uid"
+          [ "$uid" = 1000 ]
+
+      - name: Container logs
+        if: always()
+        run: docker logs sxng-publish || true
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      # Both `v3.24.0` and `3.24.0` are published, deliberately. The git tag
+      # carries the `v`; the conventional Docker tag does not; and
+      # docker/metadata-action's {{version}} silently strips it. Publishing a
+      # documented `v`-prefixed tag that then does not exist is a real failure
+      # mode this fleet has already hit once. Publishing both removes the
+      # question rather than answering it.
+      #
+      # `latest` moves only for a plain release tag. A prerelease (v3.24.0-rc1)
+      # publishes its own tags and leaves `latest` where it was.
+      - name: Tag and push
+        id: push
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          V="${REF_NAME#v}"                      # 3.24.0        (or 3.24.0-rc1)
+          MINOR="$(echo "$V" | cut -d. -f1,2)"   # 3.24
+
+          # Exact tags always. The FLOATING tags — :3.24 and :latest — move only
+          # for a plain release: someone pinned to :3.24 is asking for the
+          # newest stable 3.24.x, and quietly handing them an rc is the kind of
+          # surprise a floating tag exists to avoid.
+          TAGS=("$REF_NAME" "$V")
+          case "$V" in
+            *-*) echo "prerelease $V — publishing exact tags only, not :$MINOR or :latest" ;;
+            *)   TAGS+=("$MINOR" "latest") ;;
+          esac
+
+          for t in "${TAGS[@]}"; do
+            echo "pushing $IMAGE:$t"
+            docker tag "$IMAGE:candidate" "$IMAGE:$t"
+            docker push "$IMAGE:$t"
+          done
+
+          # The digest of what was actually pushed, for the attestation below.
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$V" | cut -d@ -f2)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "pushed digest $DIGEST"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,85 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.24.0] - 2026-09-06
+
+Consolidated fix pass closing ten tickets (build `searxng-mcp-fix-pass-2026-09`). **PDF
+fetching worked for no one and now works** — the headline change is a deletion, not a feature.
+
+### Fixed
+- **PDFs were routed to the one tier that cannot read them** (vikunja#682). A fast path in
+  `fetch.ts` matched `.pdf` on the pathname and dispatched straight to tier 2, on a comment
+  asserting *"Firecrawl can't extract PDF text"*. That was true of trieve/firecrawl v0.0.55 and
+  false of the v2 backend deployed since. Crawl4AI, meanwhile, renders the PDF in a browser,
+  finds no text nodes and trips its own anti-bot heuristic — and the resulting `null` was
+  reported as `"CRAWL4AI_URL not configured"` on containers where it plainly was, sending
+  investigators to check config that was already correct. The fast path is gone; PDFs take the
+  ordinary cascade and tier 1 serves them.
+- **`isPdfUrl` removed with it.** Suffix matching was never the right predicate — it missed
+  every PDF served from an extensionless URL, and those hit the tier-3 rejection instead. PDF
+  handling is now keyed on `Content-Type` **plus** the `%PDF-` body signature, so a page
+  mislabelled `application/pdf` is extracted rather than hard-failing.
+- **The tier-3 rejection no longer says "use Crawl4AI"** — wrong twice over, since Crawl4AI
+  cannot parse PDFs either and reaching tier 3 means tier 1 already declined. It now names the
+  actual cause and differs by backend version.
+- **Every tier-1 scrape failed under `FIRECRAWL_API_VERSION=v1`** (vikunja#649). `formats` was
+  an unconditional `["markdown", "html"]`, but v1's enum is `markdown | rawHtml | screenshot`
+  and it rejects `html` with a 400 that fails the whole scrape. The read side had the mirror
+  defect. Both are now keyed on the version — latent under v2, live on any rollback.
+- **The crawl4ai job poll was broken two ways** (vikunja#684). The route `/task/{task_id}` does
+  not exist on 0.8.6 — it 404s, and the miss was indistinguishable from a page with no content.
+  The response shape had also changed: a completed job nests the crawl result one level deeper
+  than the old code read, so fixing only the route would have turned a 404 into a 200 that still
+  produced no text. Both fixed; the older flat shape is still accepted. A 404 now logs, naming
+  the targeted crawl4ai version.
+- **The outbound User-Agent lied on every request from three modules** (vikunja#641).
+  `llms-txt.ts` claimed 3.8.0; `reddit.ts` and `youtube.ts` both claimed 3.15.0. All now use the
+  shared constant built from `package.json`, and a test rejects any hardcoded
+  `searxng-mcp/<semver>` literal in `src/` — this was the second round of the same drift.
+
+### Changed
+- **A failed fetch now says why, per tier** (vikunja#682 part 4). `"All fetch tiers failed"` was
+  equally consistent with nothing being configured, a backend being down, and the page genuinely
+  having no content. The error now names each tier and what happened to it — distinguishing
+  `skipped (not_configured)` from `attempted, no content` from an upstream error. Upstream error
+  text is bounded to 200 characters.
+- **`domain_stats` reports the window it actually measured** (vikunja#686). The aggregate header
+  printed a constant `"30d window"` from a TTL ceiling, not a measurement period — against the
+  live database it would have claimed thirty days over a window 33 hours old. It now renders the
+  real elapsed window and the schema version, both also exposed in `structuredContent`.
+- **Thin samples no longer render as percentages.** Below five attempts a single outcome moves
+  the rate by at least 20 points, so `0% ok (0/2)` and `0% ok (0/50)` read alike while being
+  wholly different findings. Under the threshold this now shows `insufficient data (0/2)`;
+  `no data` stays distinct.
+- **README split** (vikunja#683). 905 lines / 70KB down to ~190, with the reference material
+  moved to `docs/` behind an index. Adds a "Why searxng-mcp?" comparison table. The npm package
+  now ships `docs/`, so its README's links resolve.
+
+### Added
+- **Container image published to `ghcr.io/tadmstr/searxng-mcp`** on every release tag
+  (vikunja#681). `linux/amd64`, gated on the same smoke assertions CI runs — `/health`
+  unauthenticated, `/mcp` 401/401/200, uid 1000 — executed against the exact image that is then
+  pushed, with build provenance attested to the registry. Both `vX.Y.Z` and `X.Y.Z` tags are
+  published; floating `X.Y` and `latest` move only for non-prereleases.
+- **A per-version Firecrawl capability table** in `src/firecrawl-api.ts`. Four behaviours now
+  differ between backends (`actions`, `map`, `pdf`, `htmlFormat`); the existing
+  `firecrawlSupportsX` helpers are thin readers over it.
+
+### Security
+- **Dev dependency tree is now gated** (vikunja#634). `pnpm audit --prod` covered what ships;
+  nothing covered the build and test tooling, and vite carried GHSA-fx2h-pf6j-xcff (high,
+  `server.fs.deny` bypass) and GHSA-v6wh-96g9-6wx3 for ten releases. vite 8.0.7 → 8.2.2, and
+  `pnpm audit --dev` runs as its own CI step — separate from `--prod`, so a red gate keeps
+  meaning one thing.
+- Upstream error text relayed in the new per-tier failure reason is length-bounded. Accepted at
+  audit as `OE-02`; see `host-forge/security/accepted-risks.md`.
+
+### Internal
+- Coverage floor raised 72/65/74/74 → 84/77/83/86 against a measured
+  85.51/78.54/84.86/87.83 (vikunja#680). The previous floor was set 2026-07-12 and went ten
+  releases without moving, so it had come to permit a twelve-point silent regression.
+- Tests 883 → 927.
+
 ## [3.23.0] - 2026-09-04
 
 Firecrawl v2 client behind a configuration axis (build

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ docker compose -f docker-compose.example.yml up -d
 SEARXNG_URL=http://localhost:8081 CACHE_URL=redis://localhost:6381 npx @tadmstr/searxng-mcp
 ```
 
+**As a container** — published to GHCR on every release:
+
+```bash
+docker pull ghcr.io/tadmstr/searxng-mcp:latest
+```
+
+Tags, uid, and provenance verification: [Deployment](docs/deployment.md#container-image).
+
 For a full local topology including Firecrawl, Crawl4AI, Ollama, Kiwix, the adblock proxy, and NATS, see [`docker-compose.full.yml`](docker-compose.full.yml).
 
 ## Tools

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Built with [Claude Code](https://claude.ai/code) using the multi-agent workflow 
 ## Quick Start
 
 **A running [SearXNG](https://github.com/searxng/searxng) instance is the only requirement.**
-Everything else is optional and improves a specific dimension — see [Prerequisites](#prerequisites).
+Everything else is optional and improves a specific dimension — see [Prerequisites](docs/configuration.md#prerequisites-and-service-setup).
 
 **SearXNG only** — nothing else deployed:
 
@@ -46,65 +46,42 @@ For a full local topology including Firecrawl, Crawl4AI, Ollama, Kiwix, the adbl
 
 ## Tools
 
-| Tool | Description | Key Parameters |
-|------|-------------|----------------|
-| `search` | Search via SearXNG with local reranking. Fetches a wider result pool, reranks by relevance, returns top N. SearXNG's native direct answers, infoboxes, spelling corrections, and related suggestions are surfaced above the list and in `structuredContent`. | `query`, `num_results` (1–20), `category`, `time_range`, `domain_profile`, `expand`, `language`, `engines`, `site`, `min_score` |
-| `search_and_fetch` | Search, rerank, then fetch full content of the top result(s) using the fetch cascade (Firecrawl → Crawl4AI → raw HTTP). | `query`, `category`, `time_range`, `fetch_count` (1–3), `domain_profile`, `expand`, `language`, `engines`, `site`, `min_score` |
-| `search_and_summarize` | Search, fetch top results, then synthesize a summary with citations via Ollama (`OLLAMA_SUMMARIZE_MODEL`). Falls back to raw fetched content if Ollama is unavailable. | `query`, `fetch_count` (1–5), `category`, `time_range`, `domain_profile`, `expand`, `language`, `engines`, `site`, `min_score` |
-| `fetch_url` | Fetch and extract readable markdown from any public URL. GitHub hosts take the GitHub fast path; YouTube video URLs return the transcript and Reddit thread URLs return post+comments (both opt-in via robots, see below); all others use the fetch cascade (Firecrawl → Crawl4AI → raw HTTP). Trimmed to a token budget (default ~8,000 chars). | `url`, `domain_profile`, `max_tokens`, `target_selector`, `wait_for_selector` |
-| `crawl_site` | Crawl an entire site and return a manifest of URL/title/snippet for each page. Tries Firecrawl crawl first, falls back to sitemap parsing, then optional BFS. Full page content is cached in Valkey so follow-up `fetch_url` calls are zero-cost. | `url`, `max_pages` (default: `CRAWL_MAX_PAGES_DEFAULT`), `bfs` (bool, opt-in BFS) |
-| `clear_cache` | Purge the search cache, fetch cache, crawl manifest cache, or all. Useful when researching fast-moving topics where cached results may be stale. | `target` (`search`, `fetch`, `crawl`, `all`) |
-| `domain_stats` | Read-only view of the [domain capability database](#domain-capability-database). With `hostname`: one domain's per-tier success rates and capability flags. Without: an aggregate across all tracked domains (per-tier success, worst failing domains, seen-but-never-fetched count). Returns MCP structured output (`structuredContent`) for programmatic thresholding. | `hostname` (optional) |
+| Tool | What it does |
+|------|--------------|
+| `search` | Search via SearXNG with local ML reranking, plus SearXNG's own direct answers, infoboxes and suggestions. |
+| `search_and_fetch` | Search, rerank, then fetch full content of the top result(s) through the fetch cascade. |
+| `search_and_summarize` | Search, fetch, then synthesize a cited summary via Ollama. Falls back to raw content if Ollama is absent. |
+| `fetch_url` | Fetch and extract readable markdown from any public URL, via fast paths or the fetch cascade. |
+| `crawl_site` | Crawl a site and return a URL/title/snippet manifest. Page content is cached, so follow-up `fetch_url` calls are free. |
+| `clear_cache` | Purge the search, fetch or crawl cache. |
+| `domain_stats` | Read-only view of the domain capability database — per-tier success rates, as structured output. |
 
-### Parameters
+Full parameter reference: [`docs/tools.md`](docs/tools.md).
 
-**`category`** — `general` (default), `news`, `it`, `science`
+## Why searxng-mcp?
 
-**`time_range`** — `day`, `week`, `month`, `year` — limits results by publication date. Omit for all-time results.
+There are a number of SearXNG MCP servers. Most wrap the search endpoint and stop there. The
+differentiators here are in what happens *after* the search:
 
-**`fetch_count`** — number of top reranked results to fetch full content for (default `1`, max `3` for `search_and_fetch`; default `3`, max `5` for `search_and_summarize`).
+| | searxng-mcp | Typical SearXNG MCP server |
+|---|---|---|
+| SearXNG search | yes | yes |
+| ML reranking of results | local cross-encoder, reorders by relevance | SearXNG's own ordering |
+| Full-page content retrieval | three-tier cascade — Firecrawl, Crawl4AI, in-process raw fetch + Readability | none, or a single raw fetch |
+| Per-domain routing | domain capability database learns which tier works per domain and skips the ones that do not | none |
+| Summarisation | Ollama, with citations back to source URLs | none |
+| Site crawling | `crawl_site` — Firecrawl crawl, sitemap fallback, optional BFS | none |
+| Caching | persistent, shared across clients (Valkey/Redis) | in-process or none |
+| Challenge handling | detection-gated solver tier, plus a Wayback fallback | none |
+| Observability | OpenTelemetry traces and metrics, NATS events, structured logs | none |
 
-**`domain_profile`** — apply a named domain filter profile: `homelab` (surfaces self-hosted/Linux docs) or `dev` (surfaces Stack Overflow, MDN, npm). Omit for default filters.
-
-**`expand`** — when `true`, rewrites the query via Ollama (`OLLAMA_EXPAND_MODEL`) before searching to improve recall. Requires `OLLAMA_URL`. Defaults to the `EXPAND_QUERIES` env var value.
-
-**`language`** — BCP-47 language code (e.g. `en`, `de`) or `all` to restrict to a specific language. Omit to use the SearXNG instance default. Available on `search`, `search_and_fetch`, and `search_and_summarize`.
-
-**`engines`** — comma-separated SearXNG engine names to restrict the search to (e.g. `google,duckduckgo`). Forwarded verbatim; unknown/disabled engines degrade to fewer results rather than erroring. Available on all three search tools.
-
-**`site`** — restrict results to one domain or a list (e.g. `github.com` or `["github.com", "gitlab.com"]`). Applied best-effort as a `site:` query operator — most engines (Google, Bing, DDG, Brave) honor it, some ignore it. Available on all three search tools.
-
-**`max_tokens`** (`fetch_url`) — approximate token budget for returned content (chars ≈ tokens × 4). Omit for the ~2,000-token / 8,000-char default; max 10,000 tokens.
-
-**`target_selector`** (`fetch_url`) — CSS selector to scope extraction to a specific element (e.g. `article`, `main .content`). Honored natively by Firecrawl/Crawl4AI and applied client-side on the raw-HTTP tier; ignored by fast paths and when it matches nothing.
-
-**`wait_for_selector`** (`fetch_url`) — CSS selector to wait for before extracting, for JS-rendered pages. Honored by the rendering tiers (Firecrawl/Crawl4AI); ignored on raw HTTP (no JS).
+**Only SearXNG is required.** Everything in the table above degrades gracefully: with nothing
+else deployed, `fetch_url` still returns extracted content from the in-process tier 3, and the
+startup capability line tells you exactly which features are off.
 
 ## Architecture
 
-```
-MCP client (stdio)
-      │
-      ▼
-  searxng-mcp ──────────────→ cache ($CACHE_URL)           → result cache (search 1h, fetch 24h, crawl 6h)
-      │
-      ├── expand (optional) →  Ollama ($OLLAMA_URL)        → rewritten query (qwen3:4b)
-      ├── search ───────────→ SearXNG ($SEARXNG_URL)      → raw results
-      ├── rerank ───────────→ Reranker ($RERANKER_URL)    → ranked results
-      │                       (fallback: SearXNG order if reranker unavailable)
-      ├── fetch content ────┬→ GitHub API (github.com)    → markdown
-      │                     ├→ Kiwix ($KIWIX_URL)         → ZIM content (Wikipedia/SO/Arch Wiki, fast path)
-      │                     ├→ Hister ($HISTER_URL)       → browsing-history index (login-walled/JS-heavy fast path)
-      │                     ├→ Firecrawl ($FIRECRAWL_URL) → page markdown (tier 1)
-      │                     ├→ Crawl4AI ($CRAWL4AI_URL)  → page markdown (tier 2, optional; via $ADBLOCK_PROXY_URL if set)
-      │                     ├→ Raw HTTP + Readability     → page markdown (tier 3 fallback; via $ADBLOCK_PROXY_URL if set)
-      │                     ├→ Byparr solver (opt-in)     → challenge-solved page markdown (only on a detected challenge, $SOLVER_ENABLED)
-      │                     └→ Wayback Machine (opt-in)  → archived page markdown (tier 4, $WAYBACK_ENABLED)
-      ├── crawl_site ───────┬→ Firecrawl crawl           → page manifest (phase 1)
-      │                     ├→ Sitemap parsing           → page manifest (phase 2 fallback, fast-xml-parser)
-      │                     └→ BFS crawl (opt-in)        → page manifest (phase 3, $CRAWL_BFS_ENABLED)
-      └── summarize (opt.) →  Ollama ($OLLAMA_URL)        → synthesized summary ($OLLAMA_SUMMARIZE_MODEL)
-```
+The fetch cascade, in full. Each stage is optional and skipped cleanly when unconfigured.
 
 ```mermaid
 flowchart TD
@@ -117,10 +94,9 @@ flowchart TD
     llms_fetch["Probe /llms-full.txt\nextract matching section\n→ return"]
     kiwix{"Kiwix host?\nKIWIX_URL set"}
     kiwix_fetch["Local Kiwix ZIM\nWikipedia · Stack Overflow · Arch Wiki\n→ cache + return"]
-    pdf{".pdf URL?"}
     robots["robots.txt pre-check — tiers 1–3\ndisallowed → RobotsDisallowedError (cached 24h)"]
     tier_skip(["Per-domain tier skip\nsuccess rate &lt;30% over ≥10 tries\nor tier_skip operator override"])
-    t1["Tier 1 — Firecrawl\n$FIRECRAWL_URL"]
+    t1["Tier 1 — Firecrawl\n$FIRECRAWL_URL\nserves PDFs under FIRECRAWL_API_VERSION=v2"]
     t2["Tier 2 — Crawl4AI\n$CRAWL4AI_URL · optional\nadblock proxy if $ADBLOCK_PROXY_URL"]
     t3["Tier 3 — Raw HTTP + Readability\nfallback: raw HTML slice\nadblock proxy if $ADBLOCK_PROXY_URL"]
     challenge(["Challenge detected\non this URL, this request?"])
@@ -137,9 +113,7 @@ flowchart TD
     llms -->|yes| llms_fetch
     llms -->|no| kiwix
     kiwix -->|yes| kiwix_fetch
-    kiwix -->|no| pdf
-    pdf -->|"yes — skip tier 1"| t2
-    pdf -->|no| robots
+    kiwix -->|no| robots
     robots --> tier_skip
     tier_skip --> t1
     t1 -->|success| post
@@ -164,7 +138,6 @@ flowchart TD
     style llms_fetch fill:#dae8fc,stroke:#6c8ebf,color:#000000
     style kiwix fill:#fff9c4,stroke:#b8860b,color:#000000
     style kiwix_fetch fill:#fff9c4,stroke:#b8860b,color:#000000
-    style pdf fill:#ffffff,stroke:#333333,color:#000000
     style robots fill:#ffffff,stroke:#333333,color:#000000
     style tier_skip fill:#f5f5f5,stroke:#666666,color:#000000
     style t1 fill:#d5e8d4,stroke:#5a8a4a,color:#000000
@@ -177,714 +150,20 @@ flowchart TD
     style result fill:#ffffff,stroke:#333333,color:#000000
 ```
 
-**Only SearXNG is required.** Every tier below it is optional: Firecrawl, Crawl4AI, Valkey, Ollama, Kiwix, the reranker, the solver and Wayback each improve a named dimension, and the server degrades gracefully when any of them is unavailable. Tier 3 is a raw HTTP fetch plus Readability running in-process, so `fetch_url` still returns extracted content with nothing else deployed. Set `FIRECRAWL_ENABLED=false` and leave `CRAWL4AI_URL` unset to say so explicitly — those tiers are then skipped with `reason: not_configured` rather than attempted and missed.
+Read the rest — tier semantics, the domain capability database, adblocking, every fast path,
+resilience and observability — in [`docs/architecture.md`](docs/architecture.md).
 
-### Adblocking
+## Documentation
 
-searxng-mcp ships two adblocking sidecars, but only one of them applies to every deployment:
-
-| Sidecar | Tier | Mechanism | Applies when |
-|---------|------|-----------|--------------|
-| `docker/adblock-proxy/` | Tiers 2+3 (Crawl4AI, raw fetch) | HTTP forward proxy — filters plain-HTTP ad domains | `ADBLOCK_PROXY_URL` is set |
-| `docker/puppeteer-adblock/` | Tier 1 (Firecrawl) | CDP-level interception in the browser service | **Only** on a `v1` firecrawl-simple stack built from `docker-compose.full.yml` |
-
-#### Tier 1 — Puppeteer adblock (v1 stacks only)
-
-`docker/puppeteer-adblock/` builds an image layering `@ghostery/adblocker-puppeteer` over `trieve/puppeteer-service-ts`. EasyList + EasyPrivacy are loaded at startup and refreshed every 168 hours, and the blocker is applied to every page Firecrawl creates.
-
-**It is not automatic, and it does not apply under `FIRECRAWL_API_VERSION=v2`:**
-
-- It reaches a deployment only if that deployment builds it. `docker-compose.full.yml` in this repo does; a Firecrawl stack brought up from upstream's own compose, or any stack pointing `PLAYWRIGHT_MICROSERVICE_URL` at a stock `trieve/puppeteer-service-ts` image, does not — tier 1 then has no adblocking, silently.
-- It is Puppeteer-specific. Upstream Firecrawl 2.x replaced the Puppeteer service with `apps/playwright-service-ts`, so on a `v2` backend this image is not part of the stack at all. Porting it would mean rewriting against `@ghostery/adblocker-playwright`, not rebuilding.
-
-To check rather than assume, confirm the browser container carries the hook:
-
-```bash
-docker exec <firecrawl-browser-container> ls node_modules/@ghostery
-```
-
-Env vars, read by that image only:
-
-| Var | Default | Description |
-|-----|---------|-------------|
-| `ADBLOCK_DISABLE` | _unset_ | Set to `true` to skip filter loading entirely. |
-| `ADBLOCK_FILTERS_URL` | EasyList + EasyPrivacy | Comma-separated list of filter list URLs. |
-| `ADBLOCK_REFRESH_HOURS` | `168` | Cadence at which the blocker rebuilds from the configured URLs. |
-
-The base image is pinned by SHA256 digest. To rebuild and restart it:
-
-```bash
-docker compose -f docker-compose.full.yml up -d --build firecrawl-puppeteer
-```
-
-**Per-domain bypass:** `domains.json` reserves an `adblock_skip` slot for future operator overrides. Wiring isn't implemented — it would require Firecrawl to forward a custom header through to the browser service, which isn't part of its API. Tracked as scope-creep item I.
-
-#### Tier 2+3 — Adblock proxy
-
-Set `ADBLOCK_PROXY_URL` (e.g. `http://adblock-proxy:8118`) to route Crawl4AI and raw Node fetch requests through an HTTP forward proxy that filters ad and tracker requests. HTTPS CONNECT tunnels are passed through unmodified — no MITM, so filtering applies to plain-HTTP ad domains only. Where the tier-1 hook above is in play it handles HTTPS filtering for that tier; where it is not — including every `v2` deployment — nothing filters tier 1 at all.
-
-As of v3.19.0, the proxy validates the **resolved** address — not just the requested hostname string — on both its CONNECT and plain-HTTP paths before connecting, closing a DNS-rebinding gap (audit finding SSRF-10).
-
-See [`docker/adblock-proxy/`](docker/adblock-proxy/) for the service definition, configuration options, and deployment instructions (included in `docker-compose.full.yml`).
-
-### Data-driven tier routing
-
-Before invoking the fetch cascade, searxng-mcp reads the domain's `tier_stats_30d` (see [domain capability database](#domain-capability-database)) and skips any tier with success rate below 30% over at least 10 attempts. Cold-start domains (<10 attempts) keep the default cascade. Each skip emits a `searxng.fetch.tier.skipped` NATS event and increments `searxng_fetch_total{outcome=skipped}`, both carrying the reason. Three reasons exist: `low_success_rate` (the stats rule above), `operator_override` (a `tier_skip` entry in `domains.json`), and `not_configured` (the tier's service is switched off, or has no URL). `not_configured` takes precedence over both others — an override cannot un-skip a tier there is nothing to call. Because a skipped tier is never recorded as an attempt, an unconfigured tier no longer books misses into `tier_stats_30d` meaning “not deployed” rather than “tried and failed”.
-
-**Operator override.** Add a `tier_skip` map to `domains.json` to force-skip tiers regardless of stats:
-
-```json
-{
-  "tier_skip": {
-    "example-bot-blocked.com": ["tier1"],
-    "another-site.example": ["tier1", "tier2"]
-  }
-}
-```
-
-`tier_skip` keys can be bare domains (`example.com` matches the domain and all subdomains) or domain + path prefix (`example.com/api/`). The file is hot-reloaded — no restart needed. Manual overrides emit `reason: operator_override`.
-
-### Content-type fast path
-
-A URL serving structured, non-HTML content — `application/json`, any `*+json`, XML, YAML, TOML, CSV, or `text/plain` — is detected via a `HEAD` probe and routed straight to the raw-HTTP tier instead of the full Firecrawl/Crawl4AI cascade. JSON is returned pretty-printed inside a fenced code block. Previously, asking a headless browser to render a JSON API response or CDN asset returned empty markdown, so API and CDN endpoints (`registry.npmjs.org`, `api.osv.dev`, `cdn.jsdelivr.net`, …) simply failed.
-
-Guarantees:
-- The probe is **fail-open**. An unreachable host, a server that refuses `HEAD`, or an unreadable/unparseable `Content-Type` header all fall through to the normal cascade unchanged.
-- `application/xhtml+xml` is deliberately excluded — that is markup for a browser, not structured data.
-- HTML that a server mislabels as `text/plain` is still parsed as HTML, not dumped as a raw text block.
-
-### Domain capability database
-
-Every fetch records what searxng-mcp learns about the target domain to Valkey under `domain:<hostname>` (90-day TTL, schema_version 6). Captured per record:
-
-- `tier_stats_30d.{tier1,tier2,tier3,tier4,solver,github}.{attempts, ok, fail, last_fail_reason, window_start_ms}` — fetch success rate per tier over a rolling 30-day window. The cutoff is applied at **read time**, shared by tier-routing decisions and `domain_stats` reporting, so the two cannot disagree — a domain fetched once and then left idle reports a genuinely empty window rather than stale numbers surviving until the next write. The `tier4` (Wayback Machine) slot is recorded only when `WAYBACK_ENABLED=true`; the `solver` slot (Byparr challenge-solving tier, see [Challenge detection and solver tier](#challenge-detection-and-solver-tier)) only when `SOLVER_ENABLED=true`. The `github` slot records the [GitHub fast path](#github-urls) (`raw.githubusercontent.com` / `api.github.com` / `github.com` README fetches), which bypasses the tier cascade but is still tracked here. A `schema_version` bump rebuilds existing records fresh — accumulated windows for currently-idle domains are discarded (precedented across the 1→2, 2→3, 3→4, 4→5, 5→6 bumps).
-- `capabilities.metadata_fetch.{attempts, ok, fail, last_fail_reason}` — success/failure of the metadata side-channel fetch (`fetchRawHtmlForMetadata`, used for JSON-LD/og:title sampling). Tracked separately from `tier_stats_30d` since it answers "is this domain reachable at all", not "did full-content delivery succeed".
-- `capabilities.seen_in_search.{count, last_seen_ms}` — how often the domain appears in `search` results. Written fire-and-forget by `searxSearch()` on every return path (including cache hits) with no fetch performed, so a domain can be tracked before it is ever fetched.
-- `capabilities.robots_txt.{present, fetched, allows_us}` — robots.txt presence and whether it permits us
-- `capabilities.llms_full_txt.{present, size_bytes, last_checked}` — whether the domain serves `/llms-full.txt`
-- `capabilities.json_ld_article.{sampled, present, last_sampled_at}` — whether the page carries Article-schema JSON-LD at all (Schema.org `Article`/`NewsArticle`/`BlogPosting`/`TechArticle` and subtypes like `ScholarlyArticle`/`OpinionNewsArticle`/`LiveBlogPosting`, matched by bare name or fully-qualified `https://schema.org/...` `@type`), independent of whether that schema had extractable body text — many sites publish headline/metadata JSON-LD with no `articleBody`, which is a distinct concern from [post-extraction](#fetch-quality) actually using it.
-- `capabilities.og_title.{sampled, present, last_sampled_at}` — same for `<meta property="og:title">`
-- `preferred_strategy` — currently set to `llms_full_txt` when a present probe lands; future phases will use this to skip the tier cascade
-
-Inspect a record with the bundled CLI, or query it from an agent via the `domain_stats` tool (single-domain or aggregate; see [Tools](#tools)):
-
-```bash
-pnpm dump-domain docs.anthropic.com
-```
-
-`dump-domain` distinguishes a window that has expired from a tier that has no data at all, rather than showing both the same way.
-
-Concurrent updates for the same hostname (the tier-attempt, robots-probe, and post-extract-sample recorders that fire in parallel during one fetch) are serialized through a server-side Lua compare-and-set, paired with an in-process per-key queue that removes contention between a single process's own writers so the CAS only has to arbitrate genuinely concurrent writes across processes. Versions before v3.17.0 used a `WATCH`/`MULTI`/`EXEC` read-modify-write against a shared connection, which does not actually serialize concurrent writers — data collected before v3.17.0 was substantially incomplete as a result. Upgrading discards existing tier statistics via the schema bump; expect `domain_stats` to read near-empty immediately after upgrading and refill over the following days.
-
-#### Domain-db persistence
-
-The domain-db lives only in Valkey under a 90-day TTL and 30-day rolling windows, so a cache flush or TTL expiry erases capability learning that is expensive to re-acquire. Two CLIs make it durable:
-
-```bash
-pnpm domain-db-maintenance   # SCAN all domain:* records → write a dated JSON snapshot (+ prune) and emit OTel gauges
-pnpm restore-domain-db       # re-seed the domain-db from the newest snapshot after a flush
-```
-
-- **`domain-db-maintenance`** is a standalone job — run it on a schedule via cron or a container cron sidecar, **not** as an in-process timer. (The original reason was that searxng-mcp ran as several concurrent per-agent stdio children that would each fire the timer. That is no longer true: since vikunja#149/#321 it is one shared container. The conclusion still holds for a different reason — an in-process timer ties a bounded full-keyspace `SCAN` to the lifetime of the request-serving process, whereas a standalone job can be scheduled, retried and observed on its own.) One bounded `SCAN` feeds both outputs: a durable dated snapshot and, when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, gauges (`searxng_domains_tracked`, `searxng_domains_failing`, `searxng_domain_tier_success_ratio{tier}`) force-flushed before exit.
-- **`restore-domain-db`** re-seeds only keys that are missing or whose live record is strictly staler than the snapshot (compares `last_fetch`) — it never clobbers a fresher-or-equal live record, so it is safe to run against a live, partially-populated Valkey (e.g. in a service boot sequence for automatic flush recovery).
-
-| Env var | Default | Purpose |
-|---------|---------|---------|
-| `DOMAIN_DB_SNAPSHOT_DIR` | `./domain-db-snapshots` | Where dated snapshots are written/read. Set to a durable path (appdata or NFS mount) in deployment. |
-| `DOMAIN_DB_SNAPSHOT_RETENTION` | `14` | How many snapshots to keep; older ones are pruned each maintenance run. |
-
-### llms.txt fast path
-
-For whitelisted documentation domains in `domains.json` (`llms_txt` array), `fetchPage` tries `<origin>/llms-full.txt` first and extracts the section matching the requested URL before invoking any tier. This avoids running puppeteer against well-instrumented docs sites and returns a clean markdown section directly. Probe outcomes and the full body are cached in Valkey (`llms:<origin>:full`, 24 h / 7 d for present/absent). Default whitelist: `docs.anthropic.com`, `docs.openai.com`, `docs.stripe.com`, `docs.crawl4ai.com`, `docs.firecrawl.dev`, `docs.cursor.com`. Extend by editing `domains.json` — the file is hot-reloaded.
-
-A document is accepted only if it is between 1 KB and 64 MB; anything outside that is treated as absent and falls through to the normal tier cascade. The upper bound is a capability boundary as much as a memory one — for reference, `docs.anthropic.com/llms-full.txt` was 40.3 MB as of 2026-09-03, so lowering it much further would drop that domain off the fast path.
-
-### Kiwix fast path
-
-When `KIWIX_URL` is set, fetch requests for known offline-capable hosts are intercepted
-before the Firecrawl/Crawl4AI cascade and served from the local [Kiwix](https://kiwix.org/)
-ZIM archive. This eliminates the 100% tier-1 failure rate for sites like Wikipedia (which
-blocks headless scrapers) and returns clean readable content with zero external network traffic.
-
-Supported hosts and ZIM books (kiwix-serve must run with `--nodatealiases` / `-z`):
-
-| Host | ZIM book |
-|------|----------|
-| `en.wikipedia.org`, `wikipedia.org` | `wikipedia_en_all_mini` |
-| `stackoverflow.com` | `stackoverflow.com_en_all` |
-| `wiki.archlinux.org` | `archlinux_en_all_maxi` |
-
-The Kiwix path runs after the llms-txt fast path and before the robots gate. If the Kiwix
-request fails or returns empty, the full tier cascade runs as normal. When `KIWIX_URL` is
-unset the feature adds zero overhead — `isKiwixHost()` returns false immediately.
-
-Set `KIWIX_URL` to your kiwix-serve base URL (e.g. `http://localhost:8292`).
-
-### YouTube & Reddit fast paths
-
-`fetch_url` recognises YouTube video URLs (`youtube.com`, `youtu.be`) and Reddit thread URLs and can serve them directly instead of scraping the rendered page:
-
-- **YouTube** — extracts the video's caption track from the watch page and returns the transcript. Enabled by `YOUTUBE_TRANSCRIPT_ENABLED` (default on).
-- **Reddit** — fetches the public `.json` view and returns the post plus top comments in the standard `{title, url, text}` shape; falls through on HTTP 429. Enabled by `REDDIT_FASTPATH_ENABLED` (default on).
-
-Both rely on **unofficial, undocumented endpoints** (YouTube's timedtext API, Reddit's `.json`) — best-effort with no SLA; either may break on an upstream change, hence the kill switches. On any miss the request falls through to the normal tier cascade (which can still get a YouTube page's title/description).
-
-**robots.txt:** both endpoints are disallowed by the sites' `robots.txt` (Reddit disallows everything; YouTube disallows `/api/`, where the transcript lives). By default these fast paths respect that and stay dormant, falling through to the cascade. On your own instance you can opt into direct fetching with `YOUTUBE_IGNORE_ROBOTS=true` / `REDDIT_IGNORE_ROBOTS=true`.
-
-### Site crawling
-
-`crawl_site` crawls an entire site and returns a manifest of URL/title/snippet for each page found. It uses a four-phase strategy cascade:
-
-1. **Firecrawl crawl** — sends a crawl job to Firecrawl (`/crawl`), polls until complete, and returns the full page list. Targets `/v1/crawl` or `/v2/crawl` per `FIRECRAWL_API_VERSION`. Controlled by `FIRECRAWL_CRAWL_POLL_INTERVAL_MS` and `FIRECRAWL_CRAWL_MAX_WAIT_MS`.
-2. **Firecrawl map** (`v2` only) — asks `/v2/map` for the site's URLs, then fetches them. Purpose-built for exactly what phase 3 hand-rolls, and it copes with sites whose sitemap is absent, stale or split across nested indexes. Skipped entirely under `v1`, where the endpoint does not exist.
-3. **Sitemap parsing** — fetches `/sitemap.xml` (and linked sitemaps) and extracts URLs with titles/snippets. Uses `fast-xml-parser` for sitemap XML parsing.
-4. **BFS crawl** (opt-in) — if sitemap parsing also fails, performs a breadth-first crawl starting from the given URL up to `CRAWL_BFS_MAX_DEPTH` link hops. Only runs when `CRAWL_BFS_ENABLED=true` or the `bfs` tool parameter is `true`.
-
-Each phase falls through to the next, but **no longer silently**: a non-2xx from the crawl
-start, the crawl poll or the map endpoint is logged and recorded against the `crawl` slot in
-the per-domain stats, so `domain_stats` answers "does the Firecrawl phase ever succeed here?"
-without needing a live probe.
-
-Full page content fetched during the crawl is cached in Valkey (TTL: `CRAWL_MANIFEST_TTL_SECONDS`, default 6 hours). Subsequent `fetch_url` calls for any URL in the manifest return immediately from cache — zero fetch overhead for follow-up reads.
-
-The manifest cache can be cleared with `clear_cache(target="crawl")`.
-
-### Wayback Machine fallback
-
-When `WAYBACK_ENABLED=true`, a fourth tier queries the Wayback Machine CDX API for an archived snapshot when all three main tiers fail. Returned content is prefixed with a provenance header (`[Archived snapshot – <timestamp> – <original_url>]`) so callers know the content may not reflect the current page state.
-
-### Challenge detection and solver tier
-
-A Cloudflare-style challenge interstitial is frequently served with **HTTP 200** — routine for
-Managed Challenge and Turnstile — which used to pass straight through the tier cascade as a
-successful fetch: Readability-extracted, cached, and written to the domain capability database
-as evidence the tier works on that domain, feeding tier-skip decisions on nothing but a wrong
-signal. As of v3.19.0, tiers 1–3 detect this case (matched on Cloudflare edge headers at
-403/503, and on interstitial markers in a 200-status body) and report it as a distinct miss
-(`reason: challenge_detected`) instead of a hit. A detected challenge is never cached and never
-written to domain-db.
-
-When `SOLVER_ENABLED=true` and `SOLVER_URL` points at a running solver — Byparr, or any service
-implementing FlareSolverr's `POST /v1` contract — a challenge detected on a given request
-triggers one solve attempt, dispatched after the tier 3 cascade fails and before the Wayback
-fallback. The solve is **strictly per-request**: the tier never fires on a URL that was not
-challenged in that same request, so it adds no overhead to the ordinary path. The solver's
-response is replayed through the normal bounded-fetch and extraction path — re-validated for
-SSRF (`assertPublicUrl` + `assertResolvedPublic` against the solver's resulting URL, since it
-may differ from the one requested) and re-checked for a challenge — rather than trusted
-directly, so a "solved" page that is still an interstitial registers as a miss, not a cache
-write. Solver-returned cookies are scoped to the solved host and never forwarded elsewhere.
-
-**This is not a guaranteed bypass.** Byparr's own documentation is explicit that a solve is not
-guaranteed and often needs residential-IP traffic. A miss here is the expected common case and
-degrades cleanly into the Wayback tier — not an error, and not something to alert on.
-
-### Fetch quality
-
-After any tier returns content with raw HTML, a post-extraction pass improves title and body quality:
-
-- **JSON-LD Article extraction** — Schema.org `Article` / `NewsArticle` / `BlogPosting` / `TechArticle` blocks supply cleaner `headline` and `articleBody` than tier-1 chrome scraping (size-capped at 1 MB per script tag).
-- **Title cascade** — falls back through `og:title` → `twitter:title` → `<title>` (with publisher-suffix stripping) → first `<h1>` → URL.
-- **Tier-2 Readability comparison** — when Crawl4AI returns markdown, JSDOM+Readability also runs over its raw HTML and is preferred when its text is longer (or unconditionally when Crawl4AI returns less than 500 chars).
-
-### Relevance filtering (`min_score`)
-
-The three search tools accept `min_score` (0–1), a floor applied after reranking. Omit it and nothing changes.
-
-It filters on the **raw cross-encoder `relevance_score`**, not on the value used for ordering. Ranking sorts by `relevance_score + RERANK_RECENCY_WEIGHT * recencyScore(publishedDate)`, which with the default weight of `0.15` ranges over **0–1.15, not 0–1**. Filtering a parameter called "minimum relevance" on that number would quietly make it mean "relevant enough *or* recent enough". Filtering happens before the top-N slice, so the floor never costs you a result that cleared it.
-
-Two things make this knob behave differently from how a 0–1 range suggests. Both were measured against the local FlashRank service on the query *"how to configure nginx reverse proxy"*:
-
-| Document | `relevance_score` |
+| | |
 |---|---|
-| nginx reverse-proxy guide (`proxy_pass`) | **0.998** |
-| Apache `mod_proxy` reverse proxying | **0.967** |
-| nginx install page (topical, wrong subject) | **0.0028** |
-| banana bread recipe | **0.0000151** |
-
-- **The distribution is strongly bimodal.** Relevant results cluster near 1.0, irrelevant ones near 0, with very little in between — so any threshold in roughly 0.01–0.9 behaves near-identically. Useful values are around **0.01–0.1**; `0.5` is not a meaningful midpoint.
-- **A high score means topically related, not correct.** The Apache document scored 0.967 on an nginx query. `min_score` is a topicality floor and cannot be trusted as a correctness filter.
-
-Thresholds are model-dependent and not comparable across rerankers. When the reranker is unavailable there are no scores to filter on, so `min_score` becomes a **no-op with a throttled warning** — returning unfiltered results silently would let you believe a floor had been applied, and returning nothing would turn a reranker outage into "no results found".
-
-### Resilience
-
-- **Multi-instance SearXNG failover.** `SEARXNG_URL` accepts a list of interchangeable replicas (`,` or `;` separated), tried in order. A single value behaves exactly as before — one request, one host, no health lookup, no extra cache traffic. Three things about the multi-instance path are worth knowing:
-  - The timeout budget is **total, not per instance**. `SEARXNG_TOTAL_TIMEOUT_MS` bounds the whole call and is decremented as candidates fail, so adding a replica cannot make a total outage take longer to report.
-  - Health state lives in the **cache, not in process memory**, so one process's discovery of a dead instance informs the next call. It is a hint, not a circuit breaker: a failed instance is moved to the back of the order for `SEARXNG_UNHEALTHY_TTL_SECONDS`, never removed, and if every instance is marked down the full list is tried anyway. A cache outage degrades to "try every instance in configured order" — never to an error.
-  - **Failover is loud.** Each fall-through emits a `search.failover` NATS event and a throttled stderr line. A silent failover is indistinguishable from a healthy primary, which is how a half-dead deployment goes unnoticed for weeks.
-
-  Fan-out (querying replicas in parallel and merging) is deliberately **not** implemented: it needs meta reconciliation with no obvious right answer — if two instances return different `answers`/`infoboxes`, which wins? `searxSearch` already merges across expanded query variants, so the marginal recall gain is small.
-
-- **Cache never hangs a search.** The Valkey client is bounded by `CACHE_COMMAND_TIMEOUT_MS`/`CACHE_CONNECT_TIMEOUT_MS`/`CACHE_MAX_RETRIES_PER_REQUEST` (see [Configuration](#configuration)). A stalled or CPU-spiked cache backend now rejects the command instead of hanging forever — the existing fail-soft handling degrades that rejection to a cache miss (serve live) rather than throwing. Cache connect failures, client errors, and per-command errors emit a throttled `[searxng-mcp]` stderr line (deduped per key so a sustained outage leaves a periodic breadcrumb, not a flood) — stderr is always on, and is the sink that never depends on configuration. On the forge deployment OTel and NATS are also wired (`OTEL_EXPORTER_OTLP_ENDPOINT` and `NATS_URL` are both set, and the startup capability line reports `otel,nats` in its on-list), so stderr is the floor rather than the whole story.
-- **Process crash handlers** — `uncaughtException` logs then exits 1, so the supervisor restarts cleanly (Docker's `restart: unless-stopped` on the forge deployment); `unhandledRejection` logs and continues rather than crashing the shared process silently.
-- **Graceful-degradation warnings** — the reranker fallback and the Ollama/LLM expand + summarize fallbacks emit one throttled stderr line each when they silently degrade quality (reranker unavailable, LLM backend unreachable).
-- **Version is single-sourced** from `package.json` at runtime (`src/version.ts`) — the `McpServer` version, OTel tracer/meter version, and outbound `USER_AGENT` all track it, so they can't drift independently.
-
-### Observability (opt-in)
-
-Tracing, metrics, and event publishing are entirely opt-in — with none of the env vars below set, the server has zero observability overhead and never loads the OpenTelemetry or NATS packages at runtime.
-
-**OpenTelemetry (traces + metrics)** — set `OTEL_EXPORTER_OTLP_ENDPOINT` to your collector's HTTP endpoint and the server emits:
-
-- Spans (per request): `tool.<name>` → `expand_query`? → `searxng_request` → `rerank` → `fetch` (×N) → `tier1_firecrawl` | `tier2_crawl4ai` | `tier3_rawfetch` | `solver_byparr` → `post_extract`; plus `summarize_llm` for `search_and_summarize`.
-- Counters: `searxng_search_total{profile, expand}`, `searxng_fetch_total{tier, outcome}`, `searxng_cache_total{namespace, outcome}`, `searxng_errors_total{stage, error_type}`.
-- Histograms: `searxng_search_duration_seconds{profile}`, `searxng_fetch_duration_seconds{tier, outcome}`.
-
-Standard OTEL env vars apply (`OTEL_SERVICE_NAME` defaults to `searxng-mcp`).
-
-**NATS events** — set `NATS_URL` (e.g. `nats://localhost:4222`) and the server publishes a structured event on every search, fetch, cache hit/miss, robots skip, and error. Authenticates via `NATS_CREDS` (a JWT creds file) or `NATS_USER`/`NATS_PASSWORD` (bcrypt username/password) — creds-file auth wins if both are set. Subjects:
-
-| Subject | When |
-|---------|------|
-| `searxng.search.requested` | Search tool invoked |
-| `searxng.search.completed` | Search returned (with sources, latency, rerank applied) |
-| `searxng.fetch.requested` | `fetchPage` called |
-| `searxng.fetch.tier.miss` | A tier returned empty or threw |
-| `searxng.fetch.tier.skipped` | robots.txt disallowed |
-| `searxng.fetch.completed` | Fetch resolved (with `tier_served`, `text_len`, latency) |
-| `searxng.cache.hit` / `.miss` | On every Valkey lookup |
-| `searxng.error` | Stage-tagged errors |
-
-Each envelope includes `request_id` and (when OTel is enabled) `trace_id` so subscribers can join the two streams. Subject prefix overridable via `NATS_SUBJECT_PREFIX`. Search queries flow through `search.*` events — downstream consumers are responsible for any PII scrubbing.
-
-### Politeness
-
-- **Honest User-Agent** — outbound requests identify as `searxng-mcp/<version> (+https://github.com/TadMSTR/searxng-mcp; personal research)`.
-- **robots.txt compliance** — `/robots.txt` is fetched once per origin and cached for 24 hours in Valkey under `robots:<origin>`. Disallowed paths are skipped before any tier runs and logged as `skipped_robots url=… reason=…`.
-
-## Transport
-
-**stdio** (default) — compatible with Claude Code MCP plugin and LibreChat `stdio` config.
-
-**HTTP** — set `SEARXNG_MCP_TRANSPORT=http` to run as a shared HTTP/SSE server suitable for multi-client deployments or Docker-based setups. Binds to `SEARXNG_MCP_HOST:SEARXNG_MCP_PORT` (default `127.0.0.1:3001`):
-
-```bash
-SEARXNG_MCP_TRANSPORT=http SEARXNG_MCP_PORT=3001 npx @tadmstr/searxng-mcp
-```
-
-Register with Claude Code against an HTTP server:
-
-```bash
-claude mcp add-json searxng --scope user '{
-  "type": "http",
-  "url": "http://localhost:3001/mcp"
-}'
-```
-
-Sessions are keyed by the `Mcp-Session-Id` header, so multiple clients can connect to the same shared process concurrently. Idle sessions are swept after `HTTP_SESSION_IDLE_TIMEOUT_MS` and hard-capped at `HTTP_MAX_SESSIONS` — see [Configuration](#configuration).
-
-### HTTP transport authentication
-
-The HTTP transport is **unauthenticated by default**, which is safe only because it binds `127.0.0.1` by default. If you change `SEARXNG_MCP_HOST` to anything else — including `0.0.0.0`, which is what running in a container requires — set `SEARXNG_MCP_AUTH_TOKEN` as well:
-
-```bash
-SEARXNG_MCP_AUTH_TOKEN=$(openssl rand -hex 32)
-```
-
-When it is set, every request except `GET /health` must carry the token as an [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750) bearer credential:
-
-```
-Authorization: Bearer <token>
-```
-
-Anything else — no header, a different scheme, a wrong token — gets `401` with `WWW-Authenticate: Bearer` and a JSON-RPC error body. The response is identical in all three cases and never echoes the presented credential. Tokens are compared as SHA-256 digests, so the comparison is constant-time and leaks no length information.
-
-Registering an authenticated server with Claude Code:
-
-```bash
-claude mcp add-json searxng --scope user '{
-  "type": "http",
-  "url": "http://localhost:3001/mcp",
-  "headers": {"Authorization": "Bearer <token>"}
-}'
-```
-
-Leaving the variable unset preserves the previous behaviour exactly, so stdio users and existing loopback-bound HTTP deployments need no change. There is no per-caller authorization model — a single token authenticates *access to the server*, not a particular client identity. On startup, a non-loopback bind with no token logs a warning.
-
-**`GET /health` is deliberately exempt** from the check. It is the container healthcheck and the monitoring liveness probe, it takes no input, and its response (`status`, `cache`, `sessions`) carries no secrets.
-
-**`GET /health`** — unauthenticated liveness probe, localhost-bound alongside the MCP endpoint. Pings Valkey through the bounded cache command timeout (so the check itself can never hang) and returns:
-
-```json
-{"status": "ok", "cache": "up", "sessions": 3}
-```
-
-or, when the cache backend is unreachable:
-
-```json
-{"status": "degraded", "cache": "degraded", "sessions": 3}
-```
-
-`sessions` is the live HTTP session count. Useful for sysadmin monitoring to detect a degraded cache from the MCP side without instrumenting the cache backend directly.
-
-## Prerequisites
-
-**Runtime:** Node.js 20+, and pnpm (or npm).
-
-### Required
-
-- A running [SearXNG](https://github.com/searxng/searxng) instance, with JSON output enabled (see below).
-
-That is the whole list. Everything under it is progressive enhancement.
-
-### Strongly recommended
-
-| Service | What it buys you |
-|---------|------------------|
-| [Valkey](https://valkey.io/), Dragonfly or any Redis-compatible cache | Repeat searches and fetches are served from cache instead of re-run. The single largest latency win. Fail-soft: a cache timeout serves live. |
-| A reranker with a Jina-compatible `/v1/rerank` endpoint | Reorders results by semantic relevance to the query. Without it results keep SearXNG's own ordering and a throttled degradation line is logged. |
-
-Neither has a kill switch — both have a default URL and are always attempted, because both fail
-soft. Absence costs quality and latency, never correctness.
-
-### Optional
-
-| Service | Capability it unlocks | Turn it on with |
-|---------|----------------------|-----------------|
-| [Firecrawl](https://github.com/mendableai/firecrawl) | Fetch tier 1 — Puppeteer-rendered pages, best extraction quality on JS-heavy sites | On by default; `FIRECRAWL_URL`, or `FIRECRAWL_ENABLED=false` to skip the tier |
-| [Crawl4AI](https://github.com/unclecode/crawl4ai) | Fetch tier 2 — browser automation fallback when tier 1 returns empty content | `CRAWL4AI_URL` |
-| [Ollama](https://ollama.com/) with `qwen3:4b` and/or `qwen3:14b`, or any OpenAI-compatible endpoint | Query expansion and LLM-synthesized summaries (`search_and_summarize`) | `OLLAMA_URL` or `LLM_BASE_URL` |
-| [kiwix-serve](https://github.com/kiwix/kiwix-tools) | Offline serving of Wikipedia, Stack Overflow and the Arch Wiki from local ZIM archives | `KIWIX_URL` |
-| Hister | Archived-page fallback from a private archive | `HISTER_URL` |
-| [Byparr](https://github.com/ThePhaseless/Byparr) or FlareSolverr | Solves Cloudflare-style interstitials on the domains that serve them | `SOLVER_URL` + `SOLVER_ENABLED=true` |
-| Wayback Machine | Tier-4 fallback to an archived snapshot when all three tiers fail | `WAYBACK_ENABLED=true` |
-| An OTLP collector / NATS | Traces and metrics; a JetStream event stream of every search and fetch | `OTEL_EXPORTER_OTLP_ENDPOINT` / `NATS_URL` |
-
-On startup the server logs one line naming exactly which of these are configured, so a
-lower-quality result set can be traced to a missing service rather than guessed at:
-
-```
-[searxng-mcp] capabilities on=tier3,cache,reranker off=tier1,tier2,llm,kiwix,hister,solver,wayback,otel,nats
-```
-
-It reports configuration, not reachability — nothing is probed, so the line never delays startup.
-
-The rest of this section is setup reference for whichever of the above you chose to deploy —
-skip any you did not.
-
-### SearXNG
-
-SearXNG must have JSON output format enabled. In `settings.yml`:
-
-```yaml
-search:
-  formats:
-    - html
-    - json
-```
-
-### Reranker (recommended)
-
-The reranker must expose a Jina-compatible `/v1/rerank` endpoint. A lightweight FlashRank wrapper works well — see the [`docker/reranker/`](https://github.com/TadMSTR/homelab-agent/tree/main/docker/reranker) reference in [homelab-agent](https://github.com/TadMSTR/homelab-agent).
-
-### Firecrawl (optional — fetch tier 1)
-
-Any Firecrawl-compatible instance works. The local [firecrawl-simple](https://github.com/mendableai/firecrawl/tree/main/apps/api) deployment is sufficient. Set `FIRECRAWL_API_KEY` if your instance requires authentication (defaults to `placeholder-local` for local deployments that skip auth).
-
-#### Firecrawl API version
-
-`FIRECRAWL_API_VERSION` selects which API the client speaks — `v1` (default) or `v2`. The two
-are not interchangeable and no backend serves both:
-
-| Backend | Version | Notes |
-|---|---|---|
-| [firecrawl-simple](https://github.com/devflowinc/firecrawl-simple) | `v1` | Serves `/v1/scrape` and `/v1/crawl` only. No `/map`. |
-| [Upstream Firecrawl 2.x](https://github.com/firecrawl/firecrawl) | `v2` | Serves `/v2/scrape`, `/v2/crawl` and `/v2/map`. |
-
-An unrecognised value fails at startup rather than falling back. That is deliberate: a wrong
-version prefix produces a 404 that `crawl_site` would swallow into its sitemap fallback, and a
-wholly dead code path returning healthy-looking manifests is exactly how the `/v2`-against-`v1`
-mismatch survived unnoticed for the life of the feature.
-
-**Capability boundary under `v2` self-hosting.** Upstream Firecrawl implements page `actions`,
-screenshots and the stealth proxy in **Fire-engine**, which is closed-source and cloud-only.
-Every engine a self-hosted deployment can reach (`fetch`, `playwright`, `pdf`, `document`)
-reports `actions: false`, and a scrape carrying an `actions` array is rejected outright with
-HTTP 400 `SCRAPE_ACTIONS_NOT_SUPPORTED` — the whole request fails, it does not degrade.
-
-The practical consequence is one **semantic downgrade**:
-
-| Tuning parameter | Under `v1` | Under `v2` |
-|---|---|---|
-| `target_selector` | `includeTags` | `includeTags` — unchanged |
-| `wait_for_selector` | a real wait action on the selector | `waitFor`, a **fixed delay** of `FIRECRAWL_WAIT_FOR_MS` |
-
-Under `v2`, `wait_for_selector` waits on *time*, not on the selector. The page may still be
-unsettled when the delay elapses, and the delay is paid in full even when the selector was
-already present. If that matters for a given site, tier 2 (Crawl4AI) does support real
-selector waits and the cascade will reach it when tier 1 returns nothing useful.
-
-The LLM-backed scrape formats (`json`, `summary`, `query`, `highlights`) are also unavailable
-on a self-hosted deployment without an LLM endpoint configured on the backend; searxng-mcp
-does not request them.
-
-### Crawl4AI (optional — fetch tier 2)
-
-[Crawl4AI](https://github.com/unclecode/crawl4ai) is an optional second-tier fetch fallback used when Firecrawl returns empty content (bot-blocked pages, JS-heavy sites). Set `CRAWL4AI_URL` to enable it. If unset, the cascade skips to raw HTTP fetch.
-
-```bash
-docker run -d -p 11235:11235 unclecode/crawl4ai:0.8.6
-```
-
-If your instance requires API token authentication, set `CRAWL4AI_API_TOKEN`.
-
-On the `search_and_summarize` path, Crawl4AI requests use `fit_markdown` for noise-filtered content extraction. Other callers (`search_and_fetch`, `fetch_url`) use `raw_markdown`.
-
-### Kiwix (optional)
-
-[kiwix-serve](https://github.com/kiwix/kiwix-tools) serves ZIM archives over HTTP. Download
-the required ZIM files and run kiwix-serve with `--nodatealiases` (`-z`) so book names are
-stable:
-
-```bash
-kiwix-serve --port 8292 --nodatealiases /path/to/zims/
-```
-
-Required ZIM files for each supported host:
-- Wikipedia: `wikipedia_en_all_mini` (or `maxi`)
-- Stack Overflow: `stackoverflow.com_en_all`
-- Arch Wiki: `archlinux_en_all_maxi`
-
-ZIM files can be downloaded from [library.kiwix.org](https://library.kiwix.org/).
-
-### Hister (optional)
-
-[Hister](https://github.com/nicholasgasior/hister) is a browsing-history index populated by a Firefox extension. When `HISTER_URL` is set, `fetchPage` checks the history index before invoking the tier cascade — useful for login-walled and JS-heavy pages where scrapers fail.
-
-Set `HISTER_URL` to your Hister instance base URL and `HISTER_TOKEN` if bearer token auth is required.
-
-### Valkey / Redis
-
-Any Redis-compatible instance. Valkey is recommended. Search results are cached for 1 hour; fetched pages for 24 hours. If unavailable, the server operates without caching.
-
-### Ollama
-
-Required for `expand` and `search_and_summarize`. Pull the required models:
-
-```bash
-ollama pull qwen3:4b   # query expansion
-ollama pull qwen3:14b  # summarization
-```
-
-Set `think: false` behavior is handled automatically — no extra Ollama configuration needed.
-
-## Configuration
-
-All service URLs are configurable via environment variables.
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SEARXNG_URL` | `http://localhost:8081` | SearXNG instance URL. Accepts a **list** of interchangeable replicas separated by `,` or `;` (e.g. `http://searxng-a:8080,http://searxng-b:8080`) — tried in order, with failover. A single value behaves exactly as before: one request, one host, no health lookup. Entries that are not valid http(s) URLs are dropped with a warning; if none survive the default is used rather than the server refusing to start. Basic-auth credentials may be embedded (`http://user:pass@host:8080`) — they are lifted out of the URL at startup and sent as an `Authorization: Basic` header, and never appear in logs, events, cache keys or error messages. |
-| `SEARXNG_TOTAL_TIMEOUT_MS` | `10000` | Total timeout budget for one search **across all instances**, not per instance. Iterating N replicas at the per-attempt timeout each would make a total outage take longer to report the more replicas you add. |
-| `SEARXNG_ATTEMPT_TIMEOUT_MS` | `10000` | Per-instance ceiling, further capped by whatever remains of `SEARXNG_TOTAL_TIMEOUT_MS`. |
-| `SEARXNG_UNHEALTHY_TTL_SECONDS` | `30` | How long a failed instance is deprioritised for. A hint that reorders candidates, not a circuit breaker — an unhealthy instance is moved to the back, never removed, and if every instance is marked down the full list is still tried. Stored in the cache so the hint is shared across processes; a cache outage degrades to "try every instance in configured order". |
-| `FIRECRAWL_URL` | `http://localhost:3002` | Firecrawl instance URL |
-| `FIRECRAWL_API_VERSION` | `v1` | Which Firecrawl API to speak — `v1` or `v2`. Any other value **fails at startup** rather than silently constructing a URL that 404s. See [Firecrawl API version](#firecrawl-api-version). |
-| `FIRECRAWL_WAIT_FOR_MS` | `2000` | Under `v2` only: how long a scrape waits for the page to settle when `wait_for_selector` is requested. v2 has no selector-based wait — see the capability boundary below. |
-| `FIRECRAWL_ENABLED` | `true` | Set to `false` when no Firecrawl is deployed — tier 1 is then skipped with `reason: not_configured` instead of attempting a connection on every fetch |
-| `RERANKER_URL` | `http://localhost:8787` | Reranker instance URL |
-| `FIRECRAWL_API_KEY` | `placeholder-local` | Firecrawl API key (if required) |
-| `GITHUB_TOKEN` | *(unset)* | GitHub personal access token — increases rate limit from 60 to 5,000 req/hour |
-| `OLLAMA_URL` | *(unset)* | Ollama API base URL — required for `expand` and `search_and_summarize` |
-| `OLLAMA_API_KEY` | *(unset)* | Bearer token for authenticated Ollama proxies — adds `Authorization: Bearer <key>` header when set |
-| `OLLAMA_EXPAND_MODEL` | `qwen3:4b` | Model used by query expansion (`expand` parameter). Override without rebuilding. |
-| `OLLAMA_SUMMARIZE_MODEL` | `qwen3:14b` | Model used by `search_and_summarize`. Override without rebuilding. |
-| `LLM_BASE_URL` | *(unset)* | OpenAI-compatible chat endpoint (e.g. vLLM, llama.cpp, LM Studio) for `expand` + `search_and_summarize`. Must include the API path — e.g. `http://host:8000/v1` — the server appends `/chat/completions`. When set, takes precedence over `OLLAMA_URL`, so an already-loaded model can be reused instead of running a separate Ollama model. |
-| `LLM_MODEL` | *(unset)* | Model id for the OpenAI-compatible backend; overrides `OLLAMA_EXPAND_MODEL` / `OLLAMA_SUMMARIZE_MODEL` when set. |
-| `LLM_API_KEY` | *(unset)* | Bearer token for the OpenAI-compatible backend — adds `Authorization: Bearer <key>` when set. |
-| `LLM_DISABLE_THINKING` | `true` | Sends `chat_template_kwargs.enable_thinking: false` so reasoning models (e.g. Qwen3) return direct output. Set to `false` for servers that reject that field. |
-| `CACHE_URL` | `redis://localhost:6381` | Redis-compatible URL — enables result caching. Also accepts `VALKEY_URL` or `REDIS_URL` as aliases. Works with Redis, Valkey, and Dragonfly. Server degrades gracefully if unavailable. |
-| `CACHE_COMMAND_TIMEOUT_MS` | `2500` | Valkey command timeout — a stalled/CPU-spiked cache backend rejects instead of hanging (`cacheGet()` is the first `await` in every search). Invalid/non-positive values fall back to the default rather than becoming a NaN that would disable the timeout. |
-| `CACHE_CONNECT_TIMEOUT_MS` | `3000` | Valkey connection timeout. Same fallback behavior as `CACHE_COMMAND_TIMEOUT_MS`. |
-| `CACHE_MAX_RETRIES_PER_REQUEST` | `2` | Max retries per Valkey command before it rejects. Same fallback behavior as `CACHE_COMMAND_TIMEOUT_MS`. |
-| `CACHE_TTL_SECONDS` | `3600` | Search result cache TTL in seconds |
-| `FETCH_CACHE_TTL_SECONDS` | `86400` | Fetched page cache TTL in seconds |
-| `CRAWL_MANIFEST_TTL_SECONDS` | `21600` | Crawl manifest and page content cache TTL in seconds (6 hours) |
-| `CRAWL_MAX_PAGES_DEFAULT` | `20` | Default max pages returned by `crawl_site` when no `max_pages` is passed |
-| `CRAWL_BFS_ENABLED` | `false` | Set to `true` to enable BFS fallback in `crawl_site` globally. Can also be enabled per-call with the `bfs` parameter. |
-| `CRAWL_BFS_MAX_DEPTH` | `3` | Maximum link-hop depth for BFS crawl |
-| `FIRECRAWL_CRAWL_POLL_INTERVAL_MS` | `2000` | Polling interval when waiting for a Firecrawl crawl job to complete |
-| `FIRECRAWL_CRAWL_MAX_WAIT_MS` | `120000` | Maximum time to wait for a Firecrawl crawl job before falling back to sitemap |
-| `EXPAND_QUERIES` | `false` | Set to `true` to enable query expansion globally |
-| `CRAWL4AI_URL` | *(unset)* | Crawl4AI instance URL — enables second-tier fetch fallback when Firecrawl fails |
-| `CRAWL4AI_ENABLED` | `true` | Set to `false` to skip tier 2 regardless of `CRAWL4AI_URL`. Tier 2 is also skipped when `CRAWL4AI_URL` is unset |
-| `CRAWL4AI_API_TOKEN` | *(unset)* | Optional Bearer token for Crawl4AI instances with API token protection |
-| `WAYBACK_ENABLED` | `false` | Set to `true` to enable Wayback Machine tier-4 fallback — fetches archived snapshots when all three tiers fail |
-| `SOLVER_URL` | *(unset)* | Base URL of a Byparr (or other FlareSolverr `POST /v1`-compatible) challenge-solving service, e.g. `http://byparr:8191`. Unset leaves the tier inert regardless of `SOLVER_ENABLED`. |
-| `SOLVER_ENABLED` | `false` | Kill switch for the challenge-solving tier — mirrors `WAYBACK_ENABLED`. Requires `SOLVER_URL` to also be set; fires only when a challenge was actually detected on the current request, never on an unchallenged URL. |
-| `SOLVER_MAX_TIMEOUT_MS` | `60000` | Per-request ceiling passed to the solver as `maxTimeout`. |
-| `ADBLOCK_PROXY_URL` | *(unset)* | HTTP proxy URL for tier-2 (Crawl4AI) and tier-3 (raw Node fetch) adblocking — e.g. `http://adblock-proxy:8118`. See `docker/adblock-proxy/`. |
-| `KIWIX_URL` | *(unset)* | kiwix-serve base URL (e.g. `http://localhost:8292`) — enables Kiwix fast path for Wikipedia, Stack Overflow, and Arch Wiki. Feature is disabled and zero-overhead when unset. |
-| `HISTER_URL` | *(unset)* | Hister browsing-history index base URL — enables Hister fast path before the tier cascade for login-walled and JS-heavy pages. Feature disabled and zero-overhead when unset. |
-| `HISTER_TOKEN` | *(unset)* | Bearer token for Hister API authentication. Required when `HISTER_URL` is set and the instance has token auth enabled. |
-| `YOUTUBE_TRANSCRIPT_ENABLED` | `true` | Enables the YouTube transcript fast path in `fetch_url`. Set to `false` to disable (e.g. if the unofficial timedtext endpoint breaks upstream). |
-| `YOUTUBE_IGNORE_ROBOTS` | `false` | Opt into fetching YouTube transcripts despite YouTube's `robots.txt` disallowing `/api/`. Default respects robots (fast path stays dormant, falls through to the cascade). |
-| `REDDIT_FASTPATH_ENABLED` | `true` | Enables the Reddit `.json` fast path in `fetch_url`. Set to `false` to disable. |
-| `REDDIT_IGNORE_ROBOTS` | `false` | Opt into fetching Reddit `.json` despite Reddit's `robots.txt` (`Disallow: /`). Default respects robots (fast path stays dormant, falls through to the cascade). |
-| `SEARXNG_MCP_TRANSPORT` | `stdio` | Transport mode: `stdio` (default, single-client) or `http` (shared HTTP/SSE server). |
-| `SEARXNG_MCP_PORT` | `3001` | HTTP listen port (HTTP transport mode only). |
-| `SEARXNG_MCP_HOST` | `127.0.0.1` | HTTP listen address (HTTP transport mode only). |
-| `SEARXNG_MCP_AUTH_TOKEN` | *(unset)* | HTTP transport only. When set, every request except `GET /health` must send `Authorization: Bearer <token>` or get a `401`. Unset (the default) disables the check entirely. **Set this whenever `SEARXNG_MCP_HOST` is not loopback** — see [HTTP transport authentication](#http-transport-authentication). |
-| `HTTP_SESSION_IDLE_TIMEOUT_MS` | `600000` | HTTP transport only. A session idle longer than this is evicted by a background sweep (sessions with an in-flight request are exempt, so a long `crawl_site` call is never closed mid-request). Bounds session-map growth from clients killed mid-turn, which never fire `transport.onclose`. |
-| `HTTP_MAX_SESSIONS` | `256` | HTTP transport only. Hard-cap backstop — if the session map ever exceeds this, the least-recently-used idle session is evicted regardless of the idle timeout. |
-| `HTTP_MAX_BODY_BYTES` | `1048576` | HTTP transport only. Maximum request body read on the pre-session `initialize` path; a larger body gets `413` and the read stops at the limit rather than buffering to completion first. Requests carrying an `Mcp-Session-Id` are read by the MCP SDK's own transport and are not covered by this — see [Bounded reads](#bounded-reads). |
-| `NATS_USER` | *(unset)* | NATS username for bcrypt username/password auth, used alongside `NATS_PASSWORD`. Ignored if `NATS_CREDS` is also set (creds-file JWT auth wins). |
-| `NATS_PASSWORD` | *(unset)* | NATS password — see `NATS_USER`. |
-
-## Install
-
-### npm (recommended)
-
-```bash
-npm install -g @tadmstr/searxng-mcp
-```
-
-Or run directly with `npx`:
-
-```bash
-npx @tadmstr/searxng-mcp
-```
-
-### From source
-
-```bash
-git clone https://github.com/TadMSTR/searxng-mcp.git
-cd searxng-mcp
-pnpm install
-pnpm build
-```
-
-Output: `build/src/index.js`
-
-## MCP Client Configuration
-
-### Claude Code (CLI)
-
-The recommended approach uses `claude mcp add-json` to register the server with full env var support:
-
-```bash
-claude mcp add-json searxng --scope user '{
-  "command": "npx",
-  "args": ["-y", "@tadmstr/searxng-mcp"],
-  "env": {
-    "SEARXNG_URL": "http://localhost:8081",
-    "FIRECRAWL_URL": "http://localhost:3002",
-    "RERANKER_URL": "http://localhost:8787",
-    "OLLAMA_URL": "http://localhost:11434",
-    "CACHE_URL": "redis://localhost:6379",
-    "CACHE_TTL_SECONDS": "3600",
-    "FETCH_CACHE_TTL_SECONDS": "86400",
-    "EXPAND_QUERIES": "false",
-    "CRAWL4AI_URL": "http://localhost:11235"
-  }
-}'
-```
-
-This writes to `~/.claude.json`. Do not add searxng to `~/.claude/settings.json` — that file is not used for MCP env var injection in Claude Code.
-
-### Claude Desktop (`claude_desktop_config.json`)
-
-```json
-{
-  "mcpServers": {
-    "searxng": {
-      "command": "npx",
-      "args": ["-y", "@tadmstr/searxng-mcp"],
-      "env": {
-        "SEARXNG_URL": "http://localhost:8081",
-        "FIRECRAWL_URL": "http://localhost:3002",
-        "RERANKER_URL": "http://localhost:8787",
-        "OLLAMA_URL": "http://localhost:11434",
-        "CACHE_URL": "redis://localhost:6379",
-        "CRAWL4AI_URL": "http://localhost:11235"
-      }
-    }
-  }
-}
-```
-
-### LibreChat (`librechat.yaml`)
-
-```yaml
-mcpServers:
-  searxng:
-    type: stdio
-    command: node
-    args:
-      - /path/to/searxng-mcp/build/src/index.js
-    env:
-      SEARXNG_URL: http://localhost:8081
-      FIRECRAWL_URL: http://localhost:3002
-      RERANKER_URL: http://localhost:8787
-      OLLAMA_URL: http://localhost:11434
-      CACHE_URL: redis://localhost:6379
-      CRAWL4AI_URL: http://localhost:11235
-```
-
-## GitHub URLs
-
-GitHub URLs are handled natively without Firecrawl. `githubFetch` dispatches on hostname:
-
-- **Repo root** (`github.com/owner/repo`) — fetches the README via the GitHub API
-- **File blob** (`github.com/owner/repo/blob/branch/path/to/file`) — rewrites to and fetches raw content from `raw.githubusercontent.com`
-- **Raw file** (`raw.githubusercontent.com/...`) — fetched directly as-is
-- **API** (`api.github.com/...`) — response decoded (base64 `content` fields) or pretty-printed as JSON
-
-Direct `raw.githubusercontent.com` and `api.github.com` URLs previously matched only `github.com` and fell through to the HTML-scraping tier cascade, which cannot render a raw text file or bare JSON response — they failed 100% of the time. They now take the GitHub fast path.
-
-Unauthenticated requests are rate-limited to 60/hour. Set `GITHUB_TOKEN` to raise this to 5,000/hour.
-
-## Security
-
-### URL safety (SSRF)
-
-Every outbound fetch to a caller-influenced or discovered URL — the raw-HTTP tier, robots.txt / llms.txt / Wayback / sitemap probes, the BFS crawl link-fetch, and the GitHub fast path — is guarded two ways:
-
-1. **String check** (`assertPublicUrl`) — rejects non-HTTP(S) URLs and private/internal IP *literals*: RFC1918 (`10.x`, `192.168.x`, `172.16–31.x`), loopback (`127.x`, `::1`), link-local / cloud metadata (`169.254.x`), CGNAT (`100.64/10`), IPv6 ULA (`fc00::/7`) and link-local (`fe80::/10`), IPv4-mapped, and multicast/reserved ranges.
-2. **Connect-time DNS validation** — a shared undici dispatcher whose `connect.lookup` validates the *resolved* address (the exact one the socket connects to). This closes the DNS-rebinding / TOCTOU gap where a public hostname resolves to a private address, and it re-runs on **every redirect hop**, so a redirect chain cannot bounce into your internal network.
-
-Firecrawl (tier1) and Crawl4AI (tier2) resolve and fetch the target URL themselves, so the connect-time dispatcher above can't cover them. `fetchPage` and `crawlSite` call `assertResolvedPublic(url)` — a one-time hostname resolution rejecting any private/reserved result — immediately before dispatching to either service, closing the common DNS-rebinding case on that path (narrower TOCTOU window than the connect-time guard, since the service re-resolves).
-
-Configured internal services (Firecrawl, Crawl4AI, SearXNG, Ollama, Reranker) are reached by their own URLs and are intentionally not guarded.
-
-### Redirect protection
-
-The raw-HTTP and GitHub fast-path fetches additionally use `redirect: "manual"` and reject 3xx responses outright (the `Location` header is never echoed back to the caller). Redirect-following probes (robots.txt, llms.txt, sitemap) are covered by the connect-time DNS validation above, which re-checks each hop.
-
-### Transport exposure
-
-stdio has no network surface. The HTTP transport binds `127.0.0.1` by default and is unauthenticated in that configuration; moving it off loopback without setting `SEARXNG_MCP_AUTH_TOKEN` exposes every tool — including arbitrary-URL `fetch_url` and destructive `clear_cache` — to anything that can route to the port. See [HTTP transport authentication](#http-transport-authentication).
-
-### Bounded reads
-
-Every response body read from a third party, and the one request body this server reads itself, stops at a byte limit and cancels the rest of the stream rather than buffering the whole thing and checking its size afterwards. A post-hoc size check has already paid the memory cost it is trying to avoid.
-
-| Read | Limit | Notes |
-|---|---|---|
-| Fetch tiers (raw, Firecrawl, Crawl4AI, solver, Wayback, Reddit, YouTube, GitHub, sitemap/crawl) | `RAW_HTML_MAX_BYTES` (2 MB) | Shared `readBoundedText` helper. |
-| `llms-full.txt` probe | `MAX_SIZE_BYTES` (64 MB) | Read one byte past the ceiling so an oversized document is still *detected* as oversized and reported absent, rather than truncated to the limit and served as if complete. |
-| HTTP transport request body | `HTTP_MAX_BODY_BYTES` (1 MB) | `initialize` path only; `413` on exceeding. |
-
-The bound is on **bytes retained**, not bytes transferred. Cancellation is not instantaneous — socket buffers and in-flight data mean a peer can still push some way past the cap — so this hard-bounds memory and only reduces transfer (measured roughly 10x against a 40 MB stub).
-
-**One limitation, out of this server's control:** requests carrying an `Mcp-Session-Id` are handled by the MCP SDK's `StreamableHTTPServerTransport.handleRequest()`, which reads its own request body. That read is not bounded by anything here. It is reachable only by a caller that has already authenticated and established a session.
-
-Reads from first-party services configured by the operator — SearXNG and Ollama — are deliberately left unbounded. They are not attacker-influenced, and bounding them would add ceremony without changing a threat.
-
-### Dependency auditing
-
-CI runs `pnpm audit` on every push. The lockfile (`pnpm-lock.yaml`) is committed for reproducible, auditable builds.
-
-### Credential handling
-
-Basic-auth credentials embedded in `SEARXNG_URL` are extracted at startup and sent as an `Authorization` header; the URL used for the request, for cache keys, for log lines, for NATS events and for error messages is always the credential-free origin. This matters more than it looks: Node's `fetch` refuses a URL containing userinfo outright and puts the whole URL — password included — into the resulting `TypeError`'s message, so leaving credentials in the URL would both break every request and leak the password into any sink that forwards an error message.
-
-No credentials are stored or logged by the server. API keys (`FIRECRAWL_API_KEY`, `GITHUB_TOKEN`, `CRAWL4AI_API_TOKEN`) are read from environment variables and used only in outbound requests to their respective services.
-
-### Input validation
-
-Environment variables are validated at startup — `RERANK_RECENCY_WEIGHT` warns on NaN, negative, or >1.0 values. Numeric tool parameters use `z.coerce.number()` with range constraints.
+| [Configuration](docs/configuration.md) | Every environment variable, and setup for each optional backing service. |
+| [Tools](docs/tools.md) | Full per-tool parameter reference. |
+| [Deployment](docs/deployment.md) | Install, transports, HTTP auth, and MCP client recipes. |
+| [Architecture](docs/architecture.md) | Fetch cascade, tier semantics, domain capability database. |
+| [Security](docs/security.md) | SSRF, redirects, transport exposure, bounded reads, credentials. |
+
+Index: [`docs/index.md`](docs/index.md).
 
 ## Contributing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,374 @@
+<!-- Split out of README.md in v3.24.0 (vikunja#683). The README had reached 905 lines / 70KB, at which point it was a reference manual pretending to be an introduction. -->
+
+# Architecture
+
+```
+MCP client (stdio)
+      │
+      ▼
+  searxng-mcp ──────────────→ cache ($CACHE_URL)           → result cache (search 1h, fetch 24h, crawl 6h)
+      │
+      ├── expand (optional) →  Ollama ($OLLAMA_URL)        → rewritten query (qwen3:4b)
+      ├── search ───────────→ SearXNG ($SEARXNG_URL)      → raw results
+      ├── rerank ───────────→ Reranker ($RERANKER_URL)    → ranked results
+      │                       (fallback: SearXNG order if reranker unavailable)
+      ├── fetch content ────┬→ GitHub API (github.com)    → markdown
+      │                     ├→ Kiwix ($KIWIX_URL)         → ZIM content (Wikipedia/SO/Arch Wiki, fast path)
+      │                     ├→ Hister ($HISTER_URL)       → browsing-history index (login-walled/JS-heavy fast path)
+      │                     ├→ Firecrawl ($FIRECRAWL_URL) → page markdown (tier 1)
+      │                     ├→ Crawl4AI ($CRAWL4AI_URL)  → page markdown (tier 2, optional; via $ADBLOCK_PROXY_URL if set)
+      │                     ├→ Raw HTTP + Readability     → page markdown (tier 3 fallback; via $ADBLOCK_PROXY_URL if set)
+      │                     ├→ Byparr solver (opt-in)     → challenge-solved page markdown (only on a detected challenge, $SOLVER_ENABLED)
+      │                     └→ Wayback Machine (opt-in)  → archived page markdown (tier 4, $WAYBACK_ENABLED)
+      ├── crawl_site ───────┬→ Firecrawl crawl           → page manifest (phase 1)
+      │                     ├→ Sitemap parsing           → page manifest (phase 2 fallback, fast-xml-parser)
+      │                     └→ BFS crawl (opt-in)        → page manifest (phase 3, $CRAWL_BFS_ENABLED)
+      └── summarize (opt.) →  Ollama ($OLLAMA_URL)        → synthesized summary ($OLLAMA_SUMMARIZE_MODEL)
+```
+
+```mermaid
+flowchart TD
+    entry["fetchPage(url)"]
+    cache{"Valkey cache hit?"}
+    cached["→ return cached { title, url, text }"]
+    github{"GitHub host?\ngithub.com · raw · api"}
+    gh_fetch["GitHub API / raw.githubusercontent.com / api.github.com\n→ return"]
+    llms{"llms.txt domain?"}
+    llms_fetch["Probe /llms-full.txt\nextract matching section\n→ return"]
+    kiwix{"Kiwix host?\nKIWIX_URL set"}
+    kiwix_fetch["Local Kiwix ZIM\nWikipedia · Stack Overflow · Arch Wiki\n→ cache + return"]
+    robots["robots.txt pre-check — tiers 1–3\ndisallowed → RobotsDisallowedError (cached 24h)"]
+    tier_skip(["Per-domain tier skip\nsuccess rate &lt;30% over ≥10 tries\nor tier_skip operator override"])
+    t1["Tier 1 — Firecrawl\n$FIRECRAWL_URL\nserves PDFs under FIRECRAWL_API_VERSION=v2"]
+    t2["Tier 2 — Crawl4AI\n$CRAWL4AI_URL · optional\nadblock proxy if $ADBLOCK_PROXY_URL"]
+    t3["Tier 3 — Raw HTTP + Readability\nfallback: raw HTML slice\nadblock proxy if $ADBLOCK_PROXY_URL"]
+    challenge(["Challenge detected\non this URL, this request?"])
+    solver["Solver — Byparr\n$SOLVER_URL · opt-in, SOLVER_ENABLED=true\nSSRF-guarded replay"]
+    t4["Tier 4 — Wayback Machine CDX API\narchived snapshot · WAYBACK_ENABLED=true"]
+    post["Post-extraction\nJSON-LD Article · title cascade\nog:title → twitter:title → title → h1 → URL"]
+    result["→ return { title, url, text }"]
+
+    entry --> cache
+    cache -->|hit| cached
+    cache -->|miss| github
+    github -->|yes| gh_fetch
+    github -->|no| llms
+    llms -->|yes| llms_fetch
+    llms -->|no| kiwix
+    kiwix -->|yes| kiwix_fetch
+    kiwix -->|no| robots
+    robots --> tier_skip
+    tier_skip --> t1
+    t1 -->|success| post
+    t1 -->|"empty / error"| t2
+    t2 -->|success| post
+    t2 -->|"empty / error"| t3
+    t3 -->|success| post
+    t3 -->|"empty / error"| challenge
+    challenge -->|"yes, SOLVER_ENABLED"| solver
+    challenge -->|no| t4
+    solver -->|success| post
+    solver -->|"miss / disabled"| t4
+    t4 -->|success| result
+    post --> result
+
+    style entry fill:#ffffff,stroke:#333333,color:#000000
+    style cache fill:#ffffff,stroke:#333333,color:#000000
+    style cached fill:#ffffff,stroke:#333333,color:#000000
+    style github fill:#dae8fc,stroke:#6c8ebf,color:#000000
+    style gh_fetch fill:#dae8fc,stroke:#6c8ebf,color:#000000
+    style llms fill:#dae8fc,stroke:#6c8ebf,color:#000000
+    style llms_fetch fill:#dae8fc,stroke:#6c8ebf,color:#000000
+    style kiwix fill:#fff9c4,stroke:#b8860b,color:#000000
+    style kiwix_fetch fill:#fff9c4,stroke:#b8860b,color:#000000
+    style robots fill:#ffffff,stroke:#333333,color:#000000
+    style tier_skip fill:#f5f5f5,stroke:#666666,color:#000000
+    style t1 fill:#d5e8d4,stroke:#5a8a4a,color:#000000
+    style t2 fill:#d5e8d4,stroke:#5a8a4a,color:#000000
+    style t3 fill:#d5e8d4,stroke:#5a8a4a,color:#000000
+    style challenge fill:#f5f5f5,stroke:#666666,color:#000000
+    style solver fill:#d5e8d4,stroke:#5a8a4a,color:#000000
+    style t4 fill:#f8cecc,stroke:#a03030,color:#000000
+    style post fill:#e1d5e7,stroke:#7a5a8a,color:#000000
+    style result fill:#ffffff,stroke:#333333,color:#000000
+```
+
+**Only SearXNG is required.** Every tier below it is optional: Firecrawl, Crawl4AI, Valkey, Ollama, Kiwix, the reranker, the solver and Wayback each improve a named dimension, and the server degrades gracefully when any of them is unavailable. Tier 3 is a raw HTTP fetch plus Readability running in-process, so `fetch_url` still returns extracted content with nothing else deployed. Set `FIRECRAWL_ENABLED=false` and leave `CRAWL4AI_URL` unset to say so explicitly — those tiers are then skipped with `reason: not_configured` rather than attempted and missed.
+
+## Adblocking
+
+searxng-mcp ships two adblocking sidecars, but only one of them applies to every deployment:
+
+| Sidecar | Tier | Mechanism | Applies when |
+|---------|------|-----------|--------------|
+| `docker/adblock-proxy/` | Tiers 2+3 (Crawl4AI, raw fetch) | HTTP forward proxy — filters plain-HTTP ad domains | `ADBLOCK_PROXY_URL` is set |
+| `docker/puppeteer-adblock/` | Tier 1 (Firecrawl) | CDP-level interception in the browser service | **Only** on a `v1` firecrawl-simple stack built from `docker-compose.full.yml` |
+
+### Tier 1 — Puppeteer adblock (v1 stacks only)
+
+`docker/puppeteer-adblock/` builds an image layering `@ghostery/adblocker-puppeteer` over `trieve/puppeteer-service-ts`. EasyList + EasyPrivacy are loaded at startup and refreshed every 168 hours, and the blocker is applied to every page Firecrawl creates.
+
+**It is not automatic, and it does not apply under `FIRECRAWL_API_VERSION=v2`:**
+
+- It reaches a deployment only if that deployment builds it. `docker-compose.full.yml` in this repo does; a Firecrawl stack brought up from upstream's own compose, or any stack pointing `PLAYWRIGHT_MICROSERVICE_URL` at a stock `trieve/puppeteer-service-ts` image, does not — tier 1 then has no adblocking, silently.
+- It is Puppeteer-specific. Upstream Firecrawl 2.x replaced the Puppeteer service with `apps/playwright-service-ts`, so on a `v2` backend this image is not part of the stack at all. Porting it would mean rewriting against `@ghostery/adblocker-playwright`, not rebuilding.
+
+To check rather than assume, confirm the browser container carries the hook:
+
+```bash
+docker exec <firecrawl-browser-container> ls node_modules/@ghostery
+```
+
+Env vars, read by that image only:
+
+| Var | Default | Description |
+|-----|---------|-------------|
+| `ADBLOCK_DISABLE` | _unset_ | Set to `true` to skip filter loading entirely. |
+| `ADBLOCK_FILTERS_URL` | EasyList + EasyPrivacy | Comma-separated list of filter list URLs. |
+| `ADBLOCK_REFRESH_HOURS` | `168` | Cadence at which the blocker rebuilds from the configured URLs. |
+
+The base image is pinned by SHA256 digest. To rebuild and restart it:
+
+```bash
+docker compose -f docker-compose.full.yml up -d --build firecrawl-puppeteer
+```
+
+**Per-domain bypass:** `domains.json` reserves an `adblock_skip` slot for future operator overrides. Wiring isn't implemented — it would require Firecrawl to forward a custom header through to the browser service, which isn't part of its API. Tracked as scope-creep item I.
+
+### Tier 2+3 — Adblock proxy
+
+Set `ADBLOCK_PROXY_URL` (e.g. `http://adblock-proxy:8118`) to route Crawl4AI and raw Node fetch requests through an HTTP forward proxy that filters ad and tracker requests. HTTPS CONNECT tunnels are passed through unmodified — no MITM, so filtering applies to plain-HTTP ad domains only. Where the tier-1 hook above is in play it handles HTTPS filtering for that tier; where it is not — including every `v2` deployment — nothing filters tier 1 at all.
+
+As of v3.19.0, the proxy validates the **resolved** address — not just the requested hostname string — on both its CONNECT and plain-HTTP paths before connecting, closing a DNS-rebinding gap (audit finding SSRF-10).
+
+See [`docker/adblock-proxy/`](../docker/adblock-proxy/) for the service definition, configuration options, and deployment instructions (included in `docker-compose.full.yml`).
+
+## Data-driven tier routing
+
+Before invoking the fetch cascade, searxng-mcp reads the domain's `tier_stats_30d` (see [domain capability database](#domain-capability-database)) and skips any tier with success rate below 30% over at least 10 attempts. Cold-start domains (<10 attempts) keep the default cascade. Each skip emits a `searxng.fetch.tier.skipped` NATS event and increments `searxng_fetch_total{outcome=skipped}`, both carrying the reason. Three reasons exist: `low_success_rate` (the stats rule above), `operator_override` (a `tier_skip` entry in `domains.json`), and `not_configured` (the tier's service is switched off, or has no URL). `not_configured` takes precedence over both others — an override cannot un-skip a tier there is nothing to call. Because a skipped tier is never recorded as an attempt, an unconfigured tier no longer books misses into `tier_stats_30d` meaning “not deployed” rather than “tried and failed”.
+
+**Operator override.** Add a `tier_skip` map to `domains.json` to force-skip tiers regardless of stats:
+
+```json
+{
+  "tier_skip": {
+    "example-bot-blocked.com": ["tier1"],
+    "another-site.example": ["tier1", "tier2"]
+  }
+}
+```
+
+`tier_skip` keys can be bare domains (`example.com` matches the domain and all subdomains) or domain + path prefix (`example.com/api/`). The file is hot-reloaded — no restart needed. Manual overrides emit `reason: operator_override`.
+
+## Content-type fast path
+
+A URL serving structured, non-HTML content — `application/json`, any `*+json`, XML, YAML, TOML, CSV, or `text/plain` — is detected via a `HEAD` probe and routed straight to the raw-HTTP tier instead of the full Firecrawl/Crawl4AI cascade. JSON is returned pretty-printed inside a fenced code block. Previously, asking a headless browser to render a JSON API response or CDN asset returned empty markdown, so API and CDN endpoints (`registry.npmjs.org`, `api.osv.dev`, `cdn.jsdelivr.net`, …) simply failed.
+
+Guarantees:
+- The probe is **fail-open**. An unreachable host, a server that refuses `HEAD`, or an unreadable/unparseable `Content-Type` header all fall through to the normal cascade unchanged.
+- `application/xhtml+xml` is deliberately excluded — that is markup for a browser, not structured data.
+- HTML that a server mislabels as `text/plain` is still parsed as HTML, not dumped as a raw text block.
+
+## Domain capability database
+
+Every fetch records what searxng-mcp learns about the target domain to Valkey under `domain:<hostname>` (90-day TTL, schema_version 6). Captured per record:
+
+- `tier_stats_30d.{tier1,tier2,tier3,tier4,solver,github}.{attempts, ok, fail, last_fail_reason, window_start_ms}` — fetch success rate per tier over a rolling 30-day window. The cutoff is applied at **read time**, shared by tier-routing decisions and `domain_stats` reporting, so the two cannot disagree — a domain fetched once and then left idle reports a genuinely empty window rather than stale numbers surviving until the next write. The `tier4` (Wayback Machine) slot is recorded only when `WAYBACK_ENABLED=true`; the `solver` slot (Byparr challenge-solving tier, see [Challenge detection and solver tier](#challenge-detection-and-solver-tier)) only when `SOLVER_ENABLED=true`. The `github` slot records the [GitHub fast path](tools.md#github-urls) (`raw.githubusercontent.com` / `api.github.com` / `github.com` README fetches), which bypasses the tier cascade but is still tracked here. A `schema_version` bump rebuilds existing records fresh — accumulated windows for currently-idle domains are discarded (precedented across the 1→2, 2→3, 3→4, 4→5, 5→6 bumps).
+- `capabilities.metadata_fetch.{attempts, ok, fail, last_fail_reason}` — success/failure of the metadata side-channel fetch (`fetchRawHtmlForMetadata`, used for JSON-LD/og:title sampling). Tracked separately from `tier_stats_30d` since it answers "is this domain reachable at all", not "did full-content delivery succeed".
+- `capabilities.seen_in_search.{count, last_seen_ms}` — how often the domain appears in `search` results. Written fire-and-forget by `searxSearch()` on every return path (including cache hits) with no fetch performed, so a domain can be tracked before it is ever fetched.
+- `capabilities.robots_txt.{present, fetched, allows_us}` — robots.txt presence and whether it permits us
+- `capabilities.llms_full_txt.{present, size_bytes, last_checked}` — whether the domain serves `/llms-full.txt`
+- `capabilities.json_ld_article.{sampled, present, last_sampled_at}` — whether the page carries Article-schema JSON-LD at all (Schema.org `Article`/`NewsArticle`/`BlogPosting`/`TechArticle` and subtypes like `ScholarlyArticle`/`OpinionNewsArticle`/`LiveBlogPosting`, matched by bare name or fully-qualified `https://schema.org/...` `@type`), independent of whether that schema had extractable body text — many sites publish headline/metadata JSON-LD with no `articleBody`, which is a distinct concern from [post-extraction](#fetch-quality) actually using it.
+- `capabilities.og_title.{sampled, present, last_sampled_at}` — same for `<meta property="og:title">`
+- `preferred_strategy` — currently set to `llms_full_txt` when a present probe lands; future phases will use this to skip the tier cascade
+
+Inspect a record with the bundled CLI, or query it from an agent via the `domain_stats` tool (single-domain or aggregate; see [Tools](tools.md)):
+
+```bash
+pnpm dump-domain docs.anthropic.com
+```
+
+`dump-domain` distinguishes a window that has expired from a tier that has no data at all, rather than showing both the same way.
+
+Concurrent updates for the same hostname (the tier-attempt, robots-probe, and post-extract-sample recorders that fire in parallel during one fetch) are serialized through a server-side Lua compare-and-set, paired with an in-process per-key queue that removes contention between a single process's own writers so the CAS only has to arbitrate genuinely concurrent writes across processes. Versions before v3.17.0 used a `WATCH`/`MULTI`/`EXEC` read-modify-write against a shared connection, which does not actually serialize concurrent writers — data collected before v3.17.0 was substantially incomplete as a result. Upgrading discards existing tier statistics via the schema bump; expect `domain_stats` to read near-empty immediately after upgrading and refill over the following days.
+
+### Domain-db persistence
+
+The domain-db lives only in Valkey under a 90-day TTL and 30-day rolling windows, so a cache flush or TTL expiry erases capability learning that is expensive to re-acquire. Two CLIs make it durable:
+
+```bash
+pnpm domain-db-maintenance   # SCAN all domain:* records → write a dated JSON snapshot (+ prune) and emit OTel gauges
+pnpm restore-domain-db       # re-seed the domain-db from the newest snapshot after a flush
+```
+
+- **`domain-db-maintenance`** is a standalone job — run it on a schedule via cron or a container cron sidecar, **not** as an in-process timer. (The original reason was that searxng-mcp ran as several concurrent per-agent stdio children that would each fire the timer. That is no longer true: since vikunja#149/#321 it is one shared container. The conclusion still holds for a different reason — an in-process timer ties a bounded full-keyspace `SCAN` to the lifetime of the request-serving process, whereas a standalone job can be scheduled, retried and observed on its own.) One bounded `SCAN` feeds both outputs: a durable dated snapshot and, when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, gauges (`searxng_domains_tracked`, `searxng_domains_failing`, `searxng_domain_tier_success_ratio{tier}`) force-flushed before exit.
+- **`restore-domain-db`** re-seeds only keys that are missing or whose live record is strictly staler than the snapshot (compares `last_fetch`) — it never clobbers a fresher-or-equal live record, so it is safe to run against a live, partially-populated Valkey (e.g. in a service boot sequence for automatic flush recovery).
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `DOMAIN_DB_SNAPSHOT_DIR` | `./domain-db-snapshots` | Where dated snapshots are written/read. Set to a durable path (appdata or NFS mount) in deployment. |
+| `DOMAIN_DB_SNAPSHOT_RETENTION` | `14` | How many snapshots to keep; older ones are pruned each maintenance run. |
+
+## llms.txt fast path
+
+For whitelisted documentation domains in `domains.json` (`llms_txt` array), `fetchPage` tries `<origin>/llms-full.txt` first and extracts the section matching the requested URL before invoking any tier. This avoids running puppeteer against well-instrumented docs sites and returns a clean markdown section directly. Probe outcomes and the full body are cached in Valkey (`llms:<origin>:full`, 24 h / 7 d for present/absent). Default whitelist: `docs.anthropic.com`, `docs.openai.com`, `docs.stripe.com`, `docs.crawl4ai.com`, `docs.firecrawl.dev`, `docs.cursor.com`. Extend by editing `domains.json` — the file is hot-reloaded.
+
+A document is accepted only if it is between 1 KB and 64 MB; anything outside that is treated as absent and falls through to the normal tier cascade. The upper bound is a capability boundary as much as a memory one — for reference, `docs.anthropic.com/llms-full.txt` was 40.3 MB as of 2026-09-03, so lowering it much further would drop that domain off the fast path.
+
+## Kiwix fast path
+
+When `KIWIX_URL` is set, fetch requests for known offline-capable hosts are intercepted
+before the Firecrawl/Crawl4AI cascade and served from the local [Kiwix](https://kiwix.org/)
+ZIM archive. This eliminates the 100% tier-1 failure rate for sites like Wikipedia (which
+blocks headless scrapers) and returns clean readable content with zero external network traffic.
+
+Supported hosts and ZIM books (kiwix-serve must run with `--nodatealiases` / `-z`):
+
+| Host | ZIM book |
+|------|----------|
+| `en.wikipedia.org`, `wikipedia.org` | `wikipedia_en_all_mini` |
+| `stackoverflow.com` | `stackoverflow.com_en_all` |
+| `wiki.archlinux.org` | `archlinux_en_all_maxi` |
+
+The Kiwix path runs after the llms-txt fast path and before the robots gate. If the Kiwix
+request fails or returns empty, the full tier cascade runs as normal. When `KIWIX_URL` is
+unset the feature adds zero overhead — `isKiwixHost()` returns false immediately.
+
+Set `KIWIX_URL` to your kiwix-serve base URL (e.g. `http://localhost:8292`).
+
+## YouTube & Reddit fast paths
+
+`fetch_url` recognises YouTube video URLs (`youtube.com`, `youtu.be`) and Reddit thread URLs and can serve them directly instead of scraping the rendered page:
+
+- **YouTube** — extracts the video's caption track from the watch page and returns the transcript. Enabled by `YOUTUBE_TRANSCRIPT_ENABLED` (default on).
+- **Reddit** — fetches the public `.json` view and returns the post plus top comments in the standard `{title, url, text}` shape; falls through on HTTP 429. Enabled by `REDDIT_FASTPATH_ENABLED` (default on).
+
+Both rely on **unofficial, undocumented endpoints** (YouTube's timedtext API, Reddit's `.json`) — best-effort with no SLA; either may break on an upstream change, hence the kill switches. On any miss the request falls through to the normal tier cascade (which can still get a YouTube page's title/description).
+
+**robots.txt:** both endpoints are disallowed by the sites' `robots.txt` (Reddit disallows everything; YouTube disallows `/api/`, where the transcript lives). By default these fast paths respect that and stay dormant, falling through to the cascade. On your own instance you can opt into direct fetching with `YOUTUBE_IGNORE_ROBOTS=true` / `REDDIT_IGNORE_ROBOTS=true`.
+
+## Site crawling
+
+`crawl_site` crawls an entire site and returns a manifest of URL/title/snippet for each page found. It uses a four-phase strategy cascade:
+
+1. **Firecrawl crawl** — sends a crawl job to Firecrawl (`/crawl`), polls until complete, and returns the full page list. Targets `/v1/crawl` or `/v2/crawl` per `FIRECRAWL_API_VERSION`. Controlled by `FIRECRAWL_CRAWL_POLL_INTERVAL_MS` and `FIRECRAWL_CRAWL_MAX_WAIT_MS`.
+2. **Firecrawl map** (`v2` only) — asks `/v2/map` for the site's URLs, then fetches them. Purpose-built for exactly what phase 3 hand-rolls, and it copes with sites whose sitemap is absent, stale or split across nested indexes. Skipped entirely under `v1`, where the endpoint does not exist.
+3. **Sitemap parsing** — fetches `/sitemap.xml` (and linked sitemaps) and extracts URLs with titles/snippets. Uses `fast-xml-parser` for sitemap XML parsing.
+4. **BFS crawl** (opt-in) — if sitemap parsing also fails, performs a breadth-first crawl starting from the given URL up to `CRAWL_BFS_MAX_DEPTH` link hops. Only runs when `CRAWL_BFS_ENABLED=true` or the `bfs` tool parameter is `true`.
+
+Each phase falls through to the next, but **no longer silently**: a non-2xx from the crawl
+start, the crawl poll or the map endpoint is logged and recorded against the `crawl` slot in
+the per-domain stats, so `domain_stats` answers "does the Firecrawl phase ever succeed here?"
+without needing a live probe.
+
+Full page content fetched during the crawl is cached in Valkey (TTL: `CRAWL_MANIFEST_TTL_SECONDS`, default 6 hours). Subsequent `fetch_url` calls for any URL in the manifest return immediately from cache — zero fetch overhead for follow-up reads.
+
+The manifest cache can be cleared with `clear_cache(target="crawl")`.
+
+## Wayback Machine fallback
+
+When `WAYBACK_ENABLED=true`, a fourth tier queries the Wayback Machine CDX API for an archived snapshot when all three main tiers fail. Returned content is prefixed with a provenance header (`[Archived snapshot – <timestamp> – <original_url>]`) so callers know the content may not reflect the current page state.
+
+## Challenge detection and solver tier
+
+A Cloudflare-style challenge interstitial is frequently served with **HTTP 200** — routine for
+Managed Challenge and Turnstile — which used to pass straight through the tier cascade as a
+successful fetch: Readability-extracted, cached, and written to the domain capability database
+as evidence the tier works on that domain, feeding tier-skip decisions on nothing but a wrong
+signal. As of v3.19.0, tiers 1–3 detect this case (matched on Cloudflare edge headers at
+403/503, and on interstitial markers in a 200-status body) and report it as a distinct miss
+(`reason: challenge_detected`) instead of a hit. A detected challenge is never cached and never
+written to domain-db.
+
+When `SOLVER_ENABLED=true` and `SOLVER_URL` points at a running solver — Byparr, or any service
+implementing FlareSolverr's `POST /v1` contract — a challenge detected on a given request
+triggers one solve attempt, dispatched after the tier 3 cascade fails and before the Wayback
+fallback. The solve is **strictly per-request**: the tier never fires on a URL that was not
+challenged in that same request, so it adds no overhead to the ordinary path. The solver's
+response is replayed through the normal bounded-fetch and extraction path — re-validated for
+SSRF (`assertPublicUrl` + `assertResolvedPublic` against the solver's resulting URL, since it
+may differ from the one requested) and re-checked for a challenge — rather than trusted
+directly, so a "solved" page that is still an interstitial registers as a miss, not a cache
+write. Solver-returned cookies are scoped to the solved host and never forwarded elsewhere.
+
+**This is not a guaranteed bypass.** Byparr's own documentation is explicit that a solve is not
+guaranteed and often needs residential-IP traffic. A miss here is the expected common case and
+degrades cleanly into the Wayback tier — not an error, and not something to alert on.
+
+## Fetch quality
+
+After any tier returns content with raw HTML, a post-extraction pass improves title and body quality:
+
+- **JSON-LD Article extraction** — Schema.org `Article` / `NewsArticle` / `BlogPosting` / `TechArticle` blocks supply cleaner `headline` and `articleBody` than tier-1 chrome scraping (size-capped at 1 MB per script tag).
+- **Title cascade** — falls back through `og:title` → `twitter:title` → `<title>` (with publisher-suffix stripping) → first `<h1>` → URL.
+- **Tier-2 Readability comparison** — when Crawl4AI returns markdown, JSDOM+Readability also runs over its raw HTML and is preferred when its text is longer (or unconditionally when Crawl4AI returns less than 500 chars).
+
+## Relevance filtering (`min_score`)
+
+The three search tools accept `min_score` (0–1), a floor applied after reranking. Omit it and nothing changes.
+
+It filters on the **raw cross-encoder `relevance_score`**, not on the value used for ordering. Ranking sorts by `relevance_score + RERANK_RECENCY_WEIGHT * recencyScore(publishedDate)`, which with the default weight of `0.15` ranges over **0–1.15, not 0–1**. Filtering a parameter called "minimum relevance" on that number would quietly make it mean "relevant enough *or* recent enough". Filtering happens before the top-N slice, so the floor never costs you a result that cleared it.
+
+Two things make this knob behave differently from how a 0–1 range suggests. Both were measured against the local FlashRank service on the query *"how to configure nginx reverse proxy"*:
+
+| Document | `relevance_score` |
+|---|---|
+| nginx reverse-proxy guide (`proxy_pass`) | **0.998** |
+| Apache `mod_proxy` reverse proxying | **0.967** |
+| nginx install page (topical, wrong subject) | **0.0028** |
+| banana bread recipe | **0.0000151** |
+
+- **The distribution is strongly bimodal.** Relevant results cluster near 1.0, irrelevant ones near 0, with very little in between — so any threshold in roughly 0.01–0.9 behaves near-identically. Useful values are around **0.01–0.1**; `0.5` is not a meaningful midpoint.
+- **A high score means topically related, not correct.** The Apache document scored 0.967 on an nginx query. `min_score` is a topicality floor and cannot be trusted as a correctness filter.
+
+Thresholds are model-dependent and not comparable across rerankers. When the reranker is unavailable there are no scores to filter on, so `min_score` becomes a **no-op with a throttled warning** — returning unfiltered results silently would let you believe a floor had been applied, and returning nothing would turn a reranker outage into "no results found".
+
+## Resilience
+
+- **Multi-instance SearXNG failover.** `SEARXNG_URL` accepts a list of interchangeable replicas (`,` or `;` separated), tried in order. A single value behaves exactly as before — one request, one host, no health lookup, no extra cache traffic. Three things about the multi-instance path are worth knowing:
+  - The timeout budget is **total, not per instance**. `SEARXNG_TOTAL_TIMEOUT_MS` bounds the whole call and is decremented as candidates fail, so adding a replica cannot make a total outage take longer to report.
+  - Health state lives in the **cache, not in process memory**, so one process's discovery of a dead instance informs the next call. It is a hint, not a circuit breaker: a failed instance is moved to the back of the order for `SEARXNG_UNHEALTHY_TTL_SECONDS`, never removed, and if every instance is marked down the full list is tried anyway. A cache outage degrades to "try every instance in configured order" — never to an error.
+  - **Failover is loud.** Each fall-through emits a `search.failover` NATS event and a throttled stderr line. A silent failover is indistinguishable from a healthy primary, which is how a half-dead deployment goes unnoticed for weeks.
+
+  Fan-out (querying replicas in parallel and merging) is deliberately **not** implemented: it needs meta reconciliation with no obvious right answer — if two instances return different `answers`/`infoboxes`, which wins? `searxSearch` already merges across expanded query variants, so the marginal recall gain is small.
+
+- **Cache never hangs a search.** The Valkey client is bounded by `CACHE_COMMAND_TIMEOUT_MS`/`CACHE_CONNECT_TIMEOUT_MS`/`CACHE_MAX_RETRIES_PER_REQUEST` (see [Configuration](configuration.md)). A stalled or CPU-spiked cache backend now rejects the command instead of hanging forever — the existing fail-soft handling degrades that rejection to a cache miss (serve live) rather than throwing. Cache connect failures, client errors, and per-command errors emit a throttled `[searxng-mcp]` stderr line (deduped per key so a sustained outage leaves a periodic breadcrumb, not a flood) — stderr is always on, and is the sink that never depends on configuration. On the forge deployment OTel and NATS are also wired (`OTEL_EXPORTER_OTLP_ENDPOINT` and `NATS_URL` are both set, and the startup capability line reports `otel,nats` in its on-list), so stderr is the floor rather than the whole story.
+- **Process crash handlers** — `uncaughtException` logs then exits 1, so the supervisor restarts cleanly (Docker's `restart: unless-stopped` on the forge deployment); `unhandledRejection` logs and continues rather than crashing the shared process silently.
+- **Graceful-degradation warnings** — the reranker fallback and the Ollama/LLM expand + summarize fallbacks emit one throttled stderr line each when they silently degrade quality (reranker unavailable, LLM backend unreachable).
+- **Version is single-sourced** from `package.json` at runtime (`src/version.ts`) — the `McpServer` version, OTel tracer/meter version, and outbound `USER_AGENT` all track it, so they can't drift independently.
+
+## Observability (opt-in)
+
+Tracing, metrics, and event publishing are entirely opt-in — with none of the env vars below set, the server has zero observability overhead and never loads the OpenTelemetry or NATS packages at runtime.
+
+**OpenTelemetry (traces + metrics)** — set `OTEL_EXPORTER_OTLP_ENDPOINT` to your collector's HTTP endpoint and the server emits:
+
+- Spans (per request): `tool.<name>` → `expand_query`? → `searxng_request` → `rerank` → `fetch` (×N) → `tier1_firecrawl` | `tier2_crawl4ai` | `tier3_rawfetch` | `solver_byparr` → `post_extract`; plus `summarize_llm` for `search_and_summarize`.
+- Counters: `searxng_search_total{profile, expand}`, `searxng_fetch_total{tier, outcome}`, `searxng_cache_total{namespace, outcome}`, `searxng_errors_total{stage, error_type}`.
+- Histograms: `searxng_search_duration_seconds{profile}`, `searxng_fetch_duration_seconds{tier, outcome}`.
+
+Standard OTEL env vars apply (`OTEL_SERVICE_NAME` defaults to `searxng-mcp`).
+
+**NATS events** — set `NATS_URL` (e.g. `nats://localhost:4222`) and the server publishes a structured event on every search, fetch, cache hit/miss, robots skip, and error. Authenticates via `NATS_CREDS` (a JWT creds file) or `NATS_USER`/`NATS_PASSWORD` (bcrypt username/password) — creds-file auth wins if both are set. Subjects:
+
+| Subject | When |
+|---------|------|
+| `searxng.search.requested` | Search tool invoked |
+| `searxng.search.completed` | Search returned (with sources, latency, rerank applied) |
+| `searxng.fetch.requested` | `fetchPage` called |
+| `searxng.fetch.tier.miss` | A tier returned empty or threw |
+| `searxng.fetch.tier.skipped` | robots.txt disallowed |
+| `searxng.fetch.completed` | Fetch resolved (with `tier_served`, `text_len`, latency) |
+| `searxng.cache.hit` / `.miss` | On every Valkey lookup |
+| `searxng.error` | Stage-tagged errors |
+
+Each envelope includes `request_id` and (when OTel is enabled) `trace_id` so subscribers can join the two streams. Subject prefix overridable via `NATS_SUBJECT_PREFIX`. Search queries flow through `search.*` events — downstream consumers are responsible for any PII scrubbing.
+
+## Politeness
+
+- **Honest User-Agent** — outbound requests identify as `searxng-mcp/<version> (+https://github.com/TadMSTR/searxng-mcp; personal research)`.
+- **robots.txt compliance** — `/robots.txt` is fetched once per origin and cached for 24 hours in Valkey under `robots:<origin>`. Disallowed paths are skipped before any tier runs and logged as `skipped_robots url=… reason=…`.
+
+---
+
+[← Docs index](index.md) · [Configuration](configuration.md) · [Tools](tools.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,219 @@
+<!-- Split out of README.md in v3.24.0 (vikunja#683). The README had reached 905 lines / 70KB, at which point it was a reference manual pretending to be an introduction. -->
+
+# Configuration
+
+All service URLs are configurable via environment variables.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SEARXNG_URL` | `http://localhost:8081` | SearXNG instance URL. Accepts a **list** of interchangeable replicas separated by `,` or `;` (e.g. `http://searxng-a:8080,http://searxng-b:8080`) — tried in order, with failover. A single value behaves exactly as before: one request, one host, no health lookup. Entries that are not valid http(s) URLs are dropped with a warning; if none survive the default is used rather than the server refusing to start. Basic-auth credentials may be embedded (`http://user:pass@host:8080`) — they are lifted out of the URL at startup and sent as an `Authorization: Basic` header, and never appear in logs, events, cache keys or error messages. |
+| `SEARXNG_TOTAL_TIMEOUT_MS` | `10000` | Total timeout budget for one search **across all instances**, not per instance. Iterating N replicas at the per-attempt timeout each would make a total outage take longer to report the more replicas you add. |
+| `SEARXNG_ATTEMPT_TIMEOUT_MS` | `10000` | Per-instance ceiling, further capped by whatever remains of `SEARXNG_TOTAL_TIMEOUT_MS`. |
+| `SEARXNG_UNHEALTHY_TTL_SECONDS` | `30` | How long a failed instance is deprioritised for. A hint that reorders candidates, not a circuit breaker — an unhealthy instance is moved to the back, never removed, and if every instance is marked down the full list is still tried. Stored in the cache so the hint is shared across processes; a cache outage degrades to "try every instance in configured order". |
+| `FIRECRAWL_URL` | `http://localhost:3002` | Firecrawl instance URL |
+| `FIRECRAWL_API_VERSION` | `v1` | Which Firecrawl API to speak — `v1` or `v2`. Any other value **fails at startup** rather than silently constructing a URL that 404s. See [Firecrawl API version](#firecrawl-api-version). |
+| `FIRECRAWL_WAIT_FOR_MS` | `2000` | Under `v2` only: how long a scrape waits for the page to settle when `wait_for_selector` is requested. v2 has no selector-based wait — see the capability boundary below. |
+| `FIRECRAWL_ENABLED` | `true` | Set to `false` when no Firecrawl is deployed — tier 1 is then skipped with `reason: not_configured` instead of attempting a connection on every fetch |
+| `RERANKER_URL` | `http://localhost:8787` | Reranker instance URL |
+| `FIRECRAWL_API_KEY` | `placeholder-local` | Firecrawl API key (if required) |
+| `GITHUB_TOKEN` | *(unset)* | GitHub personal access token — increases rate limit from 60 to 5,000 req/hour |
+| `OLLAMA_URL` | *(unset)* | Ollama API base URL — required for `expand` and `search_and_summarize` |
+| `OLLAMA_API_KEY` | *(unset)* | Bearer token for authenticated Ollama proxies — adds `Authorization: Bearer <key>` header when set |
+| `OLLAMA_EXPAND_MODEL` | `qwen3:4b` | Model used by query expansion (`expand` parameter). Override without rebuilding. |
+| `OLLAMA_SUMMARIZE_MODEL` | `qwen3:14b` | Model used by `search_and_summarize`. Override without rebuilding. |
+| `LLM_BASE_URL` | *(unset)* | OpenAI-compatible chat endpoint (e.g. vLLM, llama.cpp, LM Studio) for `expand` + `search_and_summarize`. Must include the API path — e.g. `http://host:8000/v1` — the server appends `/chat/completions`. When set, takes precedence over `OLLAMA_URL`, so an already-loaded model can be reused instead of running a separate Ollama model. |
+| `LLM_MODEL` | *(unset)* | Model id for the OpenAI-compatible backend; overrides `OLLAMA_EXPAND_MODEL` / `OLLAMA_SUMMARIZE_MODEL` when set. |
+| `LLM_API_KEY` | *(unset)* | Bearer token for the OpenAI-compatible backend — adds `Authorization: Bearer <key>` when set. |
+| `LLM_DISABLE_THINKING` | `true` | Sends `chat_template_kwargs.enable_thinking: false` so reasoning models (e.g. Qwen3) return direct output. Set to `false` for servers that reject that field. |
+| `CACHE_URL` | `redis://localhost:6381` | Redis-compatible URL — enables result caching. Also accepts `VALKEY_URL` or `REDIS_URL` as aliases. Works with Redis, Valkey, and Dragonfly. Server degrades gracefully if unavailable. |
+| `CACHE_COMMAND_TIMEOUT_MS` | `2500` | Valkey command timeout — a stalled/CPU-spiked cache backend rejects instead of hanging (`cacheGet()` is the first `await` in every search). Invalid/non-positive values fall back to the default rather than becoming a NaN that would disable the timeout. |
+| `CACHE_CONNECT_TIMEOUT_MS` | `3000` | Valkey connection timeout. Same fallback behavior as `CACHE_COMMAND_TIMEOUT_MS`. |
+| `CACHE_MAX_RETRIES_PER_REQUEST` | `2` | Max retries per Valkey command before it rejects. Same fallback behavior as `CACHE_COMMAND_TIMEOUT_MS`. |
+| `CACHE_TTL_SECONDS` | `3600` | Search result cache TTL in seconds |
+| `FETCH_CACHE_TTL_SECONDS` | `86400` | Fetched page cache TTL in seconds |
+| `CRAWL_MANIFEST_TTL_SECONDS` | `21600` | Crawl manifest and page content cache TTL in seconds (6 hours) |
+| `CRAWL_MAX_PAGES_DEFAULT` | `20` | Default max pages returned by `crawl_site` when no `max_pages` is passed |
+| `CRAWL_BFS_ENABLED` | `false` | Set to `true` to enable BFS fallback in `crawl_site` globally. Can also be enabled per-call with the `bfs` parameter. |
+| `CRAWL_BFS_MAX_DEPTH` | `3` | Maximum link-hop depth for BFS crawl |
+| `FIRECRAWL_CRAWL_POLL_INTERVAL_MS` | `2000` | Polling interval when waiting for a Firecrawl crawl job to complete |
+| `FIRECRAWL_CRAWL_MAX_WAIT_MS` | `120000` | Maximum time to wait for a Firecrawl crawl job before falling back to sitemap |
+| `EXPAND_QUERIES` | `false` | Set to `true` to enable query expansion globally |
+| `CRAWL4AI_URL` | *(unset)* | Crawl4AI instance URL — enables second-tier fetch fallback when Firecrawl fails |
+| `CRAWL4AI_ENABLED` | `true` | Set to `false` to skip tier 2 regardless of `CRAWL4AI_URL`. Tier 2 is also skipped when `CRAWL4AI_URL` is unset |
+| `CRAWL4AI_API_TOKEN` | *(unset)* | Optional Bearer token for Crawl4AI instances with API token protection |
+| `WAYBACK_ENABLED` | `false` | Set to `true` to enable Wayback Machine tier-4 fallback — fetches archived snapshots when all three tiers fail |
+| `SOLVER_URL` | *(unset)* | Base URL of a Byparr (or other FlareSolverr `POST /v1`-compatible) challenge-solving service, e.g. `http://byparr:8191`. Unset leaves the tier inert regardless of `SOLVER_ENABLED`. |
+| `SOLVER_ENABLED` | `false` | Kill switch for the challenge-solving tier — mirrors `WAYBACK_ENABLED`. Requires `SOLVER_URL` to also be set; fires only when a challenge was actually detected on the current request, never on an unchallenged URL. |
+| `SOLVER_MAX_TIMEOUT_MS` | `60000` | Per-request ceiling passed to the solver as `maxTimeout`. |
+| `ADBLOCK_PROXY_URL` | *(unset)* | HTTP proxy URL for tier-2 (Crawl4AI) and tier-3 (raw Node fetch) adblocking — e.g. `http://adblock-proxy:8118`. See `docker/adblock-proxy/`. |
+| `KIWIX_URL` | *(unset)* | kiwix-serve base URL (e.g. `http://localhost:8292`) — enables Kiwix fast path for Wikipedia, Stack Overflow, and Arch Wiki. Feature is disabled and zero-overhead when unset. |
+| `HISTER_URL` | *(unset)* | Hister browsing-history index base URL — enables Hister fast path before the tier cascade for login-walled and JS-heavy pages. Feature disabled and zero-overhead when unset. |
+| `HISTER_TOKEN` | *(unset)* | Bearer token for Hister API authentication. Required when `HISTER_URL` is set and the instance has token auth enabled. |
+| `YOUTUBE_TRANSCRIPT_ENABLED` | `true` | Enables the YouTube transcript fast path in `fetch_url`. Set to `false` to disable (e.g. if the unofficial timedtext endpoint breaks upstream). |
+| `YOUTUBE_IGNORE_ROBOTS` | `false` | Opt into fetching YouTube transcripts despite YouTube's `robots.txt` disallowing `/api/`. Default respects robots (fast path stays dormant, falls through to the cascade). |
+| `REDDIT_FASTPATH_ENABLED` | `true` | Enables the Reddit `.json` fast path in `fetch_url`. Set to `false` to disable. |
+| `REDDIT_IGNORE_ROBOTS` | `false` | Opt into fetching Reddit `.json` despite Reddit's `robots.txt` (`Disallow: /`). Default respects robots (fast path stays dormant, falls through to the cascade). |
+| `SEARXNG_MCP_TRANSPORT` | `stdio` | Transport mode: `stdio` (default, single-client) or `http` (shared HTTP/SSE server). |
+| `SEARXNG_MCP_PORT` | `3001` | HTTP listen port (HTTP transport mode only). |
+| `SEARXNG_MCP_HOST` | `127.0.0.1` | HTTP listen address (HTTP transport mode only). |
+| `SEARXNG_MCP_AUTH_TOKEN` | *(unset)* | HTTP transport only. When set, every request except `GET /health` must send `Authorization: Bearer <token>` or get a `401`. Unset (the default) disables the check entirely. **Set this whenever `SEARXNG_MCP_HOST` is not loopback** — see [HTTP transport authentication](deployment.md#http-transport-authentication). |
+| `HTTP_SESSION_IDLE_TIMEOUT_MS` | `600000` | HTTP transport only. A session idle longer than this is evicted by a background sweep (sessions with an in-flight request are exempt, so a long `crawl_site` call is never closed mid-request). Bounds session-map growth from clients killed mid-turn, which never fire `transport.onclose`. |
+| `HTTP_MAX_SESSIONS` | `256` | HTTP transport only. Hard-cap backstop — if the session map ever exceeds this, the least-recently-used idle session is evicted regardless of the idle timeout. |
+| `HTTP_MAX_BODY_BYTES` | `1048576` | HTTP transport only. Maximum request body read on the pre-session `initialize` path; a larger body gets `413` and the read stops at the limit rather than buffering to completion first. Requests carrying an `Mcp-Session-Id` are read by the MCP SDK's own transport and are not covered by this — see [Bounded reads](security.md#bounded-reads). |
+| `NATS_USER` | *(unset)* | NATS username for bcrypt username/password auth, used alongside `NATS_PASSWORD`. Ignored if `NATS_CREDS` is also set (creds-file JWT auth wins). |
+| `NATS_PASSWORD` | *(unset)* | NATS password — see `NATS_USER`. |
+
+# Prerequisites and service setup
+
+**Runtime:** Node.js 20+, and pnpm (or npm).
+
+## Required
+
+- A running [SearXNG](https://github.com/searxng/searxng) instance, with JSON output enabled (see below).
+
+That is the whole list. Everything under it is progressive enhancement.
+
+## Strongly recommended
+
+| Service | What it buys you |
+|---------|------------------|
+| [Valkey](https://valkey.io/), Dragonfly or any Redis-compatible cache | Repeat searches and fetches are served from cache instead of re-run. The single largest latency win. Fail-soft: a cache timeout serves live. |
+| A reranker with a Jina-compatible `/v1/rerank` endpoint | Reorders results by semantic relevance to the query. Without it results keep SearXNG's own ordering and a throttled degradation line is logged. |
+
+Neither has a kill switch — both have a default URL and are always attempted, because both fail
+soft. Absence costs quality and latency, never correctness.
+
+## Optional
+
+| Service | Capability it unlocks | Turn it on with |
+|---------|----------------------|-----------------|
+| [Firecrawl](https://github.com/mendableai/firecrawl) | Fetch tier 1 — Puppeteer-rendered pages, best extraction quality on JS-heavy sites | On by default; `FIRECRAWL_URL`, or `FIRECRAWL_ENABLED=false` to skip the tier |
+| [Crawl4AI](https://github.com/unclecode/crawl4ai) | Fetch tier 2 — browser automation fallback when tier 1 returns empty content | `CRAWL4AI_URL` |
+| [Ollama](https://ollama.com/) with `qwen3:4b` and/or `qwen3:14b`, or any OpenAI-compatible endpoint | Query expansion and LLM-synthesized summaries (`search_and_summarize`) | `OLLAMA_URL` or `LLM_BASE_URL` |
+| [kiwix-serve](https://github.com/kiwix/kiwix-tools) | Offline serving of Wikipedia, Stack Overflow and the Arch Wiki from local ZIM archives | `KIWIX_URL` |
+| Hister | Archived-page fallback from a private archive | `HISTER_URL` |
+| [Byparr](https://github.com/ThePhaseless/Byparr) or FlareSolverr | Solves Cloudflare-style interstitials on the domains that serve them | `SOLVER_URL` + `SOLVER_ENABLED=true` |
+| Wayback Machine | Tier-4 fallback to an archived snapshot when all three tiers fail | `WAYBACK_ENABLED=true` |
+| An OTLP collector / NATS | Traces and metrics; a JetStream event stream of every search and fetch | `OTEL_EXPORTER_OTLP_ENDPOINT` / `NATS_URL` |
+
+On startup the server logs one line naming exactly which of these are configured, so a
+lower-quality result set can be traced to a missing service rather than guessed at:
+
+```
+[searxng-mcp] capabilities on=tier3,cache,reranker off=tier1,tier2,llm,kiwix,hister,solver,wayback,otel,nats
+```
+
+It reports configuration, not reachability — nothing is probed, so the line never delays startup.
+
+The rest of this section is setup reference for whichever of the above you chose to deploy —
+skip any you did not.
+
+## SearXNG
+
+SearXNG must have JSON output format enabled. In `settings.yml`:
+
+```yaml
+search:
+  formats:
+    - html
+    - json
+```
+
+## Reranker (recommended)
+
+The reranker must expose a Jina-compatible `/v1/rerank` endpoint. A lightweight FlashRank wrapper works well — see the [`docker/reranker/`](https://github.com/TadMSTR/homelab-agent/tree/main/docker/reranker) reference in [homelab-agent](https://github.com/TadMSTR/homelab-agent).
+
+## Firecrawl (optional — fetch tier 1)
+
+Any Firecrawl-compatible instance works. The local [firecrawl-simple](https://github.com/mendableai/firecrawl/tree/main/apps/api) deployment is sufficient. Set `FIRECRAWL_API_KEY` if your instance requires authentication (defaults to `placeholder-local` for local deployments that skip auth).
+
+### Firecrawl API version
+
+`FIRECRAWL_API_VERSION` selects which API the client speaks — `v1` (default) or `v2`. The two
+are not interchangeable and no backend serves both:
+
+| Backend | Version | Notes |
+|---|---|---|
+| [firecrawl-simple](https://github.com/devflowinc/firecrawl-simple) | `v1` | Serves `/v1/scrape` and `/v1/crawl` only. No `/map`. |
+| [Upstream Firecrawl 2.x](https://github.com/firecrawl/firecrawl) | `v2` | Serves `/v2/scrape`, `/v2/crawl` and `/v2/map`. |
+
+An unrecognised value fails at startup rather than falling back. That is deliberate: a wrong
+version prefix produces a 404 that `crawl_site` would swallow into its sitemap fallback, and a
+wholly dead code path returning healthy-looking manifests is exactly how the `/v2`-against-`v1`
+mismatch survived unnoticed for the life of the feature.
+
+**Capability boundary under `v2` self-hosting.** Upstream Firecrawl implements page `actions`,
+screenshots and the stealth proxy in **Fire-engine**, which is closed-source and cloud-only.
+Every engine a self-hosted deployment can reach (`fetch`, `playwright`, `pdf`, `document`)
+reports `actions: false`, and a scrape carrying an `actions` array is rejected outright with
+HTTP 400 `SCRAPE_ACTIONS_NOT_SUPPORTED` — the whole request fails, it does not degrade.
+
+The practical consequence is one **semantic downgrade**:
+
+| Tuning parameter | Under `v1` | Under `v2` |
+|---|---|---|
+| `target_selector` | `includeTags` | `includeTags` — unchanged |
+| `wait_for_selector` | a real wait action on the selector | `waitFor`, a **fixed delay** of `FIRECRAWL_WAIT_FOR_MS` |
+
+Under `v2`, `wait_for_selector` waits on *time*, not on the selector. The page may still be
+unsettled when the delay elapses, and the delay is paid in full even when the selector was
+already present. If that matters for a given site, tier 2 (Crawl4AI) does support real
+selector waits and the cascade will reach it when tier 1 returns nothing useful.
+
+The LLM-backed scrape formats (`json`, `summary`, `query`, `highlights`) are also unavailable
+on a self-hosted deployment without an LLM endpoint configured on the backend; searxng-mcp
+does not request them.
+
+## Crawl4AI (optional — fetch tier 2)
+
+[Crawl4AI](https://github.com/unclecode/crawl4ai) is an optional second-tier fetch fallback used when Firecrawl returns empty content (bot-blocked pages, JS-heavy sites). Set `CRAWL4AI_URL` to enable it. If unset, the cascade skips to raw HTTP fetch.
+
+```bash
+docker run -d -p 11235:11235 unclecode/crawl4ai:0.8.6
+```
+
+If your instance requires API token authentication, set `CRAWL4AI_API_TOKEN`.
+
+On the `search_and_summarize` path, Crawl4AI requests use `fit_markdown` for noise-filtered content extraction. Other callers (`search_and_fetch`, `fetch_url`) use `raw_markdown`.
+
+## Kiwix (optional)
+
+[kiwix-serve](https://github.com/kiwix/kiwix-tools) serves ZIM archives over HTTP. Download
+the required ZIM files and run kiwix-serve with `--nodatealiases` (`-z`) so book names are
+stable:
+
+```bash
+kiwix-serve --port 8292 --nodatealiases /path/to/zims/
+```
+
+Required ZIM files for each supported host:
+- Wikipedia: `wikipedia_en_all_mini` (or `maxi`)
+- Stack Overflow: `stackoverflow.com_en_all`
+- Arch Wiki: `archlinux_en_all_maxi`
+
+ZIM files can be downloaded from [library.kiwix.org](https://library.kiwix.org/).
+
+## Hister (optional)
+
+[Hister](https://github.com/nicholasgasior/hister) is a browsing-history index populated by a Firefox extension. When `HISTER_URL` is set, `fetchPage` checks the history index before invoking the tier cascade — useful for login-walled and JS-heavy pages where scrapers fail.
+
+Set `HISTER_URL` to your Hister instance base URL and `HISTER_TOKEN` if bearer token auth is required.
+
+## Valkey / Redis
+
+Any Redis-compatible instance. Valkey is recommended. Search results are cached for 1 hour; fetched pages for 24 hours. If unavailable, the server operates without caching.
+
+## Ollama
+
+Required for `expand` and `search_and_summarize`. Pull the required models:
+
+```bash
+ollama pull qwen3:4b   # query expansion
+ollama pull qwen3:14b  # summarization
+```
+
+Set `think: false` behavior is handled automatically — no extra Ollama configuration needed.
+
+---
+
+[← Docs index](index.md) · [Deployment](deployment.md) · [Architecture](architecture.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,6 +14,43 @@ Or run directly with `npx`:
 npx @tadmstr/searxng-mcp
 ```
 
+## Container image
+
+Published to GHCR on every release tag:
+
+```bash
+docker pull ghcr.io/tadmstr/searxng-mcp:latest
+```
+
+```bash
+docker run -d --name searxng-mcp -p 127.0.0.1:3001:3001 \
+  -e SEARXNG_URL=http://searxng:8080 \
+  -e SEARXNG_MCP_TRANSPORT=http \
+  -e SEARXNG_MCP_AUTH_TOKEN="$(openssl rand -hex 32)" \
+  ghcr.io/tadmstr/searxng-mcp:latest
+```
+
+Available tags, `linux/amd64`:
+
+| Tag | Moves | Use it when |
+|-----|-------|-------------|
+| `v3.24.0` and `3.24.0` | never | You want a specific release pinned. Both spellings are published — the git tag carries the `v`, the conventional Docker tag does not. |
+| `3.24` | to the newest stable `3.24.x` | You want patches automatically but not minor bumps. |
+| `latest` | to the newest stable release | You want the current release and can tolerate minor bumps. |
+
+Prereleases (`v3.24.0-rc1`) publish their exact tags only — they never move
+`3.24` or `latest`.
+
+The image runs as uid 1000 and is not root. Every published image has passed
+the same smoke assertions CI runs — `/health` answers unauthenticated, `/mcp`
+returns 401 without a bearer token and 200 with the right one — executed
+against that exact image before it was pushed. Build provenance is attested
+and pushed to the registry alongside it:
+
+```bash
+gh attestation verify oci://ghcr.io/tadmstr/searxng-mcp:latest --owner TadMSTR
+```
+
 ## From source
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,160 @@
+<!-- Split out of README.md in v3.24.0 (vikunja#683). The README had reached 905 lines / 70KB, at which point it was a reference manual pretending to be an introduction. -->
+
+# Install and deployment
+
+## npm (recommended)
+
+```bash
+npm install -g @tadmstr/searxng-mcp
+```
+
+Or run directly with `npx`:
+
+```bash
+npx @tadmstr/searxng-mcp
+```
+
+## From source
+
+```bash
+git clone https://github.com/TadMSTR/searxng-mcp.git
+cd searxng-mcp
+pnpm install
+pnpm build
+```
+
+Output: `build/src/index.js`
+
+# MCP Client Configuration
+
+## Claude Code (CLI)
+
+The recommended approach uses `claude mcp add-json` to register the server with full env var support:
+
+```bash
+claude mcp add-json searxng --scope user '{
+  "command": "npx",
+  "args": ["-y", "@tadmstr/searxng-mcp"],
+  "env": {
+    "SEARXNG_URL": "http://localhost:8081",
+    "FIRECRAWL_URL": "http://localhost:3002",
+    "RERANKER_URL": "http://localhost:8787",
+    "OLLAMA_URL": "http://localhost:11434",
+    "CACHE_URL": "redis://localhost:6379",
+    "CACHE_TTL_SECONDS": "3600",
+    "FETCH_CACHE_TTL_SECONDS": "86400",
+    "EXPAND_QUERIES": "false",
+    "CRAWL4AI_URL": "http://localhost:11235"
+  }
+}'
+```
+
+This writes to `~/.claude.json`. Do not add searxng to `~/.claude/settings.json` — that file is not used for MCP env var injection in Claude Code.
+
+## Claude Desktop (`claude_desktop_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "searxng": {
+      "command": "npx",
+      "args": ["-y", "@tadmstr/searxng-mcp"],
+      "env": {
+        "SEARXNG_URL": "http://localhost:8081",
+        "FIRECRAWL_URL": "http://localhost:3002",
+        "RERANKER_URL": "http://localhost:8787",
+        "OLLAMA_URL": "http://localhost:11434",
+        "CACHE_URL": "redis://localhost:6379",
+        "CRAWL4AI_URL": "http://localhost:11235"
+      }
+    }
+  }
+}
+```
+
+## LibreChat (`librechat.yaml`)
+
+```yaml
+mcpServers:
+  searxng:
+    type: stdio
+    command: node
+    args:
+      - /path/to/searxng-mcp/build/src/index.js
+    env:
+      SEARXNG_URL: http://localhost:8081
+      FIRECRAWL_URL: http://localhost:3002
+      RERANKER_URL: http://localhost:8787
+      OLLAMA_URL: http://localhost:11434
+      CACHE_URL: redis://localhost:6379
+      CRAWL4AI_URL: http://localhost:11235
+```
+
+# Transport
+
+**stdio** (default) — compatible with Claude Code MCP plugin and LibreChat `stdio` config.
+
+**HTTP** — set `SEARXNG_MCP_TRANSPORT=http` to run as a shared HTTP/SSE server suitable for multi-client deployments or Docker-based setups. Binds to `SEARXNG_MCP_HOST:SEARXNG_MCP_PORT` (default `127.0.0.1:3001`):
+
+```bash
+SEARXNG_MCP_TRANSPORT=http SEARXNG_MCP_PORT=3001 npx @tadmstr/searxng-mcp
+```
+
+Register with Claude Code against an HTTP server:
+
+```bash
+claude mcp add-json searxng --scope user '{
+  "type": "http",
+  "url": "http://localhost:3001/mcp"
+}'
+```
+
+Sessions are keyed by the `Mcp-Session-Id` header, so multiple clients can connect to the same shared process concurrently. Idle sessions are swept after `HTTP_SESSION_IDLE_TIMEOUT_MS` and hard-capped at `HTTP_MAX_SESSIONS` — see [Configuration](configuration.md).
+
+## HTTP transport authentication
+
+The HTTP transport is **unauthenticated by default**, which is safe only because it binds `127.0.0.1` by default. If you change `SEARXNG_MCP_HOST` to anything else — including `0.0.0.0`, which is what running in a container requires — set `SEARXNG_MCP_AUTH_TOKEN` as well:
+
+```bash
+SEARXNG_MCP_AUTH_TOKEN=$(openssl rand -hex 32)
+```
+
+When it is set, every request except `GET /health` must carry the token as an [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750) bearer credential:
+
+```
+Authorization: Bearer <token>
+```
+
+Anything else — no header, a different scheme, a wrong token — gets `401` with `WWW-Authenticate: Bearer` and a JSON-RPC error body. The response is identical in all three cases and never echoes the presented credential. Tokens are compared as SHA-256 digests, so the comparison is constant-time and leaks no length information.
+
+Registering an authenticated server with Claude Code:
+
+```bash
+claude mcp add-json searxng --scope user '{
+  "type": "http",
+  "url": "http://localhost:3001/mcp",
+  "headers": {"Authorization": "Bearer <token>"}
+}'
+```
+
+Leaving the variable unset preserves the previous behaviour exactly, so stdio users and existing loopback-bound HTTP deployments need no change. There is no per-caller authorization model — a single token authenticates *access to the server*, not a particular client identity. On startup, a non-loopback bind with no token logs a warning.
+
+**`GET /health` is deliberately exempt** from the check. It is the container healthcheck and the monitoring liveness probe, it takes no input, and its response (`status`, `cache`, `sessions`) carries no secrets.
+
+**`GET /health`** — unauthenticated liveness probe, localhost-bound alongside the MCP endpoint. Pings Valkey through the bounded cache command timeout (so the check itself can never hang) and returns:
+
+```json
+{"status": "ok", "cache": "up", "sessions": 3}
+```
+
+or, when the cache backend is unreachable:
+
+```json
+{"status": "degraded", "cache": "degraded", "sessions": 3}
+```
+
+`sessions` is the live HTTP session count. Useful for sysadmin monitoring to detect a degraded cache from the MCP side without instrumenting the cache backend directly.
+
+---
+
+[← Docs index](index.md) · [Configuration](configuration.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# searxng-mcp documentation
+
+The [README](../README.md) covers what searxng-mcp is and how to get it running. Everything
+past that point lives here.
+
+| Document | What is in it |
+|----------|---------------|
+| [Configuration](configuration.md) | Every environment variable, and the setup for each optional backing service (SearXNG, reranker, Firecrawl, Crawl4AI, Kiwix, Hister, Valkey, Ollama). |
+| [Tools](tools.md) | Full per-tool parameter reference for all seven MCP tools, plus GitHub URL handling. |
+| [Deployment](deployment.md) | Install from npm or source, stdio and HTTP transports, HTTP authentication, and MCP client recipes for Claude Code, Claude Desktop and LibreChat. |
+| [Architecture](architecture.md) | The fetch cascade and tier semantics, adblocking, data-driven tier routing, the domain capability database, every fast path, resilience, and observability. |
+| [Security](security.md) | SSRF handling, redirect protection, transport exposure, bounded reads, dependency auditing, credential handling and input validation. Vulnerability reporting is in [`SECURITY.md`](../SECURITY.md). |
+
+## Where to start
+
+- **Running it for the first time:** the README's Quick Start, then [Configuration](configuration.md).
+- **Wiring it into a client:** [Deployment](deployment.md).
+- **Working out why a fetch returned what it did:** [Architecture](architecture.md) — the tier
+  cascade and the domain capability database are the two things that decide it.
+- **Reviewing it before deploying:** [Security](security.md).

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,58 @@
+<!-- Split out of README.md in v3.24.0 (vikunja#683). The README had reached 905 lines / 70KB, at which point it was a reference manual pretending to be an introduction. -->
+
+# Security
+
+## URL safety (SSRF)
+
+Every outbound fetch to a caller-influenced or discovered URL — the raw-HTTP tier, robots.txt / llms.txt / Wayback / sitemap probes, the BFS crawl link-fetch, and the GitHub fast path — is guarded two ways:
+
+1. **String check** (`assertPublicUrl`) — rejects non-HTTP(S) URLs and private/internal IP *literals*: RFC1918 (`10.x`, `192.168.x`, `172.16–31.x`), loopback (`127.x`, `::1`), link-local / cloud metadata (`169.254.x`), CGNAT (`100.64/10`), IPv6 ULA (`fc00::/7`) and link-local (`fe80::/10`), IPv4-mapped, and multicast/reserved ranges.
+2. **Connect-time DNS validation** — a shared undici dispatcher whose `connect.lookup` validates the *resolved* address (the exact one the socket connects to). This closes the DNS-rebinding / TOCTOU gap where a public hostname resolves to a private address, and it re-runs on **every redirect hop**, so a redirect chain cannot bounce into your internal network.
+
+Firecrawl (tier1) and Crawl4AI (tier2) resolve and fetch the target URL themselves, so the connect-time dispatcher above can't cover them. `fetchPage` and `crawlSite` call `assertResolvedPublic(url)` — a one-time hostname resolution rejecting any private/reserved result — immediately before dispatching to either service, closing the common DNS-rebinding case on that path (narrower TOCTOU window than the connect-time guard, since the service re-resolves).
+
+Configured internal services (Firecrawl, Crawl4AI, SearXNG, Ollama, Reranker) are reached by their own URLs and are intentionally not guarded.
+
+## Redirect protection
+
+The raw-HTTP and GitHub fast-path fetches additionally use `redirect: "manual"` and reject 3xx responses outright (the `Location` header is never echoed back to the caller). Redirect-following probes (robots.txt, llms.txt, sitemap) are covered by the connect-time DNS validation above, which re-checks each hop.
+
+## Transport exposure
+
+stdio has no network surface. The HTTP transport binds `127.0.0.1` by default and is unauthenticated in that configuration; moving it off loopback without setting `SEARXNG_MCP_AUTH_TOKEN` exposes every tool — including arbitrary-URL `fetch_url` and destructive `clear_cache` — to anything that can route to the port. See [HTTP transport authentication](deployment.md#http-transport-authentication).
+
+## Bounded reads
+
+Every response body read from a third party, and the one request body this server reads itself, stops at a byte limit and cancels the rest of the stream rather than buffering the whole thing and checking its size afterwards. A post-hoc size check has already paid the memory cost it is trying to avoid.
+
+| Read | Limit | Notes |
+|---|---|---|
+| Fetch tiers (raw, Firecrawl, Crawl4AI, solver, Wayback, Reddit, YouTube, GitHub, sitemap/crawl) | `RAW_HTML_MAX_BYTES` (2 MB) | Shared `readBoundedText` helper. |
+| `llms-full.txt` probe | `MAX_SIZE_BYTES` (64 MB) | Read one byte past the ceiling so an oversized document is still *detected* as oversized and reported absent, rather than truncated to the limit and served as if complete. |
+| HTTP transport request body | `HTTP_MAX_BODY_BYTES` (1 MB) | `initialize` path only; `413` on exceeding. |
+
+The bound is on **bytes retained**, not bytes transferred. Cancellation is not instantaneous — socket buffers and in-flight data mean a peer can still push some way past the cap — so this hard-bounds memory and only reduces transfer (measured roughly 10x against a 40 MB stub).
+
+**One limitation, out of this server's control:** requests carrying an `Mcp-Session-Id` are handled by the MCP SDK's `StreamableHTTPServerTransport.handleRequest()`, which reads its own request body. That read is not bounded by anything here. It is reachable only by a caller that has already authenticated and established a session.
+
+Reads from first-party services configured by the operator — SearXNG and Ollama — are deliberately left unbounded. They are not attacker-influenced, and bounding them would add ceremony without changing a threat.
+
+## Dependency auditing
+
+CI runs `pnpm audit` on every push. The lockfile (`pnpm-lock.yaml`) is committed for reproducible, auditable builds.
+
+## Credential handling
+
+Basic-auth credentials embedded in `SEARXNG_URL` are extracted at startup and sent as an `Authorization` header; the URL used for the request, for cache keys, for log lines, for NATS events and for error messages is always the credential-free origin. This matters more than it looks: Node's `fetch` refuses a URL containing userinfo outright and puts the whole URL — password included — into the resulting `TypeError`'s message, so leaving credentials in the URL would both break every request and leak the password into any sink that forwards an error message.
+
+No credentials are stored or logged by the server. API keys (`FIRECRAWL_API_KEY`, `GITHUB_TOKEN`, `CRAWL4AI_API_TOKEN`) are read from environment variables and used only in outbound requests to their respective services.
+
+## Input validation
+
+Environment variables are validated at startup — `RERANK_RECENCY_WEIGHT` warns on NaN, negative, or >1.0 values. Numeric tool parameters use `z.coerce.number()` with range constraints.
+
+For vulnerability reporting and the supported-versions policy, see [`SECURITY.md`](../SECURITY.md) — deliberately not duplicated here.
+
+---
+
+[← Docs index](index.md)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,54 @@
+<!-- Split out of README.md in v3.24.0 (vikunja#683). The README had reached 905 lines / 70KB, at which point it was a reference manual pretending to be an introduction. -->
+
+# Tools
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `search` | Search via SearXNG with local reranking. Fetches a wider result pool, reranks by relevance, returns top N. SearXNG's native direct answers, infoboxes, spelling corrections, and related suggestions are surfaced above the list and in `structuredContent`. | `query`, `num_results` (1–20), `category`, `time_range`, `domain_profile`, `expand`, `language`, `engines`, `site`, `min_score` |
+| `search_and_fetch` | Search, rerank, then fetch full content of the top result(s) using the fetch cascade (Firecrawl → Crawl4AI → raw HTTP). | `query`, `category`, `time_range`, `fetch_count` (1–3), `domain_profile`, `expand`, `language`, `engines`, `site`, `min_score` |
+| `search_and_summarize` | Search, fetch top results, then synthesize a summary with citations via Ollama (`OLLAMA_SUMMARIZE_MODEL`). Falls back to raw fetched content if Ollama is unavailable. | `query`, `fetch_count` (1–5), `category`, `time_range`, `domain_profile`, `expand`, `language`, `engines`, `site`, `min_score` |
+| `fetch_url` | Fetch and extract readable markdown from any public URL. GitHub hosts take the GitHub fast path; YouTube video URLs return the transcript and Reddit thread URLs return post+comments (both opt-in via robots, see below); all others use the fetch cascade (Firecrawl → Crawl4AI → raw HTTP). Trimmed to a token budget (default ~8,000 chars). | `url`, `domain_profile`, `max_tokens`, `target_selector`, `wait_for_selector` |
+| `crawl_site` | Crawl an entire site and return a manifest of URL/title/snippet for each page. Tries Firecrawl crawl first, falls back to sitemap parsing, then optional BFS. Full page content is cached in Valkey so follow-up `fetch_url` calls are zero-cost. | `url`, `max_pages` (default: `CRAWL_MAX_PAGES_DEFAULT`), `bfs` (bool, opt-in BFS) |
+| `clear_cache` | Purge the search cache, fetch cache, crawl manifest cache, or all. Useful when researching fast-moving topics where cached results may be stale. | `target` (`search`, `fetch`, `crawl`, `all`) |
+| `domain_stats` | Read-only view of the [domain capability database](architecture.md#domain-capability-database). With `hostname`: one domain's per-tier success rates and capability flags. Without: an aggregate across all tracked domains (per-tier success, worst failing domains, seen-but-never-fetched count). Returns MCP structured output (`structuredContent`) for programmatic thresholding. | `hostname` (optional) |
+
+## Parameters
+
+**`category`** — `general` (default), `news`, `it`, `science`
+
+**`time_range`** — `day`, `week`, `month`, `year` — limits results by publication date. Omit for all-time results.
+
+**`fetch_count`** — number of top reranked results to fetch full content for (default `1`, max `3` for `search_and_fetch`; default `3`, max `5` for `search_and_summarize`).
+
+**`domain_profile`** — apply a named domain filter profile: `homelab` (surfaces self-hosted/Linux docs) or `dev` (surfaces Stack Overflow, MDN, npm). Omit for default filters.
+
+**`expand`** — when `true`, rewrites the query via Ollama (`OLLAMA_EXPAND_MODEL`) before searching to improve recall. Requires `OLLAMA_URL`. Defaults to the `EXPAND_QUERIES` env var value.
+
+**`language`** — BCP-47 language code (e.g. `en`, `de`) or `all` to restrict to a specific language. Omit to use the SearXNG instance default. Available on `search`, `search_and_fetch`, and `search_and_summarize`.
+
+**`engines`** — comma-separated SearXNG engine names to restrict the search to (e.g. `google,duckduckgo`). Forwarded verbatim; unknown/disabled engines degrade to fewer results rather than erroring. Available on all three search tools.
+
+**`site`** — restrict results to one domain or a list (e.g. `github.com` or `["github.com", "gitlab.com"]`). Applied best-effort as a `site:` query operator — most engines (Google, Bing, DDG, Brave) honor it, some ignore it. Available on all three search tools.
+
+**`max_tokens`** (`fetch_url`) — approximate token budget for returned content (chars ≈ tokens × 4). Omit for the ~2,000-token / 8,000-char default; max 10,000 tokens.
+
+**`target_selector`** (`fetch_url`) — CSS selector to scope extraction to a specific element (e.g. `article`, `main .content`). Honored natively by Firecrawl/Crawl4AI and applied client-side on the raw-HTTP tier; ignored by fast paths and when it matches nothing.
+
+**`wait_for_selector`** (`fetch_url`) — CSS selector to wait for before extracting, for JS-rendered pages. Honored by the rendering tiers (Firecrawl/Crawl4AI); ignored on raw HTTP (no JS).
+
+# GitHub URLs
+
+GitHub URLs are handled natively without Firecrawl. `githubFetch` dispatches on hostname:
+
+- **Repo root** (`github.com/owner/repo`) — fetches the README via the GitHub API
+- **File blob** (`github.com/owner/repo/blob/branch/path/to/file`) — rewrites to and fetches raw content from `raw.githubusercontent.com`
+- **Raw file** (`raw.githubusercontent.com/...`) — fetched directly as-is
+- **API** (`api.github.com/...`) — response decoded (base64 `content` fields) or pretty-printed as JSON
+
+Direct `raw.githubusercontent.com` and `api.github.com` URLs previously matched only `github.com` and fell through to the HTML-scraping tier cascade, which cannot render a raw text file or bare JSON response — they failed 100% of the time. They now take the GitHub fast path.
+
+Unauthenticated requests are rate-limited to 60/hour. Set `GITHUB_TOKEN` to raise this to 5,000/hour.
+
+---
+
+[← Docs index](index.md) · [Architecture](architecture.md)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tadmstr/searxng-mcp",
   "version": "3.23.0",
-  "description": "MCP server for SearXNG — private web search for Claude Code",
+  "description": "MCP server for SearXNG \u2014 private web search for Claude Code",
   "main": "build/src/index.js",
   "bin": {
     "searxng-mcp": "build/src/index.js"
@@ -64,6 +64,7 @@
     "@vitest/coverage-v8": "^4.1.10",
     "ajv": "^8.20.0",
     "typescript": "^5.9.3",
+    "vite": "^8.0.16",
     "vitest": "^4.1.10"
   },
   "pnpm": {
@@ -73,7 +74,8 @@
       "@hono/node-server": ">=2.0.10",
       "fast-uri": ">=4.1.3",
       "ip-address": ">=10.3.1",
-      "qs": ">=6.16.0"
+      "qs": ">=6.16.0",
+      "vite": ">=8.0.16"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tadmstr/searxng-mcp",
-  "version": "3.23.0",
+  "version": "3.24.0",
   "description": "MCP server for SearXNG \u2014 private web search for Claude Code",
   "main": "build/src/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "files": [
     "build/src/",
     "README.md",
+    "docs/",
     "LICENSE",
     "CHANGELOG.md"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   fast-uri: '>=4.1.3'
   ip-address: '>=10.3.1'
   qs: '>=6.16.0'
+  vite: '>=8.0.16'
 
 importers:
 
@@ -80,9 +81,12 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vite:
+        specifier: '>=8.0.16'
+        version: 8.2.2(@types/node@22.20.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.0.7(@types/node@22.20.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.2(@types/node@22.20.1)(yaml@2.9.0))
 
 packages:
 
@@ -219,15 +223,6 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@emnapi/core@1.9.1':
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
-
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
-
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
-
   '@exodus/bytes@1.15.1':
     resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -281,13 +276,6 @@ packages:
   '@mozilla/readability@0.6.0':
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
-
-  '@napi-rs/wasm-runtime@1.2.3':
-    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
-      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
 
   '@nats-io/nats-core@3.4.0':
     resolution: {integrity: sha512-QMDM86EUNm+wudlKC67HLar/KHHQUvJGLfb4jbahje3pUk3K9afeck9fwsxBZF0eUFox6T/TA6m/t+lQqf+QsQ==}
@@ -481,8 +469,8 @@ packages:
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
 
-  '@oxc-project/types@0.123.0':
-    resolution: {integrity: sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==}
+  '@oxc-project/types@0.148.0':
+    resolution: {integrity: sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -511,109 +499,107 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.13':
-    resolution: {integrity: sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==}
+  '@rolldown/binding-android-arm-eabi@1.2.7':
+    resolution: {integrity: sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.7':
+    resolution: {integrity: sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
-    resolution: {integrity: sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==}
+  '@rolldown/binding-darwin-arm64@1.2.7':
+    resolution: {integrity: sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
-    resolution: {integrity: sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==}
+  '@rolldown/binding-darwin-x64@1.2.7':
+    resolution: {integrity: sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
-    resolution: {integrity: sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==}
+  '@rolldown/binding-freebsd-x64@1.2.7':
+    resolution: {integrity: sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
-    resolution: {integrity: sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.7':
+    resolution: {integrity: sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
-    resolution: {integrity: sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.7':
+    resolution: {integrity: sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
-    resolution: {integrity: sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==}
+  '@rolldown/binding-linux-arm64-musl@1.2.7':
+    resolution: {integrity: sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
-    resolution: {integrity: sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.7':
+    resolution: {integrity: sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
-    resolution: {integrity: sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.7':
+    resolution: {integrity: sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
-    resolution: {integrity: sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==}
+  '@rolldown/binding-linux-x64-gnu@1.2.7':
+    resolution: {integrity: sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
-    resolution: {integrity: sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==}
+  '@rolldown/binding-linux-x64-musl@1.2.7':
+    resolution: {integrity: sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
-    resolution: {integrity: sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==}
+  '@rolldown/binding-openharmony-arm64@1.2.7':
+    resolution: {integrity: sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
-    resolution: {integrity: sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
-    resolution: {integrity: sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.7':
+    resolution: {integrity: sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
-    resolution: {integrity: sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==}
+  '@rolldown/binding-win32-x64-msvc@1.2.7':
+    resolution: {integrity: sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.13':
-    resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@tybys/wasm-util@0.10.3':
-    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -649,7 +635,7 @@ packages:
     resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=8.0.16'
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1227,8 +1213,8 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  postcss@8.5.27:
-    resolution: {integrity: sha512-79Iho8QeYyooJ8e9lCRyTVlyTAkS/kXBYKff6TMzS3kEWGQ8Ds5UEtXpGrSUDLUWok6QTvxeYy0GO8fopHnaSA==}
+  postcss@8.5.28:
+    resolution: {integrity: sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==}
     engines: {node: ^10 || ^12 || >=14}
 
   protobufjs@7.6.5:
@@ -1279,8 +1265,8 @@ packages:
     resolution: {integrity: sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==}
     engines: {node: '>=10.0.0'}
 
-  rolldown@1.0.0-rc.13:
-    resolution: {integrity: sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==}
+  rolldown@1.2.7:
+    resolution: {integrity: sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1407,9 +1393,6 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
   tweetnacl@1.0.3:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
@@ -1440,13 +1423,13 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite@8.0.7:
-    resolution: {integrity: sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==}
+  vite@8.2.2:
+    resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.0
+      '@vitejs/devtools': ^0.4.0 || ^0.5.0
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -1499,7 +1482,7 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=8.0.16'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -1693,22 +1676,6 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@emnapi/core@1.9.1':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.0
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.9.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@exodus/bytes@1.15.1': {}
 
   '@grpc/grpc-js@1.14.4':
@@ -1763,13 +1730,6 @@ snapshots:
       - supports-color
 
   '@mozilla/readability@0.6.0': {}
-
-  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
-    dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
-      '@tybys/wasm-util': 0.10.3
-    optional: true
 
   '@nats-io/nats-core@3.4.0':
     dependencies:
@@ -2031,7 +1991,7 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
-  '@oxc-project/types@0.123.0': {}
+  '@oxc-project/types@0.148.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -2053,63 +2013,54 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.13':
+  '@rolldown/binding-android-arm-eabi@1.2.7':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
+  '@rolldown/binding-android-arm64@1.2.7':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
+  '@rolldown/binding-darwin-arm64@1.2.7':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
+  '@rolldown/binding-darwin-x64@1.2.7':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
+  '@rolldown/binding-freebsd-x64@1.2.7':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.7':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
+  '@rolldown/binding-linux-arm64-gnu@1.2.7':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
+  '@rolldown/binding-linux-arm64-musl@1.2.7':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.7':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
+  '@rolldown/binding-linux-s390x-gnu@1.2.7':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
+  '@rolldown/binding-linux-x64-gnu@1.2.7':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
+  '@rolldown/binding-linux-x64-musl@1.2.7':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
-    dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
-      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+  '@rolldown/binding-openharmony-arm64@1.2.7':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
+  '@rolldown/binding-win32-arm64-msvc@1.2.7':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
+  '@rolldown/binding-win32-x64-msvc@1.2.7':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.13': {}
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
-
-  '@tybys/wasm-util@0.10.3':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@types/chai@5.2.3':
     dependencies:
@@ -2145,7 +2096,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.0.7(@types/node@22.20.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.2(@types/node@22.20.1)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -2156,13 +2107,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.0.7(@types/node@22.20.1)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.2.2(@types/node@22.20.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.7(@types/node@22.20.1)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@22.20.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -2703,7 +2654,7 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  postcss@8.5.27:
+  postcss@8.5.28:
     dependencies:
       nanoid: 3.3.18
       picocolors: 1.1.1
@@ -2763,26 +2714,26 @@ snapshots:
 
   robots-parser@3.0.1: {}
 
-  rolldown@1.0.0-rc.13:
+  rolldown@1.2.7:
     dependencies:
-      '@oxc-project/types': 0.123.0
-      '@rolldown/pluginutils': 1.0.0-rc.13
+      '@oxc-project/types': 0.148.0
+      '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.13
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.13
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.13
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.13
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.13
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.13
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.13
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.13
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.13
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.13
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.13
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.13
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.13
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.13
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.13
+      '@rolldown/binding-android-arm-eabi': 1.2.7
+      '@rolldown/binding-android-arm64': 1.2.7
+      '@rolldown/binding-darwin-arm64': 1.2.7
+      '@rolldown/binding-darwin-x64': 1.2.7
+      '@rolldown/binding-freebsd-x64': 1.2.7
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.7
+      '@rolldown/binding-linux-arm64-gnu': 1.2.7
+      '@rolldown/binding-linux-arm64-musl': 1.2.7
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.7
+      '@rolldown/binding-linux-s390x-gnu': 1.2.7
+      '@rolldown/binding-linux-x64-gnu': 1.2.7
+      '@rolldown/binding-linux-x64-musl': 1.2.7
+      '@rolldown/binding-openharmony-arm64': 1.2.7
+      '@rolldown/binding-win32-arm64-msvc': 1.2.7
+      '@rolldown/binding-win32-x64-msvc': 1.2.7
 
   router@2.2.0:
     dependencies:
@@ -2922,9 +2873,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  tslib@2.8.1:
-    optional: true
-
   tweetnacl@1.0.3: {}
 
   type-is@2.1.0:
@@ -2945,22 +2893,22 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.7(@types/node@22.20.1)(yaml@2.9.0):
+  vite@8.2.2(@types/node@22.20.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.7
-      postcss: 8.5.27
-      rolldown: 1.0.0-rc.13
+      postcss: 8.5.28
+      rolldown: 1.2.7
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.20.1
       fsevents: 2.3.3
       yaml: 2.9.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.0.7(@types/node@22.20.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.2(@types/node@22.20.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.0.7(@types/node@22.20.1)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.2.2(@types/node@22.20.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -2977,7 +2925,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.7(@types/node@22.20.1)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@22.20.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1

--- a/src/domain-stats.ts
+++ b/src/domain-stats.ts
@@ -13,6 +13,7 @@ import {
   currentWindowStat,
   type DomainRecord,
   parseDomainRecord,
+  SCHEMA_VERSION,
   TIER_SLOT_KEYS,
   type TierSlotKey,
   type TierStat,
@@ -90,7 +91,32 @@ export interface FailingDomain {
   success_rate: number;
 }
 
+/**
+ * The measurement period an aggregate actually covers.
+ *
+ * Distinct from `TIER_STATS_WINDOW_MS`, which is a TTL ceiling — the age at
+ * which counts are discarded — not a period anyone measured. The rendered
+ * header said "30d window" unconditionally, so an aggregate built minutes after
+ * a schema reset presented as thirty days of evidence (vikunja#686).
+ */
+export interface AggregateWindow {
+  // Epoch ms of the oldest counting window contributing to this aggregate, or
+  // null when nothing has been counted yet.
+  oldest_sample_ms: number | null;
+  // How long that window has actually been open. Null when there is no sample.
+  elapsed_ms: number | null;
+  // The TTL ceiling counts are discarded at. Present so a caller can tell how
+  // far the real window is from the maximum without hardcoding it.
+  ttl_ceiling_ms: number;
+}
+
 export interface DomainAggregate {
+  // The record schema every contributing record is on. Every schema bump
+  // deliberately discards prior records (see domain-db.ts) — surfacing the
+  // version is what lets a reader recognise a post-reset aggregate without
+  // going to the snapshot directory.
+  schema_version: number;
+  window: AggregateWindow;
   domains_tracked: number;
   // Domains seen in search results but never actually fetched (no tier
   // attempts) — candidates the cascade has never exercised.
@@ -104,6 +130,45 @@ export interface DomainAggregate {
   top_failing: FailingDomain[];
   // True when enumeration hit the key cap — the aggregate covers a subset.
   truncated: boolean;
+}
+
+/**
+ * Below this many attempts, render the count instead of a percentage.
+ *
+ * Five, because at n=4 a single outcome moves the rate by 25 points and at n=5
+ * by 20 — so any percentage drawn from fewer than five samples implies a
+ * precision the sample cannot support. "100% ok (1/1)" and "0% ok (0/1)" are the
+ * same amount of evidence about a domain, and rendering them as percentages
+ * invites a reader to treat them as opposite findings. `no data` was already
+ * distinguished from a number; *barely any data* was not (vikunja#686).
+ *
+ * Deliberately not the same constant as MIN_ATTEMPTS_FOR_DECISION in routing.ts,
+ * which is 10 and governs whether to *act* on a rate by skipping a tier. Acting
+ * needs more evidence than displaying, and tying the two would mean a change to
+ * one silently retuning the other.
+ */
+export const MIN_ATTEMPTS_FOR_RATE = 5;
+
+/**
+ * How a tier's success should be shown: a rate, a low-confidence count, or
+ * nothing at all. Shared by the per-domain and aggregate renderings so the two
+ * cannot disagree about what counts as enough evidence.
+ */
+function renderRate(ok: number, attempts: number): string {
+  if (attempts === 0) return "no data";
+  if (attempts < MIN_ATTEMPTS_FOR_RATE) {
+    return `insufficient data (${ok}/${attempts})`;
+  }
+  return `${Math.round((ok / attempts) * 100)}% ok (${ok}/${attempts})`;
+}
+
+/** Compact human duration for an elapsed window — "14h", "3d", "45m". */
+function humanDuration(ms: number): string {
+  const minutes = Math.floor(ms / 60000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
 }
 
 function round2(value: number): number {
@@ -179,6 +244,11 @@ export function aggregateDomainStats(
   ) as Record<TierSlotName, TierAggregate>;
   let seenNeverFetched = 0;
   const failing: FailingDomain[] = [];
+  // Oldest counting window across every contributing stat. Only windows that
+  // actually counted something are considered: a zeroed slot's window_start is
+  // bookkeeping, not evidence, and letting it in would report a measurement
+  // period longer than anything was measured over.
+  let oldestSampleMs: number | null = null;
 
   for (const record of records) {
     let domainAttempts = 0;
@@ -197,6 +267,12 @@ export function aggregateDomainStats(
       agg.fail += stat.fail;
       domainAttempts += stat.attempts;
       domainOk += stat.ok;
+      if (
+        stat.attempts > 0 &&
+        (oldestSampleMs === null || stat.window_start_ms < oldestSampleMs)
+      ) {
+        oldestSampleMs = stat.window_start_ms;
+      }
     }
 
     if (domainAttempts === 0) {
@@ -222,6 +298,12 @@ export function aggregateDomainStats(
   failing.sort((a, b) => b.attempts - a.attempts);
 
   return {
+    schema_version: SCHEMA_VERSION,
+    window: {
+      oldest_sample_ms: oldestSampleMs,
+      elapsed_ms: oldestSampleMs === null ? null : now - oldestSampleMs,
+      ttl_ceiling_ms: WINDOW_MS,
+    },
     domains_tracked: records.length,
     seen_never_fetched: seenNeverFetched,
     tiers,
@@ -293,10 +375,7 @@ export function summarizeDomainRecord(
 function tierLine(label: string, raw: TierStat, now: number): string {
   const stat = currentWindowStat(raw, now);
   const expired = stat !== raw;
-  const successRate =
-    stat.attempts > 0
-      ? `${Math.round((stat.ok / stat.attempts) * 100)}% ok (${stat.ok}/${stat.attempts})`
-      : "no data";
+  const successRate = renderRate(stat.ok, stat.attempts);
   const daysLeft = Math.max(
     0,
     Math.round((WINDOW_MS - (now - stat.window_start_ms)) / 86400000),
@@ -349,6 +428,19 @@ export function formatDomainRecord(
 }
 
 /**
+ * Render the window an aggregate actually covers, with the TTL ceiling named
+ * separately so the two are never confused for each other again.
+ */
+function describeWindow(window: AggregateWindow): string {
+  const ceiling = humanDuration(window.ttl_ceiling_ms);
+  if (window.oldest_sample_ms === null || window.elapsed_ms === null) {
+    return `no samples yet, ${ceiling} ceiling`;
+  }
+  const since = new Date(window.oldest_sample_ms).toISOString();
+  return `window ${humanDuration(window.elapsed_ms)} since ${since}, ${ceiling} ceiling`;
+}
+
+/**
  * Human-readable rendering of an aggregate across the whole domain-db. Shared by
  * the domain_stats tool's text `content` and available to the maintenance job.
  */
@@ -357,14 +449,15 @@ export function formatDomainAggregate(agg: DomainAggregate): string {
     `domains tracked: ${agg.domains_tracked}${agg.truncated ? " (truncated — scan cap hit)" : ""}`,
     `seen in search but never fetched: ${agg.seen_never_fetched}`,
     "",
-    "--- per-tier success (all domains, 30d window) ---",
+    // The measured period, not the TTL ceiling. This header read "30d window"
+    // unconditionally, so an aggregate taken an hour after a schema reset
+    // presented as a month of evidence — which is how the 6->7 reset was read
+    // as a bug twice (vikunja#686). The schema version is here for the same
+    // reason: it is the thing that explains a suddenly-empty database.
+    `--- per-tier success (all domains, ${describeWindow(agg.window)}, schema ${agg.schema_version}) ---`,
   ];
   for (const [slot, ta] of Object.entries(agg.tiers)) {
-    const rate =
-      ta.success_rate === null
-        ? "no data"
-        : `${Math.round(ta.success_rate * 100)}% ok (${ta.ok}/${ta.attempts})`;
-    lines.push(`  ${slot.padEnd(7)}: ${rate}`);
+    lines.push(`  ${slot.padEnd(7)}: ${renderRate(ta.ok, ta.attempts)}`);
   }
 
   const more =

--- a/src/fetch-utils.ts
+++ b/src/fetch-utils.ts
@@ -90,14 +90,6 @@ export async function safeFetch(
   return fetch(url, opts);
 }
 
-export function isPdfUrl(url: string): boolean {
-  try {
-    return new URL(url).pathname.toLowerCase().endsWith(".pdf");
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Read a response body as text, stopping at `limit` bytes and cancelling the
  * rest of the stream. Use this for every body read of third-party content:

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -96,11 +96,29 @@ function applyPostExtract(
  * flag it sets is a local in fetchPage, so it is request-scoped by
  * construction — no shared or ambient state.
  */
+/**
+ * Why one tier did not produce content.
+ *
+ * `runTier` collapses every failure to `null`, which is right for the cascade —
+ * it just moves on — but wrong for the caller that has to explain the outcome
+ * once every tier is exhausted. The whole of vikunja#682 hid behind exactly
+ * that collapse: a null from one tier was reported as one specific cause
+ * ("CRAWL4AI_URL not configured") on a deployment where that cause was false,
+ * which sent an investigator to check configuration that was already correct.
+ * Carrying the reason out alongside the null is what stops the next such
+ * message from being invented.
+ */
+interface TierOutcome {
+  tier: TierName;
+  reason: string;
+}
+
 async function runTier<T extends TierResult | null>(
   tier: TierName,
   url: string,
   fn: () => Promise<T>,
   onChallenge?: (signal: ChallengeSignal) => void,
+  onOutcome?: (outcome: TierOutcome) => void,
 ): Promise<T> {
   const t0 = Date.now();
   try {
@@ -115,6 +133,7 @@ async function runTier<T extends TierResult | null>(
       recordHistogram("fetch", latency_ms / 1000, { tier, outcome: "miss" });
       events.fetchTierMiss({ url, tier, reason: "empty_result", latency_ms });
       recordTierAttempt(url, tier, "miss", "empty_result").catch(() => {});
+      onOutcome?.({ tier, reason: "attempted, no content" });
     }
     return out;
   } catch (err) {
@@ -137,6 +156,7 @@ async function runTier<T extends TierResult | null>(
         () => {},
       );
       onChallenge?.(err.signal);
+      onOutcome?.({ tier, reason: CHALLENGE_MISS_REASON });
       return null as T;
     }
     const reason = err instanceof Error ? err.message : "error";
@@ -144,6 +164,7 @@ async function runTier<T extends TierResult | null>(
     recordHistogram("fetch", latency_ms / 1000, { tier, outcome: "error" });
     events.fetchTierMiss({ url, tier, reason, latency_ms });
     recordTierAttempt(url, tier, "error", reason).catch(() => {});
+    onOutcome?.({ tier, reason });
     return null as T;
   }
 }
@@ -481,6 +502,16 @@ export async function fetchPage(
       // Run tier cascade and side-channel raw-HTML metadata fetch in parallel.
       const metadataHtmlPromise = fetchRawHtmlForMetadata(url);
 
+      // Why each tier produced nothing, in cascade order. Seeded with the
+      // tiers that never ran, so "skipped because unconfigured" and "ran and
+      // came back empty" stay distinguishable in the final error rather than
+      // collapsing into one unexplained failure (vikunja#682).
+      const outcomes: TierOutcome[] = skipDecisions.map((d) => ({
+        tier: TIER_NAME[d.tier],
+        reason: `skipped (${d.reason})`,
+      }));
+      const noteOutcome = (o: TierOutcome) => outcomes.push(o);
+
       let fetched: TierResult | null = null;
       for (const tier of activeTiers) {
         fetched = await runTier(
@@ -488,6 +519,7 @@ export async function fetchPage(
           url,
           () => tier.fetch(url, storeChars, preferFit, tuning),
           onChallenge,
+          noteOutcome,
         );
         if (fetched) {
           tierServed = tier.name;
@@ -516,8 +548,12 @@ export async function fetchPage(
       // wayback exactly as a tier miss does.
       if (!fetched && challengeDetected) {
         console.error(`[searxng-mcp] fetch solver_byparr attempt url=${url}`);
-        fetched = await runTier("solver_byparr", url, () =>
-          solverFetch(url, storeChars, tuning),
+        fetched = await runTier(
+          "solver_byparr",
+          url,
+          () => solverFetch(url, storeChars, tuning),
+          undefined,
+          noteOutcome,
         );
         if (fetched) {
           tierServed = "solver_byparr";
@@ -529,8 +565,12 @@ export async function fetchPage(
 
       if (!fetched && WAYBACK_ENABLED) {
         console.error(`[searxng-mcp] fetch tier4_wayback attempt url=${url}`);
-        fetched = await runTier("tier4_wayback", url, () =>
-          waybackFetch(url, storeChars),
+        fetched = await runTier(
+          "tier4_wayback",
+          url,
+          () => waybackFetch(url, storeChars),
+          undefined,
+          noteOutcome,
         );
         if (fetched) {
           tierServed = "tier4_wayback";
@@ -541,13 +581,21 @@ export async function fetchPage(
       }
 
       if (!fetched) {
+        // Name every tier and why. "All fetch tiers failed" on its own is the
+        // shape of error that hid #682 for weeks: it is equally consistent with
+        // nothing being configured, with a backend being down, and with the
+        // page genuinely having no content, so it sends the reader nowhere.
+        const detail = outcomes.map((o) => `${o.tier}: ${o.reason}`).join("; ");
+        const message = detail
+          ? `All fetch tiers failed — ${detail}`
+          : "All fetch tiers failed";
         events.error({
           stage: "fetch",
           url,
           error_type: "all_tiers_failed",
-          message: "All fetch tiers failed",
+          message,
         });
-        throw new Error("All fetch tiers failed");
+        throw new Error(message);
       }
 
       const tierFetched: TierResult = fetched;

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -18,7 +18,6 @@ import { postExtract } from "./extractors/post-extract.js";
 import {
   assertPublicUrl,
   type FetchTuning,
-  isPdfUrl,
   type TierResult,
 } from "./fetch-utils.js";
 import { histerFetch } from "./hister.js";
@@ -33,7 +32,6 @@ import {
   fetchRawHtmlForMetadata,
   githubFetch,
   isGithubUrl,
-  tier2 as pdfTier,
   rawFetch,
   solverFetch,
   waybackFetch,
@@ -420,31 +418,16 @@ export async function fetchPage(
       // resolution (surfaces to the caller as a fetch error).
       await assertResolvedPublic(url);
 
-      // PDF fast path — Firecrawl can't extract PDF text; route directly to tier2.
-      if (isPdfUrl(url)) {
-        const pdfResult = await runTier("tier2_crawl4ai", url, () =>
-          pdfTier.fetch(url, storeChars, preferFit),
-        );
-        if (!pdfResult) {
-          throw new Error(
-            "PDF extraction requires Crawl4AI (CRAWL4AI_URL not configured)",
-          );
-        }
-        const persisted = {
-          title: pdfResult.title,
-          url: pdfResult.url,
-          text: pdfResult.text,
-        };
-        await cacheSet(key, JSON.stringify(persisted), FETCH_CACHE_TTL_SECONDS);
-        events.fetchCompleted({
-          url,
-          tier_served: "tier2_crawl4ai",
-          title: pdfResult.title,
-          text_len: pdfResult.text.length,
-          latency_ms: Date.now() - t_total,
-        });
-        return { ...persisted, text: persisted.text.slice(0, maxChars) };
-      }
+      // No PDF fast path. There used to be one here, routing every `.pdf` URL
+      // straight to tier 2 on the strength of "Firecrawl can't extract PDF
+      // text". That was true of trieve/firecrawl v0.0.55 and is false of v2,
+      // which extracts PDFs natively (see FirecrawlCapabilities.pdf). Worse,
+      // the tier it diverted to cannot do the job at all: Crawl4AI renders the
+      // PDF in a browser, finds no text nodes, and misfires its anti-bot
+      // heuristic, and the resulting null was reported as "CRAWL4AI_URL not
+      // configured" on containers where it plainly was. PDFs now take the
+      // ordinary cascade, so tier 1 serves them and a v1 backend degrades
+      // through to the message in tiers/raw.ts (vikunja#682).
 
       // Content-type fast path — a JSON/XML/YAML/CSV/plain-text endpoint has
       // nothing for a headless browser to render. Firecrawl returns empty

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -113,6 +113,28 @@ interface TierOutcome {
   reason: string;
 }
 
+/**
+ * Cap on a single tier's failure reason in the surfaced error.
+ *
+ * Most reasons are short and ours — "attempted, no content", a status code. But
+ * one is neither: `data.error` from Firecrawl is upstream-controlled text of
+ * unbounded length, and this is the first change that relays a tier's own error
+ * to the caller rather than swallowing it. An error message is not a transport
+ * for an arbitrary upstream payload.
+ *
+ * Only length is bounded, not content. Every reason this can carry is already
+ * topology-safe by construction: SsrfBlockedError deliberately keeps the
+ * resolved address off its message, raw.ts's redirect throw deliberately omits
+ * the Location header, and the tier errors carry status codes rather than URLs.
+ */
+const MAX_TIER_REASON_CHARS = 200;
+
+function boundReason(reason: string): string {
+  return reason.length > MAX_TIER_REASON_CHARS
+    ? `${reason.slice(0, MAX_TIER_REASON_CHARS)}…`
+    : reason;
+}
+
 async function runTier<T extends TierResult | null>(
   tier: TierName,
   url: string,
@@ -164,7 +186,7 @@ async function runTier<T extends TierResult | null>(
     recordHistogram("fetch", latency_ms / 1000, { tier, outcome: "error" });
     events.fetchTierMiss({ url, tier, reason, latency_ms });
     recordTierAttempt(url, tier, "error", reason).catch(() => {});
-    onOutcome?.({ tier, reason });
+    onOutcome?.({ tier, reason: boundReason(reason) });
     return null as T;
   }
 }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -127,6 +127,18 @@ interface TierOutcome {
  * resolved address off its message, raw.ts's redirect throw deliberately omits
  * the Location header, and the tier errors carry status codes rather than URLs.
  */
+// SECURITY[accepted]: relaying Firecrawl's upstream `data.error` verbatim, bounded
+// to 200 chars, is accepted rather than classified down to a canned reason. This
+// server is loopback-only and its callers are forge agents that already hold the
+// requested URL, so the text discloses nothing they do not have; every other
+// reason this path can carry is topology-safe by construction (see boundReason).
+// Dropping the upstream string would claw back the diagnostic value this whole
+// change exists to add — "All fetch tiers failed" telling an investigator nothing
+// is what cost weeks on vikunja#682. Audit: 2026-09-06/searxng-mcp-fix-pass-2026-09,
+// finding OE-02 (Low). Decision: Ted, 2026-09-06.
+// SECURITY[control]: length bound below; content needs no filter because
+// SsrfBlockedError omits the resolved address and raw.ts's redirect throw omits
+// Location, both deliberately.
 const MAX_TIER_REASON_CHARS = 200;
 
 function boundReason(reason: string): string {
@@ -460,6 +472,17 @@ export async function fetchPage(
       // catches literal private IPs. Throws SsrfBlockedError on a private
       // resolution (surfaces to the caller as a fetch error).
       await assertResolvedPublic(url);
+
+      // SECURITY[accepted]: PDF URLs now take this path to tier 1 rather than
+      // being diverted earlier, so they share tier 1's pre-existing SSRF-10
+      // exposure — Firecrawl and Crawl4AI resolve and connect in their own
+      // processes, so the pre-check above narrows but cannot fully close the
+      // DNS-rebinding TOCTOU window for them. No new code-level gap: the gap is
+      // unchanged, only the set of URLs traversing it grew. Audit:
+      // 2026-09-06/searxng-mcp-fix-pass-2026-09, finding SSRF-10 (Low) —
+      // auditor's own disposition was "no action required from this build".
+      // SECURITY[control]: assertResolvedPublic runs once here, before any tier
+      // dispatch, for every URL including PDFs.
 
       // No PDF fast path. There used to be one here, routing every `.pdf` URL
       // straight to tier 2 on the strength of "Firecrawl can't extract PDF

--- a/src/firecrawl-api.ts
+++ b/src/firecrawl-api.ts
@@ -25,30 +25,94 @@ export function firecrawlEndpoint(
 }
 
 /**
- * Whether the configured backend accepts an `actions` array.
+ * Everything that differs between the two backends, in one place.
  *
- * Only under v1. Upstream self-hosted Firecrawl implements `actions` in
- * Fire-engine alone, which is closed-source and cloud-only — every engine
- * available to a self-host deployment (`fetch`, `playwright`, `pdf`,
- * `document`) reports `actions: false`. Sending one returns HTTP 400
- * `SCRAPE_ACTIONS_NOT_SUPPORTED` and fails the whole request, verified live
- * against firecrawl 2.11.162 on forge. So this is not a graceful-degradation
- * check: sending `actions` under v2 turns every `wait_for_selector` call into a
- * hard tier-1 miss.
+ * These started as independent `firecrawlSupportsX` predicates and reached four
+ * entries, at which point answering "what does v1 actually do?" meant grepping
+ * four functions and mentally transposing them. The table answers that question
+ * directly; the predicates below are thin readers, kept for their call sites and
+ * their existing tests.
+ *
+ * Add a row here rather than a fifth predicate elsewhere.
  */
+export interface FirecrawlCapabilities {
+  /**
+   * Whether the backend accepts an `actions` array.
+   *
+   * Only under v1. Upstream self-hosted Firecrawl implements `actions` in
+   * Fire-engine alone, which is closed-source and cloud-only — every engine
+   * available to a self-host deployment (`fetch`, `playwright`, `pdf`,
+   * `document`) reports `actions: false`. Sending one returns HTTP 400
+   * `SCRAPE_ACTIONS_NOT_SUPPORTED` and fails the whole request, verified live
+   * against firecrawl 2.11.162 on forge. So this is not a graceful-degradation
+   * check: sending `actions` under v2 turns every `wait_for_selector` call into
+   * a hard tier-1 miss.
+   */
+  actions: boolean;
+  /**
+   * Whether `/map` exists. v2 only — the legacy firecrawl-simple backend has no
+   * map endpoint at all, so `crawl_site` must skip straight to its sitemap path
+   * rather than probe and 404.
+   */
+  map: boolean;
+  /**
+   * Whether the backend extracts text from PDFs.
+   *
+   * v2 does, natively, with no `parsers` option needed — verified live
+   * 2026-09-05 against firecrawl 2.11.162: `POST /v2/scrape` on RFC 9110's PDF
+   * returned 475,850 characters of clean markdown from the same `formats` array
+   * an ordinary HTML scrape sends. v1 (trieve/firecrawl 0.0.55) cannot, which is
+   * why this is a capability rather than an assumption — see `tiers/raw.ts` for
+   * the failure a v1 deployment gets.
+   */
+  pdf: boolean;
+  /**
+   * The name of the HTML format in the `formats` array, and of the matching
+   * response field.
+   *
+   * v1's enum is `markdown | rawHtml | screenshot` and it rejects `html` with a
+   * 400 that fails the *whole* scrape — so this is not cosmetic. v2 renamed it
+   * to `html`. Request and response use the same spelling on both versions, so
+   * one value keys both sides.
+   */
+  htmlFormat: "html" | "rawHtml";
+}
+
+const CAPABILITIES: Record<FirecrawlApiVersion, FirecrawlCapabilities> = {
+  v1: { actions: true, map: false, pdf: false, htmlFormat: "rawHtml" },
+  v2: { actions: false, map: true, pdf: true, htmlFormat: "html" },
+};
+
+export function firecrawlCapabilities(
+  version: FirecrawlApiVersion = FIRECRAWL_API_VERSION,
+): FirecrawlCapabilities {
+  return CAPABILITIES[version];
+}
+
+/** See {@link FirecrawlCapabilities.actions}. */
 export function firecrawlSupportsActions(
   version: FirecrawlApiVersion = FIRECRAWL_API_VERSION,
 ): boolean {
-  return version === "v1";
+  return firecrawlCapabilities(version).actions;
 }
 
-/**
- * Whether `/map` exists on the configured backend. v2 only — the legacy
- * firecrawl-simple backend has no map endpoint at all, so `crawl_site` must
- * skip straight to its sitemap path rather than probe and 404.
- */
+/** See {@link FirecrawlCapabilities.map}. */
 export function firecrawlSupportsMap(
   version: FirecrawlApiVersion = FIRECRAWL_API_VERSION,
 ): boolean {
-  return version === "v2";
+  return firecrawlCapabilities(version).map;
+}
+
+/** See {@link FirecrawlCapabilities.pdf}. */
+export function firecrawlSupportsPdf(
+  version: FirecrawlApiVersion = FIRECRAWL_API_VERSION,
+): boolean {
+  return firecrawlCapabilities(version).pdf;
+}
+
+/** See {@link FirecrawlCapabilities.htmlFormat}. */
+export function firecrawlHtmlFormat(
+  version: FirecrawlApiVersion = FIRECRAWL_API_VERSION,
+): "html" | "rawHtml" {
+  return firecrawlCapabilities(version).htmlFormat;
 }

--- a/src/llms-txt.ts
+++ b/src/llms-txt.ts
@@ -2,7 +2,7 @@ import { cacheGet, cacheSet } from "./cache.js";
 import { FETCH_CACHE_TTL_SECONDS } from "./config.js";
 import { recordLlmsFullProbe } from "./domain-db.js";
 import { getLlmsTxtAllowlist } from "./domains.js";
-import { readBoundedText, safeFetch } from "./fetch-utils.js";
+import { readBoundedText, safeFetch, USER_AGENT } from "./fetch-utils.js";
 
 const PROBE_PRESENT_TTL_SECONDS = 24 * 60 * 60;
 const PROBE_ABSENT_TTL_SECONDS = 7 * 24 * 60 * 60;
@@ -18,8 +18,6 @@ const MIN_SIZE_BYTES = 1_024;
 // boundary, not just a memory one: raising or lowering it changes which
 // documents the fast path accepts.
 const MAX_SIZE_BYTES = 64 * 1024 * 1024;
-const USER_AGENT =
-  "searxng-mcp/3.8.0 (+https://github.com/TadMSTR/searxng-mcp; personal research)";
 
 // Cap across all domains for the in-process L1 body cache, deliberately tied
 // to MAX_SIZE_BYTES: any document the fetch path accepts must be one the cache

--- a/src/reddit.ts
+++ b/src/reddit.ts
@@ -1,5 +1,10 @@
 import { REDDIT_FASTPATH_ENABLED, REDDIT_IGNORE_ROBOTS } from "./config.js";
-import { readBoundedText, safeFetch, type TierResult } from "./fetch-utils.js";
+import {
+  readBoundedText,
+  safeFetch,
+  type TierResult,
+  USER_AGENT,
+} from "./fetch-utils.js";
 import { checkRobots } from "./robots.js";
 
 const REDDIT_HOSTS = new Set([
@@ -9,8 +14,6 @@ const REDDIT_HOSTS = new Set([
   "new.reddit.com",
   "np.reddit.com",
 ]);
-const UA =
-  "searxng-mcp/3.15.0 (+https://github.com/TadMSTR/searxng-mcp; personal research)";
 const MAX_COMMENTS = 20;
 
 export function isRedditHost(url: string): boolean {
@@ -106,7 +109,7 @@ export async function redditFetch(
 
   try {
     const res = await safeFetch(jsonUrl, {
-      headers: { "User-Agent": UA, Accept: "application/json" },
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
       redirect: "follow",
       signal: AbortSignal.timeout(10_000),
     });

--- a/src/tiers/crawl4ai.ts
+++ b/src/tiers/crawl4ai.ts
@@ -13,6 +13,60 @@ import {
   type TierResult,
 } from "../fetch-utils.js";
 
+/**
+ * The crawl4ai version this tier is written against.
+ *
+ * Not decoration: the async job API was renamed *and* reshaped between the
+ * version this code was first written for and this one, and both changes failed
+ * silently — a wrong route returns 404 and a wrong shape yields empty markdown,
+ * and each was indistinguishable from "the page had no content". The route and
+ * shape assertions in tests/tiers/crawl4ai-job-api.test.ts run against a
+ * fixture captured from this version's live /openapi.json.
+ */
+export const CRAWL4AI_TARGET_VERSION = "0.8.6";
+
+/**
+ * Pull a TierResult out of one crawl4ai result object — the element of the
+ * `results` array, which is the same shape whether it arrived synchronously
+ * from /crawl or inside a completed job's envelope.
+ */
+function resultToTier(
+  result: Record<string, unknown> | null | undefined,
+  url: string,
+  maxChars: number,
+  preferFit: boolean,
+): TierResult | null {
+  const md = result?.markdown as Record<string, string> | null;
+  const mdRaw = preferFit
+    ? md?.fit_markdown || md?.raw_markdown
+    : md?.raw_markdown || md?.fit_markdown;
+  const text = (mdRaw ?? "").slice(0, maxChars);
+  if (!text) return null;
+  const metadata = result?.metadata as Record<string, string> | null;
+  const title = metadata?.title || url;
+  const html =
+    typeof result?.html === "string" ? (result.html as string) : undefined;
+  return { title, url, text, html };
+}
+
+/**
+ * Poll an enqueued crawl job to completion.
+ *
+ * Two independent defects lived here, both silent (vikunja#684):
+ *
+ * The route was `/task/{id}`, which does not exist on 0.8.6 — it 404s, the
+ * `!resp.ok` guard returned null, and the tier recorded an ordinary miss. That
+ * spelling is still printed in upstream's own installation doc, which is
+ * probably why two forge repos wrote it independently; the deployed
+ * /openapi.json is the only authority.
+ *
+ * The response shape was also wrong, and repointing the route alone would not
+ * have surfaced it. A completed job answers
+ * `{status, task_id, url, created_at, _links, result: {results: [...], success}}`
+ * — the crawl result is one level deeper than the old code's `data.result`.
+ * Reading the old path yields undefined markdown, empty text, and another
+ * silent miss. Older backends returned the flat shape, so both are accepted.
+ */
 export async function pollCrawl4aiTask(
   taskId: string,
   url: string,
@@ -27,27 +81,34 @@ export async function pollCrawl4aiTask(
     if (signal.aborted) return null;
 
     try {
-      const resp = await fetch(`${CRAWL4AI_URL}/task/${taskId}`, { signal });
-      if (!resp.ok) return null;
+      const resp = await fetch(`${CRAWL4AI_URL}/crawl/job/${taskId}`, {
+        signal,
+      });
+      if (!resp.ok) {
+        // A 404 here is the signature of exactly the bug this replaces: the
+        // route moved and every crawl became an unexplained miss. Say so, so
+        // the next rename is a visible failure rather than a silent tier drop.
+        if (resp.status === 404) {
+          console.error(
+            `[searxng-mcp] crawl4ai job poll got 404 for /crawl/job/${taskId} — ` +
+              `route or task expiry changed? this tier targets crawl4ai ${CRAWL4AI_TARGET_VERSION}`,
+          );
+        }
+        return null;
+      }
 
       const data = JSON.parse(await readBoundedText(resp)) as Record<
         string,
         unknown
       >;
       if (data.status === "completed") {
-        const result = data.result as Record<string, unknown> | null;
-        const md = result?.markdown as Record<string, string> | null;
-        const mdRaw = preferFit
-          ? md?.fit_markdown || md?.raw_markdown
-          : md?.raw_markdown || md?.fit_markdown;
-        const text = (mdRaw ?? "").slice(0, maxChars);
-        const metadata = result?.metadata as Record<string, string> | null;
-        const title = metadata?.title || url;
-        const html =
-          typeof result?.html === "string"
-            ? (result.html as string)
-            : undefined;
-        return text ? { title, url, text, html } : null;
+        const envelope = data.result as Record<string, unknown> | null;
+        // 0.8.6: result.results[0]. Older backends put the crawl result
+        // directly in `result`.
+        const nested = Array.isArray(envelope?.results)
+          ? (envelope.results[0] as Record<string, unknown> | undefined)
+          : undefined;
+        return resultToTier(nested ?? envelope, url, maxChars, preferFit);
       }
       if (data.status === "failed") return null;
     } catch {
@@ -107,20 +168,17 @@ export async function crawl4aiFetch(
       unknown
     >;
 
-    // Synchronous response — results returned directly
+    // Synchronous response — results returned directly. This is the path that
+    // actually runs on 0.8.6: POST /crawl is synchronous there and never
+    // returns a task_id. The async branch below is a compatibility path for
+    // backends that answer 202 with one.
     if (Array.isArray(data.results) && data.results.length > 0) {
-      const result = data.results[0] as Record<string, unknown>;
-      const md = result.markdown as Record<string, string> | null;
-      const mdRaw = preferFit
-        ? md?.fit_markdown || md?.raw_markdown
-        : md?.raw_markdown || md?.fit_markdown;
-      const text = (mdRaw ?? "").slice(0, maxChars);
-      if (!text) return null;
-      const metadata = result.metadata as Record<string, string> | null;
-      const title = metadata?.title || url;
-      const html =
-        typeof result.html === "string" ? (result.html as string) : undefined;
-      return { title, url, text, html };
+      return resultToTier(
+        data.results[0] as Record<string, unknown>,
+        url,
+        maxChars,
+        preferFit,
+      );
     }
 
     // Asynchronous response — poll for completion

--- a/src/tiers/firecrawl.ts
+++ b/src/tiers/firecrawl.ts
@@ -10,6 +10,7 @@ import {
 } from "../fetch-utils.js";
 import {
   firecrawlEndpoint,
+  firecrawlHtmlFormat,
   firecrawlSupportsActions,
 } from "../firecrawl-api.js";
 import type { FirecrawlScrapeResponse } from "../types.js";
@@ -28,9 +29,14 @@ export async function firecrawlScrape(
   maxChars = 8000,
   tuning?: FetchTuning,
 ): Promise<TierResult> {
+  // v1's format enum is `markdown | rawHtml | screenshot`; it rejects `html`
+  // with a 400 that fails the entire scrape, so an unconditional "html" here
+  // meant every tier-1 request failed under FIRECRAWL_API_VERSION=v1 — latent
+  // today, live the moment anyone rolls back (vikunja#649).
+  const htmlFormat = firecrawlHtmlFormat();
   const body: Record<string, unknown> = {
     url,
-    formats: ["markdown", "html"],
+    formats: ["markdown", htmlFormat],
   };
   // Only add selector fields when requested, so default scrapes are byte-for-
   // byte identical to before. target_selector → includeTags (keep only the
@@ -94,7 +100,10 @@ export async function firecrawlScrape(
 
   const title = data.data.metadata?.title ?? url;
   const text = (data.data.markdown ?? "").slice(0, maxChars);
-  const html = data.data.html;
+  // Same axis on the way back out: the response field carries the name that was
+  // requested, so reading `data.data.html` unconditionally left TierResult.html
+  // undefined under v1 even once the request itself was accepted.
+  const html = data.data[htmlFormat];
 
   return { title, url: data.data.metadata?.sourceURL ?? url, text, html };
 }

--- a/src/tiers/raw.ts
+++ b/src/tiers/raw.ts
@@ -2,7 +2,7 @@ import { Readability } from "@mozilla/readability";
 import { JSDOM } from "jsdom";
 import { ProxyAgent } from "undici";
 import { ChallengeDetectedError, detectChallenge } from "../challenge.js";
-import { ADBLOCK_PROXY_URL } from "../config.js";
+import { ADBLOCK_PROXY_URL, FIRECRAWL_API_VERSION } from "../config.js";
 import {
   classifyContentType,
   looksLikeHtml,
@@ -15,6 +15,7 @@ import {
   type TierResult,
   USER_AGENT,
 } from "../fetch-utils.js";
+import { firecrawlSupportsPdf } from "../firecrawl-api.js";
 
 // Create a ProxyAgent once at module init when ADBLOCK_PROXY_URL is configured.
 // Passed as `dispatcher` to undici-backed fetch calls (Node.js 18+ global fetch).
@@ -52,11 +53,6 @@ export async function rawFetch(
 
   const res = await safeFetch(url, fetchOptions);
 
-  if (res.headers.get("content-type")?.includes("application/pdf")) {
-    throw new Error(
-      "PDF content cannot be extracted by raw fetch — use Crawl4AI",
-    );
-  }
   if (res.status >= 300 && res.status < 400) {
     // Don't echo the Location header into the thrown message — a redirect
     // to an internal address would surface that address to the MCP caller
@@ -80,6 +76,34 @@ export async function rawFetch(
   // and the cascade books a hit.
   const bodySignal = detectChallenge(res.status, res.headers, body);
   if (bodySignal) throw new ChallengeDetectedError(bodySignal);
+
+  // Raw fetch cannot extract PDF text, so say so — but only for something that
+  // really is a PDF. Two deliberate choices here:
+  //
+  // Keyed on the header AND the `%PDF-` signature, because a body declared
+  // application/pdf that does not start with those bytes is usually an
+  // interstitial or an error page served with the wrong Content-Type. Rejecting
+  // on the header alone turned those into a hard "this is a PDF" failure when
+  // Readability could have extracted them; they now fall through below.
+  //
+  // Placed after the challenge check, so a Cloudflare interstitial mislabelled
+  // as a PDF is still booked as `challenge_detected` and can reach the solver.
+  //
+  // The message names the actual cause. It used to read "use Crawl4AI", which
+  // was wrong twice over: Crawl4AI cannot parse PDFs either, and reaching here
+  // at all means tier 1 already declined. Under v2 that is a real tier-1
+  // failure worth investigating; under v1 the backend simply has no PDF support
+  // and no amount of config will change it (vikunja#682).
+  if (
+    res.headers.get("content-type")?.includes("application/pdf") &&
+    body.startsWith("%PDF-")
+  ) {
+    throw new Error(
+      firecrawlSupportsPdf()
+        ? "PDF content cannot be extracted by raw fetch — tier 1 (Firecrawl) handles PDFs but returned nothing for this URL"
+        : `PDF content cannot be extracted by raw fetch — FIRECRAWL_API_VERSION is ${FIRECRAWL_API_VERSION}, which has no PDF support; v2 does`,
+    );
+  }
 
   // Structured payloads short-circuit before JSDOM. Readability over a JSON
   // document finds no article, falls through to returning the raw string, and

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -669,6 +669,15 @@ const SingleDomainOutputSchema = z.object({
 });
 
 const AggregateOutputSchema = z.object({
+  // Declared, not just emitted: the SDK validates structuredContent against
+  // this schema before it leaves the server, so a field missing here is a field
+  // the caller never receives however faithfully the handler builds it.
+  schema_version: z.number(),
+  window: z.object({
+    oldest_sample_ms: z.number().nullable(),
+    elapsed_ms: z.number().nullable(),
+    ttl_ceiling_ms: z.number(),
+  }),
   domains_tracked: z.number(),
   seen_never_fetched: z.number(),
   tiers: AllTiersOutputSchema,

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,7 +72,11 @@ export interface FirecrawlScrapeResponse {
   success: boolean;
   data?: {
     markdown?: string;
+    // Two spellings of one field: v2 returns `html`, v1 returns `rawHtml`,
+    // matching whichever was asked for in `formats`. See
+    // FirecrawlCapabilities.htmlFormat.
     html?: string;
+    rawHtml?: string;
     metadata?: {
       title?: string;
       sourceURL?: string;

--- a/src/youtube.ts
+++ b/src/youtube.ts
@@ -1,5 +1,10 @@
 import { YOUTUBE_IGNORE_ROBOTS, YOUTUBE_TRANSCRIPT_ENABLED } from "./config.js";
-import { readBoundedText, safeFetch, type TierResult } from "./fetch-utils.js";
+import {
+  readBoundedText,
+  safeFetch,
+  type TierResult,
+  USER_AGENT,
+} from "./fetch-utils.js";
 import { checkRobots } from "./robots.js";
 
 const YOUTUBE_HOSTS = new Set([
@@ -10,8 +15,6 @@ const YOUTUBE_HOSTS = new Set([
 ]);
 const YOUTUBE_ORIGIN = "https://www.youtube.com";
 const VIDEO_ID_RE = /^[A-Za-z0-9_-]{11}$/;
-const UA =
-  "searxng-mcp/3.15.0 (+https://github.com/TadMSTR/searxng-mcp; personal research)";
 
 export function isYouTubeHost(url: string): boolean {
   if (!YOUTUBE_TRANSCRIPT_ENABLED) return false;
@@ -155,7 +158,7 @@ export async function youtubeFetch(
 
   try {
     const watchRes = await safeFetch(`${YOUTUBE_ORIGIN}/watch?v=${videoId}`, {
-      headers: { "User-Agent": UA, "Accept-Language": "en" },
+      headers: { "User-Agent": USER_AGENT, "Accept-Language": "en" },
       redirect: "follow",
       signal: AbortSignal.timeout(10_000),
     });
@@ -169,7 +172,7 @@ export async function youtubeFetch(
     if (!track?.baseUrl) return null;
 
     const ttRes = await safeFetch(track.baseUrl, {
-      headers: { "User-Agent": UA },
+      headers: { "User-Agent": USER_AGENT },
       redirect: "follow",
       signal: AbortSignal.timeout(10_000),
     });

--- a/tests/cli/dump-domain.test.ts
+++ b/tests/cli/dump-domain.test.ts
@@ -70,11 +70,18 @@ describe("dump-domain CLI — present-domain case", () => {
     expect(output).toContain("tier1 (firecrawl)");
     expect(output).toContain("90% ok (9/10)");
     expect(output).toContain("tier2 (crawl4ai)");
-    expect(output).toContain("0% ok (0/2)");
+    // n=2 is below MIN_ATTEMPTS_FOR_RATE, so this renders as a count rather
+    // than "0% ok (0/2)" — two failures and ten failures are not the same
+    // finding, and a percentage presented them as though they were
+    // (vikunja#686). tier1 above keeps its rate at n=10.
+    expect(output).toContain("insufficient data (0/2)");
+    expect(output).not.toContain("0% ok (0/2)");
     expect(output).toContain("tier3 (raw)");
     expect(output).toContain("tier4 (wayback)");
-    expect(output).toContain("67% ok (2/3)");
+    // n=3, likewise below the threshold.
+    expect(output).toContain("insufficient data (2/3)");
     expect(output).toContain("github (fastpath)");
+    // n=5 is the first size a rate is rendered for.
     expect(output).toContain("100% ok (5/5)");
     expect(output).toContain("metadata_fetch");
     expect(output).toContain("75% ok (3/4)");

--- a/tests/domain-stats-output-contract.test.ts
+++ b/tests/domain-stats-output-contract.test.ts
@@ -220,10 +220,138 @@ describe("domain_stats advertised output schema", () => {
     expect(r.valid, JSON.stringify(r.errors ?? r.error)).toBe(true);
   });
 
+  // ── Window and schema reporting (vikunja#686) ─────────────────────────────
+
+  it("delivers schema_version and the real window to the caller, not just the text", async () => {
+    // The declared schema is what binds: the SDK strips undeclared keys before
+    // the payload leaves the server, so a field the handler builds but the
+    // schema omits reaches nobody. Asserting it on the handler's return value
+    // alone would pass in exactly that case.
+    const oldest = NOW - 14 * 3600_000;
+    vi.mocked(getValkey).mockResolvedValueOnce({
+      scan: vi.fn().mockResolvedValueOnce(["0", ["domain:good.com"]]),
+      mget: vi.fn().mockResolvedValueOnce([
+        JSON.stringify(
+          mkRecord("good.com", TIER_SLOT_KEYS, {
+            tier1: { attempts: 10, ok: 9, fail: 1, window_start_ms: oldest },
+          }),
+        ),
+      ]),
+    } as unknown as NonNullable<Awaited<ReturnType<typeof getValkey>>>);
+
+    const result = await handleDomainStats({});
+    const agg = result.structuredContent.aggregate;
+
+    expect(agg?.schema_version).toBe(7);
+    expect(agg?.window.oldest_sample_ms).toBe(oldest);
+    expect(agg?.window.elapsed_ms).toBeGreaterThan(13 * 3600_000);
+    // The ceiling is reported separately, and is NOT the measured window —
+    // conflating the two is the whole defect.
+    expect(agg?.window.ttl_ceiling_ms).toBe(30 * 24 * 3600_000);
+    expect(agg?.window.elapsed_ms).toBeLessThan(
+      agg?.window.ttl_ceiling_ms ?? 0,
+    );
+
+    const r = await validateAsClient(result.structuredContent);
+    expect(r.valid, JSON.stringify(r.errors ?? r.error)).toBe(true);
+  });
+
+  it("reports no window when nothing has been counted, rather than a fabricated one", async () => {
+    vi.mocked(getValkey).mockResolvedValueOnce({
+      scan: vi.fn().mockResolvedValueOnce(["0", ["domain:idle.com"]]),
+      mget: vi
+        .fn()
+        .mockResolvedValueOnce([
+          JSON.stringify(mkRecord("idle.com", TIER_SLOT_KEYS)),
+        ]),
+    } as unknown as NonNullable<Awaited<ReturnType<typeof getValkey>>>);
+
+    const result = await handleDomainStats({});
+    const agg = result.structuredContent.aggregate;
+
+    // Zeroed slots carry a window_start_ms too. Counting them would report a
+    // measurement period over which nothing was measured.
+    expect(agg?.window.oldest_sample_ms).toBeNull();
+    expect(agg?.window.elapsed_ms).toBeNull();
+
+    const text = result.content[0]?.text ?? "";
+    expect(text).toContain("no samples yet");
+    expect(text).not.toMatch(/window \d/);
+  });
+
+  it("no longer prints a constant 30d window header", async () => {
+    // The precise misreport: an aggregate taken minutes after a schema reset
+    // presented as thirty days of evidence.
+    const oldest = NOW - 2 * 3600_000;
+    vi.mocked(getValkey).mockResolvedValueOnce({
+      scan: vi.fn().mockResolvedValueOnce(["0", ["domain:good.com"]]),
+      mget: vi.fn().mockResolvedValueOnce([
+        JSON.stringify(
+          mkRecord("good.com", TIER_SLOT_KEYS, {
+            tier1: { attempts: 10, ok: 9, fail: 1, window_start_ms: oldest },
+          }),
+        ),
+      ]),
+    } as unknown as NonNullable<Awaited<ReturnType<typeof getValkey>>>);
+
+    const text = (await handleDomainStats({})).content[0]?.text ?? "";
+
+    expect(text).toContain("all domains, window 2h since ");
+    expect(text).toContain("schema 7");
+    expect(text).not.toContain("all domains, 30d window");
+  });
+
+  it("renders a low-confidence marker below the threshold and a rate above it", async () => {
+    vi.mocked(getValkey).mockResolvedValueOnce({
+      scan: vi.fn().mockResolvedValueOnce(["0", ["domain:thin.com"]]),
+      mget: vi.fn().mockResolvedValueOnce([
+        JSON.stringify(
+          mkRecord("thin.com", TIER_SLOT_KEYS, {
+            // n=4: one outcome either way moves the rate by 25 points.
+            tier1: { attempts: 4, ok: 0, fail: 4, window_start_ms: NOW },
+            // n=5: the first sample size the rate is rendered for.
+            tier2: { attempts: 5, ok: 0, fail: 5, window_start_ms: NOW },
+          }),
+        ),
+      ]),
+    } as unknown as NonNullable<Awaited<ReturnType<typeof getValkey>>>);
+
+    const text = (await handleDomainStats({})).content[0]?.text ?? "";
+
+    expect(text).toContain("tier1  : insufficient data (0/4)");
+    expect(text).toContain("tier2  : 0% ok (0/5)");
+    // "no data" must stay distinct from "barely any data" — three states, not
+    // two.
+    expect(text).toContain("tier3  : no data");
+  });
+
   // ── Negative controls ─────────────────────────────────────────────────────
   //
   // Without these the suite above cannot fail: a schema that accepted anything
   // would satisfy every positive assertion.
+
+  it("rejects an aggregate missing the new window block", async () => {
+    // Guards the declaration itself. If schema_version/window were dropped from
+    // AggregateOutputSchema the positive tests above would still pass on the
+    // handler's return value, because they read it before the SDK strips it.
+    vi.mocked(getValkey).mockResolvedValueOnce({
+      scan: vi.fn().mockResolvedValueOnce(["0", ["domain:good.com"]]),
+      mget: vi
+        .fn()
+        .mockResolvedValueOnce([
+          JSON.stringify(mkRecord("good.com", TIER_SLOT_KEYS)),
+        ]),
+    } as unknown as NonNullable<Awaited<ReturnType<typeof getValkey>>>);
+
+    const result = await handleDomainStats({});
+    const tampered = structuredClone(result.structuredContent) as {
+      aggregate: Record<string, unknown>;
+    };
+    delete tampered.aggregate.window;
+
+    const r = await validateAsClient(tampered);
+    expect(r.valid).toBe(false);
+  });
 
   it("rejects a slot that is not in TIER_SLOT_KEYS", async () => {
     vi.mocked(cacheGet).mockResolvedValueOnce(

--- a/tests/fetch-failure-detail.test.ts
+++ b/tests/fetch-failure-detail.test.ts
@@ -164,6 +164,38 @@ describe("fetchPage — terminal failure names every tier", () => {
     expect(String(err)).not.toMatch(/tier2_crawl4ai: attempted/);
   });
 
+  it("bounds an unbounded upstream error rather than relaying it whole", async () => {
+    // Firecrawl's `data.error` is upstream-controlled text of arbitrary length,
+    // and this is the first change that relays a tier's own error to the caller
+    // instead of swallowing it. An error message is not a transport for an
+    // arbitrary upstream payload.
+    tiers.tier1Fetch.mockRejectedValue(new Error("X".repeat(5000)));
+
+    const err = await fetchPage(URL_).catch((e: Error) => e);
+    const message = String(err);
+
+    expect(message).toContain("…");
+    expect(message.length).toBeLessThan(1000);
+    // The other tiers must still be named — truncating one reason must not
+    // swallow the rest of the diagnostic.
+    expect(message).toContain("tier2_crawl4ai: skipped (not_configured)");
+    expect(message).toContain("tier3_rawfetch");
+  });
+
+  it("leaves a normal-length reason intact", async () => {
+    // Negative control for the cap: without this, a bound that truncated
+    // everything would satisfy the test above.
+    tiers.tier1Fetch.mockRejectedValue(
+      new Error("Firecrawl error: 502 Bad Gateway"),
+    );
+
+    const err = await fetchPage(URL_).catch((e: Error) => e);
+    expect(String(err)).toContain(
+      "tier1_firecrawl: Firecrawl error: 502 Bad Gateway",
+    );
+    expect(String(err)).not.toContain("…");
+  });
+
   it("still leads with the original message, so existing matchers hold", async () => {
     await expect(fetchPage(URL_)).rejects.toThrow(/^All fetch tiers failed/);
   });

--- a/tests/fetch-failure-detail.test.ts
+++ b/tests/fetch-failure-detail.test.ts
@@ -1,0 +1,194 @@
+// vikunja#682 part 4 — when every tier fails, say why, per tier.
+//
+// The null-collapse this fixes is the structural cause of the whole #682
+// investigation. `runTier` reduces every failure to `null`, which is correct for
+// the cascade — it just moves on — but the caller then had nothing left to
+// explain the outcome with. The old PDF fast path invented a specific cause for
+// its null ("PDF extraction requires Crawl4AI (CRAWL4AI_URL not configured)")
+// on a deployment where CRAWL4AI_URL was set and crawl4ai was healthy, and that
+// message sent an investigator to check configuration that was already correct.
+//
+// The generic terminal error had the mirror problem: "All fetch tiers failed"
+// is equally consistent with nothing being configured, a backend being down,
+// and the page genuinely having no content.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/config.js", () => ({
+  FETCH_CACHE_TTL_SECONDS: 86400,
+  WAYBACK_ENABLED: false,
+  YOUTUBE_TRANSCRIPT_ENABLED: false,
+  YOUTUBE_IGNORE_ROBOTS: false,
+  REDDIT_FASTPATH_ENABLED: false,
+  REDDIT_IGNORE_ROBOTS: false,
+}));
+
+vi.mock("node:dns/promises", () => ({
+  lookup: () => Promise.resolve([{ address: "93.184.216.34", family: 4 }]),
+}));
+
+vi.mock("../src/cache.js", () => ({
+  cacheGet: vi.fn().mockResolvedValue(null),
+  cacheSet: vi.fn().mockResolvedValue(undefined),
+  fetchCacheKey: (url: string) => `fetch:${url}`,
+}));
+
+vi.mock("../src/domains.js", () => ({
+  getBlockList: vi.fn(() => []),
+  urlMatchesDomain: vi.fn(() => false),
+}));
+
+vi.mock("../src/domain-db.js", () => ({
+  recordTierAttempt: vi.fn().mockResolvedValue(undefined),
+  recordPostExtractSample: vi.fn().mockResolvedValue(undefined),
+  recordMetadataFetchAttempt: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../src/events.js", () => ({
+  events: {
+    fetchRequested: vi.fn(),
+    fetchCompleted: vi.fn(),
+    fetchTierMiss: vi.fn(),
+    fetchTierSkipped: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../src/observability.js", () => ({
+  incCounter: vi.fn(),
+  recordHistogram: vi.fn(),
+  withSpan: (_name: string, _attrs: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("../src/robots.js", () => ({
+  checkRobots: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+
+vi.mock("../src/hister.js", () => ({
+  histerFetch: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../src/kiwix.js", () => ({
+  isKiwixHost: vi.fn(() => false),
+  kiwixFetch: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../src/llms-txt.js", () => ({
+  tryLlmsTxtFetch: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../src/content-type.js", () => ({
+  probeStructuredContent: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../src/extractors/post-extract.js", () => ({
+  postExtract: vi.fn(() => ({
+    title: "t",
+    text: "x",
+    source: "baseline",
+    jsonLdPresent: false,
+  })),
+}));
+
+const tiers = vi.hoisted(() => ({
+  tier1Fetch: vi.fn(),
+  tier3Fetch: vi.fn(),
+  getTiers: vi.fn(),
+}));
+
+vi.mock("../src/routing.js", () => ({
+  getTiers: tiers.getTiers,
+  // The real map. A stubbed-empty TIER_NAME would render every skipped tier as
+  // `undefined:` and the assertions below would pass on a blank name.
+  TIER_NAME: {
+    tier1: "tier1_firecrawl",
+    tier2: "tier2_crawl4ai",
+    tier3: "tier3_rawfetch",
+  },
+}));
+
+vi.mock("../src/tiers/index.js", () => ({
+  fetchRawHtmlForMetadata: vi.fn().mockResolvedValue(null),
+  githubFetch: vi.fn(),
+  isGithubUrl: () => false,
+  rawFetch: vi.fn(),
+  tier2: { name: "tier2_crawl4ai", slot: "tier2", fetch: vi.fn() },
+  waybackFetch: vi.fn().mockResolvedValue(null),
+}));
+
+import { fetchPage } from "../src/fetch.js";
+
+const URL_ = "https://example.com/page";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tiers.getTiers.mockResolvedValue({
+    active: [
+      { name: "tier1_firecrawl", slot: "tier1", fetch: tiers.tier1Fetch },
+      { name: "tier3_rawfetch", slot: "tier3", fetch: tiers.tier3Fetch },
+    ],
+    skipped: [{ tier: "tier2", reason: "not_configured" }],
+  });
+  tiers.tier1Fetch.mockResolvedValue(null);
+  tiers.tier3Fetch.mockResolvedValue(null);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("fetchPage — terminal failure names every tier", () => {
+  it("distinguishes a skipped tier from one that ran and came back empty", async () => {
+    // The distinction that matters. An operator reading this needs to know
+    // whether to go and configure something or to go and look at a backend.
+    await expect(fetchPage(URL_)).rejects.toThrow(
+      /tier2_crawl4ai: skipped \(not_configured\)/,
+    );
+    await expect(fetchPage(URL_)).rejects.toThrow(
+      /tier1_firecrawl: attempted, no content/,
+    );
+  });
+
+  it("surfaces the underlying error from a tier that threw", async () => {
+    tiers.tier1Fetch.mockRejectedValue(
+      new Error("Firecrawl error: 502 Bad Gateway"),
+    );
+
+    await expect(fetchPage(URL_)).rejects.toThrow(
+      /tier1_firecrawl: Firecrawl error: 502 Bad Gateway/,
+    );
+  });
+
+  it("does not report an unconfigured tier as having been attempted", async () => {
+    // The precise misreport that started #682: a tier that never ran, blamed
+    // for the failure as though it had.
+    const err = await fetchPage(URL_).catch((e: Error) => e);
+    expect(String(err)).not.toMatch(/tier2_crawl4ai: attempted/);
+  });
+
+  it("still leads with the original message, so existing matchers hold", async () => {
+    await expect(fetchPage(URL_)).rejects.toThrow(/^All fetch tiers failed/);
+  });
+
+  it("names every tier that took part, none omitted", async () => {
+    const err = await fetchPage(URL_).catch((e: Error) => e);
+    for (const tier of [
+      "tier1_firecrawl",
+      "tier2_crawl4ai",
+      "tier3_rawfetch",
+    ]) {
+      expect(String(err)).toContain(tier);
+    }
+  });
+
+  it("carries the same detail into the error event, not just the throw", async () => {
+    // A message that reaches the caller but not the event stream is invisible
+    // to anyone debugging from logs after the fact.
+    const { events } = await import("../src/events.js");
+    await fetchPage(URL_).catch(() => {});
+    expect(vi.mocked(events.error)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error_type: "all_tiers_failed",
+        message: expect.stringContaining("tier2_crawl4ai: skipped"),
+      }),
+    );
+  });
+});

--- a/tests/fetch-pdf-routing.test.ts
+++ b/tests/fetch-pdf-routing.test.ts
@@ -1,0 +1,214 @@
+// Regression guard for vikunja#682: a PDF URL must take the ordinary cascade
+// and be served by tier 1.
+//
+// The bug this replaces was a fast path in fetchPage that matched `.pdf` on the
+// pathname and dispatched straight to tier 2, on a comment asserting "Firecrawl
+// can't extract PDF text". That was true of trieve/firecrawl v0.0.55 and false
+// of the v2 backend, which extracts PDFs natively — verified live 2026-09-05,
+// 475,850 characters of markdown from RFC 9110's PDF. Crawl4AI, meanwhile,
+// renders the PDF in a browser, finds no text nodes, and fails its own anti-bot
+// heuristic, so the fast path routed every PDF to the one tier that could not
+// serve it.
+//
+// These cases prove the *routing*. They cannot prove PDFs work end-to-end — the
+// tiers are stubs here. That check is a real fetch_url against a real PDF with
+// tier_served asserted, recorded in the build plan's verification section.
+//
+// Mock surface copied from fetch-content-type-routing.test.ts.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/config.js", () => ({
+  FETCH_CACHE_TTL_SECONDS: 86400,
+  WAYBACK_ENABLED: false,
+  YOUTUBE_TRANSCRIPT_ENABLED: false,
+  YOUTUBE_IGNORE_ROBOTS: false,
+  REDDIT_FASTPATH_ENABLED: false,
+  REDDIT_IGNORE_ROBOTS: false,
+}));
+
+vi.mock("node:dns/promises", () => ({
+  lookup: () => Promise.resolve([{ address: "93.184.216.34", family: 4 }]),
+}));
+
+vi.mock("../src/cache.js", () => ({
+  cacheGet: vi.fn().mockResolvedValue(null),
+  cacheSet: vi.fn().mockResolvedValue(undefined),
+  fetchCacheKey: (url: string) => `fetch:${url}`,
+}));
+
+vi.mock("../src/domains.js", () => ({
+  getBlockList: vi.fn(() => []),
+  urlMatchesDomain: vi.fn(() => false),
+}));
+
+vi.mock("../src/domain-db.js", () => ({
+  recordTierAttempt: vi.fn().mockResolvedValue(undefined),
+  recordPostExtractSample: vi.fn().mockResolvedValue(undefined),
+  recordMetadataFetchAttempt: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../src/events.js", () => ({
+  events: {
+    fetchRequested: vi.fn(),
+    fetchCompleted: vi.fn(),
+    fetchTierMiss: vi.fn(),
+    fetchTierSkipped: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../src/observability.js", () => ({
+  incCounter: vi.fn(),
+  recordHistogram: vi.fn(),
+  withSpan: (_name: string, _attrs: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("../src/robots.js", () => ({
+  checkRobots: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+
+vi.mock("../src/hister.js", () => ({
+  histerFetch: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../src/kiwix.js", () => ({
+  isKiwixHost: vi.fn(() => false),
+  kiwixFetch: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../src/llms-txt.js", () => ({
+  tryLlmsTxtFetch: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../src/content-type.js", () => ({
+  probeStructuredContent: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../src/extractors/post-extract.js", () => ({
+  postExtract: vi.fn(
+    (_url: string, _html: unknown, base: { text: string }) => ({
+      title: "t",
+      text: base.text,
+      source: "baseline",
+      jsonLdPresent: false,
+    }),
+  ),
+}));
+
+const tiers = vi.hoisted(() => ({
+  tier1Fetch: vi.fn(),
+  tier2Fetch: vi.fn(),
+}));
+
+vi.mock("../src/routing.js", () => ({
+  getTiers: vi.fn().mockResolvedValue({
+    active: [
+      { name: "tier1_firecrawl", slot: "tier1", fetch: tiers.tier1Fetch },
+      { name: "tier2_crawl4ai", slot: "tier2", fetch: tiers.tier2Fetch },
+    ],
+    skipped: [],
+  }),
+  TIER_NAME: {},
+}));
+
+vi.mock("../src/tiers/index.js", () => ({
+  fetchRawHtmlForMetadata: vi.fn().mockResolvedValue(null),
+  githubFetch: vi.fn(),
+  isGithubUrl: () => false,
+  rawFetch: vi.fn(),
+  tier2: { name: "tier2_crawl4ai", slot: "tier2", fetch: tiers.tier2Fetch },
+  waybackFetch: vi.fn().mockResolvedValue(null),
+}));
+
+import { recordTierAttempt } from "../src/domain-db.js";
+import { events } from "../src/events.js";
+import { fetchPage } from "../src/fetch.js";
+
+const { tier1Fetch, tier2Fetch } = tiers;
+const fetchCompletedMock = vi.mocked(events.fetchCompleted);
+const recordTierAttemptMock = vi.mocked(recordTierAttempt);
+
+const PDF_URL = "https://www.rfc-editor.org/rfc/rfc9110.pdf";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tier1Fetch.mockResolvedValue({
+    title: "RFC 9110",
+    url: PDF_URL,
+    text: "HTTP Semantics",
+  });
+  tier2Fetch.mockResolvedValue(null);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("fetchPage — PDF routing", () => {
+  it("serves a .pdf URL from tier1_firecrawl", async () => {
+    const result = await fetchPage(PDF_URL);
+
+    expect(tier1Fetch).toHaveBeenCalledOnce();
+    expect(result.text).toContain("HTTP Semantics");
+    // The assertion that actually pins the bug: tier1 must be the tier of
+    // record, not merely a tier that ran. A 200 from the wrong tier is not a
+    // pass.
+    expect(fetchCompletedMock).toHaveBeenCalledWith(
+      expect.objectContaining({ tier_served: "tier1_firecrawl" }),
+    );
+  });
+
+  it("never dispatches a .pdf URL to tier2 while tier1 can serve it", async () => {
+    await fetchPage(PDF_URL);
+
+    expect(tier2Fetch).not.toHaveBeenCalled();
+    expect(
+      recordTierAttemptMock.mock.calls.some(
+        (call) => call[1] === "tier2_crawl4ai",
+      ),
+    ).toBe(false);
+  });
+
+  it("books the attempt against tier1, so domain_stats stops blaming tier2", async () => {
+    await fetchPage(PDF_URL);
+
+    expect(recordTierAttemptMock).toHaveBeenCalledWith(
+      PDF_URL,
+      "tier1_firecrawl",
+      "hit",
+    );
+  });
+
+  it("falls through to tier2 when tier1 misses, rather than short-circuiting", async () => {
+    // The cascade still applies to PDFs — deleting the fast path must not
+    // pin them to tier 1 the way it previously pinned them to tier 2.
+    tier1Fetch.mockResolvedValue(null);
+    tier2Fetch.mockResolvedValue({
+      title: "RFC 9110",
+      url: PDF_URL,
+      text: "from tier two",
+    });
+
+    const result = await fetchPage(PDF_URL);
+
+    expect(tier1Fetch).toHaveBeenCalledOnce();
+    expect(tier2Fetch).toHaveBeenCalledOnce();
+    expect(result.text).toContain("from tier two");
+    expect(fetchCompletedMock).toHaveBeenCalledWith(
+      expect.objectContaining({ tier_served: "tier2_crawl4ai" }),
+    );
+  });
+
+  it("routes an extensionless PDF the same way — the old fast path could not see these", async () => {
+    // The suffix matcher missed every PDF served without a .pdf path, which is
+    // why keying on the URL was the wrong predicate even before v2 made the
+    // whole fast path obsolete.
+    const url = "https://example.com/download?doc=9110";
+
+    await fetchPage(url);
+
+    expect(tier1Fetch).toHaveBeenCalledOnce();
+    expect(fetchCompletedMock).toHaveBeenCalledWith(
+      expect.objectContaining({ tier_served: "tier1_firecrawl" }),
+    );
+  });
+});

--- a/tests/fetch.test.ts
+++ b/tests/fetch.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { assertPublicUrl, rawFetch } from "../src/fetch.js";
-import { isPdfUrl } from "../src/fetch-utils.js";
 
 describe("assertPublicUrl", () => {
   it("accepts a normal public HTTPS URL", () => {
@@ -258,24 +257,8 @@ describe("rawFetch", () => {
   });
 });
 
-describe("isPdfUrl", () => {
-  it("returns true for .pdf URL", () => {
-    expect(isPdfUrl("https://example.com/doc.pdf")).toBe(true);
-  });
-
-  it("returns true for .PDF URL (case-insensitive)", () => {
-    expect(isPdfUrl("https://example.com/doc.PDF")).toBe(true);
-  });
-
-  it("returns false for non-PDF URL", () => {
-    expect(isPdfUrl("https://example.com/page.html")).toBe(false);
-  });
-
-  it("returns false for URL with .pdf in query string but not path", () => {
-    expect(isPdfUrl("https://example.com/view?file=doc.pdf")).toBe(false);
-  });
-
-  it("returns false for invalid URL", () => {
-    expect(isPdfUrl("not a url")).toBe(false);
-  });
-});
+// `isPdfUrl` and its five tests were deleted with the PDF fast path
+// (vikunja#682). Suffix matching was never the right predicate — it missed every
+// PDF served from an extensionless URL, and those hit the tier-3 rejection
+// instead. PDF handling is now keyed on Content-Type plus the `%PDF-` body
+// signature, covered in tests/tiers/raw-pdf.test.ts.

--- a/tests/firecrawl-api-version.test.ts
+++ b/tests/firecrawl-api-version.test.ts
@@ -119,12 +119,73 @@ describe("backend capability predicates", () => {
     expect(firecrawlSupportsMap("v2")).toBe(true);
   });
 
-  it("defaults both predicates from the configured version", async () => {
+  it("reports PDF extraction available under v2 only", async () => {
+    // v2 parses PDFs natively — verified live against firecrawl 2.11.162.
+    // v1 (trieve/firecrawl 0.0.55) cannot, which is the whole reason this is a
+    // capability and not an assumption (vikunja#682).
+    const { firecrawlSupportsPdf } = await import("../src/firecrawl-api.js");
+    expect(firecrawlSupportsPdf("v1")).toBe(false);
+    expect(firecrawlSupportsPdf("v2")).toBe(true);
+  });
+
+  it("names the HTML format per version — v1 rejects `html` outright", async () => {
+    // Not cosmetic: v1's enum is markdown|rawHtml|screenshot and it 400s on
+    // `html`, failing the entire scrape (vikunja#649).
+    const { firecrawlHtmlFormat } = await import("../src/firecrawl-api.js");
+    expect(firecrawlHtmlFormat("v1")).toBe("rawHtml");
+    expect(firecrawlHtmlFormat("v2")).toBe("html");
+  });
+
+  it("defaults every predicate from the configured version", async () => {
     process.env.FIRECRAWL_API_VERSION = "v2";
-    const { firecrawlSupportsActions, firecrawlSupportsMap } = await import(
-      "../src/firecrawl-api.js"
-    );
+    const {
+      firecrawlSupportsActions,
+      firecrawlSupportsMap,
+      firecrawlSupportsPdf,
+      firecrawlHtmlFormat,
+    } = await import("../src/firecrawl-api.js");
     expect(firecrawlSupportsActions()).toBe(false);
     expect(firecrawlSupportsMap()).toBe(true);
+    expect(firecrawlSupportsPdf()).toBe(true);
+    expect(firecrawlHtmlFormat()).toBe("html");
+  });
+});
+
+describe("firecrawlCapabilities table", () => {
+  // The predicates are readers over this table. Asserting the exact row pins
+  // every capability at once, so adding a field without deciding its v1 value
+  // shows up here rather than as a silent `undefined` at a call site.
+  it("describes v1 completely", async () => {
+    const { firecrawlCapabilities } = await import("../src/firecrawl-api.js");
+    expect(firecrawlCapabilities("v1")).toEqual({
+      actions: true,
+      map: false,
+      pdf: false,
+      htmlFormat: "rawHtml",
+    });
+  });
+
+  it("describes v2 completely", async () => {
+    const { firecrawlCapabilities } = await import("../src/firecrawl-api.js");
+    expect(firecrawlCapabilities("v2")).toEqual({
+      actions: false,
+      map: true,
+      pdf: true,
+      htmlFormat: "html",
+    });
+  });
+
+  it("gives the two versions different answers on every axis", async () => {
+    // A copy-paste that left both rows identical would still satisfy the
+    // per-row assertions above if they were written from the same source.
+    const { firecrawlCapabilities } = await import("../src/firecrawl-api.js");
+    const v1 = firecrawlCapabilities("v1");
+    const v2 = firecrawlCapabilities("v2");
+    for (const key of Object.keys(v1) as (keyof typeof v1)[]) {
+      expect(
+        v1[key],
+        `capability ${key} is identical on both versions`,
+      ).not.toBe(v2[key]);
+    }
   });
 });

--- a/tests/fixtures/crawl4ai-0.8.6-job-completed.json
+++ b/tests/fixtures/crawl4ai-0.8.6-job-completed.json
@@ -1,0 +1,29 @@
+{
+  "_links": {
+    "refresh": {
+      "href": "http://127.0.0.1:11235//llm/crawl_0b0268d9"
+    },
+    "self": {
+      "href": "http://127.0.0.1:11235//llm/crawl_0b0268d9"
+    }
+  },
+  "created_at": "2026-09-06T10:25:48.823662",
+  "result": {
+    "results": [
+      {
+        "html": "<h1>Example Domain</h1>",
+        "markdown": {
+          "fit_markdown": "# Example Domain\n\nfit markdown body",
+          "raw_markdown": "# Example Domain\n\nraw markdown body"
+        },
+        "metadata": {
+          "title": "Example Domain"
+        }
+      }
+    ],
+    "success": true
+  },
+  "status": "completed",
+  "task_id": "crawl_0b0268d9",
+  "url": "[\"https://example.com/\"]"
+}

--- a/tests/fixtures/crawl4ai-0.8.6-openapi.json
+++ b/tests/fixtures/crawl4ai-0.8.6-openapi.json
@@ -1,0 +1,173 @@
+{
+  "_captured": {
+    "captured": "2026-09-06",
+    "crawl4ai_version": "0.8.6",
+    "source": "GET http://crawl4ai:11235/openapi.json on the deployed instance"
+  },
+  "info": {
+    "title": "Crawl4AI API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "root__get"
+      }
+    },
+    "/ask": {
+      "get": {
+        "operationId": "get_context_ask_get"
+      }
+    },
+    "/config/dump": {
+      "post": {
+        "operationId": "config_dump_config_dump_post"
+      }
+    },
+    "/crawl": {
+      "post": {
+        "operationId": "crawl_crawl_post"
+      }
+    },
+    "/crawl/job": {
+      "post": {
+        "operationId": "crawl_job_enqueue_crawl_job_post"
+      }
+    },
+    "/crawl/job/{task_id}": {
+      "get": {
+        "operationId": "crawl_job_status_crawl_job__task_id__get"
+      }
+    },
+    "/crawl/stream": {
+      "post": {
+        "operationId": "crawl_stream_crawl_stream_post"
+      }
+    },
+    "/execute_js": {
+      "post": {
+        "operationId": "execute_js_execute_js_post"
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "health_health_get"
+      }
+    },
+    "/hooks/info": {
+      "get": {
+        "operationId": "get_hooks_info_hooks_info_get"
+      }
+    },
+    "/html": {
+      "post": {
+        "operationId": "generate_html_html_post"
+      }
+    },
+    "/llm/job": {
+      "post": {
+        "operationId": "llm_job_enqueue_llm_job_post"
+      }
+    },
+    "/llm/job/{task_id}": {
+      "get": {
+        "operationId": "llm_job_status_llm_job__task_id__get"
+      }
+    },
+    "/llm/{url}": {
+      "get": {
+        "operationId": "llm_endpoint_llm__url__get"
+      }
+    },
+    "/mcp/schema": {
+      "get": {
+        "operationId": "_schema_endpoint_mcp_schema_get"
+      }
+    },
+    "/md": {
+      "post": {
+        "operationId": "get_markdown_md_post"
+      }
+    },
+    "/metrics": {
+      "get": {
+        "operationId": "metrics_metrics_get"
+      }
+    },
+    "/monitor/actions/cleanup": {
+      "post": {
+        "operationId": "force_cleanup_monitor_actions_cleanup_post"
+      }
+    },
+    "/monitor/actions/kill_browser": {
+      "post": {
+        "operationId": "kill_browser_monitor_actions_kill_browser_post"
+      }
+    },
+    "/monitor/actions/restart_browser": {
+      "post": {
+        "operationId": "restart_browser_monitor_actions_restart_browser_post"
+      }
+    },
+    "/monitor/browsers": {
+      "get": {
+        "operationId": "get_browsers_monitor_browsers_get"
+      }
+    },
+    "/monitor/endpoints/stats": {
+      "get": {
+        "operationId": "get_endpoint_stats_monitor_endpoints_stats_get"
+      }
+    },
+    "/monitor/health": {
+      "get": {
+        "operationId": "get_health_monitor_health_get"
+      }
+    },
+    "/monitor/logs/errors": {
+      "get": {
+        "operationId": "get_errors_log_monitor_logs_errors_get"
+      }
+    },
+    "/monitor/logs/janitor": {
+      "get": {
+        "operationId": "get_janitor_log_monitor_logs_janitor_get"
+      }
+    },
+    "/monitor/requests": {
+      "get": {
+        "operationId": "get_requests_monitor_requests_get"
+      }
+    },
+    "/monitor/stats/reset": {
+      "post": {
+        "operationId": "reset_stats_monitor_stats_reset_post"
+      }
+    },
+    "/monitor/timeline": {
+      "get": {
+        "operationId": "get_timeline_monitor_timeline_get"
+      }
+    },
+    "/pdf": {
+      "post": {
+        "operationId": "generate_pdf_pdf_post"
+      }
+    },
+    "/schema": {
+      "get": {
+        "operationId": "get_schema_schema_get"
+      }
+    },
+    "/screenshot": {
+      "post": {
+        "operationId": "generate_screenshot_screenshot_post"
+      }
+    },
+    "/token": {
+      "post": {
+        "operationId": "get_token_token_post"
+      }
+    }
+  }
+}

--- a/tests/tiers/crawl4ai-job-api.test.ts
+++ b/tests/tiers/crawl4ai-job-api.test.ts
@@ -1,0 +1,237 @@
+// vikunja#684 — the crawl4ai async job API: its route and its response shape.
+//
+// Both fixtures in this file were captured from the deployed instance, not
+// hand-authored: the OpenAPI document from GET /openapi.json, and the completed
+// job envelope by actually enqueueing a crawl and polling it to completion. A
+// hand-written mock is what let this bug survive — the code and the mock agreed
+// with each other and neither agreed with the server.
+//
+// Two independent defects lived here, and both were silent:
+//
+//   1. The poll route was `/task/{task_id}`, which does not exist on 0.8.6. It
+//      404s, the !resp.ok guard returns null, and the tier books an ordinary
+//      miss. That spelling is still printed in upstream's own installation doc
+//      (overview-05-installation.md), which is the likely reason two forge
+//      repos wrote it independently — jobsearch-mcp has the same defect
+//      (vikunja#654).
+//   2. The payload did not survive the rename. A completed job nests the crawl
+//      result one level deeper than the old code read. Repointing the route
+//      alone would have turned a 404 into a 200 that still produced no text.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// config.js reads CRAWL4AI_URL at import time, and imports are hoisted above
+// module-scope statements — so this has to run in a hoisted block or the tier
+// loads with a null base URL and the route assertion checks "null/crawl/job/…".
+vi.hoisted(() => {
+  process.env.CRAWL4AI_URL = "http://crawl4ai:11235";
+});
+
+import {
+  CRAWL4AI_TARGET_VERSION,
+  pollCrawl4aiTask,
+} from "../../src/tiers/crawl4ai.js";
+
+function fixture(name: string): Record<string, unknown> {
+  const path = fileURLToPath(
+    new URL(`../fixtures/${name}.json`, import.meta.url),
+  );
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+const openapi = fixture("crawl4ai-0.8.6-openapi") as {
+  paths: Record<string, unknown>;
+  _captured: { crawl4ai_version: string };
+};
+const completedJob = fixture("crawl4ai-0.8.6-job-completed");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("crawl4ai job route, against the deployed OpenAPI document", () => {
+  it("targets the crawl4ai version the fixture was captured from", () => {
+    // If someone refreshes the fixture from a newer instance without revisiting
+    // this tier, this is what says so.
+    expect(CRAWL4AI_TARGET_VERSION).toBe(openapi._captured.crawl4ai_version);
+  });
+
+  it("exposes the job status route this tier polls", () => {
+    expect(Object.keys(openapi.paths)).toContain("/crawl/job/{task_id}");
+  });
+
+  it("does not expose the route this tier used to poll", () => {
+    // The negative half. Without it, "the route we use exists" would pass just
+    // as well on a server that also still served the old one.
+    expect(Object.keys(openapi.paths)).not.toContain("/task/{task_id}");
+  });
+});
+
+describe("pollCrawl4aiTask — route", () => {
+  it("polls /crawl/job/{task_id}", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(completedJob), { status: 200 }),
+    );
+
+    await pollCrawl4aiTask(
+      "crawl_0b0268d9",
+      "https://example.com",
+      8000,
+      new AbortController().signal,
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://crawl4ai:11235/crawl/job/crawl_0b0268d9",
+      expect.anything(),
+    );
+  });
+
+  it("never polls the retired /task/{id} route", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(completedJob), { status: 200 }),
+    );
+
+    await pollCrawl4aiTask(
+      "crawl_0b0268d9",
+      "https://example.com",
+      8000,
+      new AbortController().signal,
+    );
+
+    const polled = mockFetch.mock.calls.map((c) => String(c[0]));
+    expect(polled.every((u) => !u.includes("/task/"))).toBe(true);
+  });
+
+  it("reports a 404 rather than dropping the tier silently", async () => {
+    // The whole reason this bug lasted: a missing route was indistinguishable
+    // from a page with no content.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockResolvedValue(new Response("not found", { status: 404 }));
+
+    const result = await pollCrawl4aiTask(
+      "crawl_gone",
+      "https://example.com",
+      8000,
+      new AbortController().signal,
+    );
+
+    expect(result).toBeNull();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("404"));
+    spy.mockRestore();
+  });
+});
+
+describe("pollCrawl4aiTask — completed job payload", () => {
+  it("reads markdown from result.results[0], the shape 0.8.6 actually returns", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(completedJob), { status: 200 }),
+    );
+
+    const result = await pollCrawl4aiTask(
+      "crawl_0b0268d9",
+      "https://example.com",
+      8000,
+      new AbortController().signal,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.text).toContain("raw markdown body");
+    expect(result?.title).toBe("Example Domain");
+    expect(result?.html).toBe("<h1>Example Domain</h1>");
+  });
+
+  it("honours preferFit against the nested shape", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(completedJob), { status: 200 }),
+    );
+
+    const result = await pollCrawl4aiTask(
+      "crawl_0b0268d9",
+      "https://example.com",
+      8000,
+      new AbortController().signal,
+      true,
+    );
+
+    expect(result?.text).toContain("fit markdown body");
+  });
+
+  it("still reads the older flat shape, for a backend that returns one", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          task_id: "crawl_legacy",
+          status: "completed",
+          result: {
+            markdown: { raw_markdown: "legacy flat body" },
+            metadata: { title: "Legacy" },
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await pollCrawl4aiTask(
+      "crawl_legacy",
+      "https://example.com",
+      8000,
+      new AbortController().signal,
+    );
+
+    expect(result?.text).toContain("legacy flat body");
+  });
+
+  it("returns null on the pre-fix read path — the defect this pins", async () => {
+    // A completed job whose crawl result is correctly nested, read by a client
+    // expecting the flat shape, yields no markdown at all. Asserting the
+    // envelope is nested is not the same as asserting the reader follows it,
+    // so this drives the real function against a payload with NOTHING at the
+    // old location.
+    const nestedOnly = {
+      task_id: "crawl_x",
+      status: "completed",
+      result: {
+        success: true,
+        results: [{ markdown: { raw_markdown: "only nested" } }],
+      },
+    };
+    expect(
+      (nestedOnly.result as Record<string, unknown>).markdown,
+    ).toBeUndefined();
+
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(nestedOnly), { status: 200 }),
+    );
+
+    const result = await pollCrawl4aiTask(
+      "crawl_x",
+      "https://example.com",
+      8000,
+      new AbortController().signal,
+    );
+
+    expect(result?.text).toBe("only nested");
+  });
+
+  it("returns null on a failed job", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ status: "failed", task_id: "crawl_f" }), {
+        status: 200,
+      }),
+    );
+
+    const result = await pollCrawl4aiTask(
+      "crawl_f",
+      "https://example.com",
+      8000,
+      new AbortController().signal,
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/tests/tiers/firecrawl-html-format.test.ts
+++ b/tests/tiers/firecrawl-html-format.test.ts
@@ -1,0 +1,132 @@
+// vikunja#649 — the HTML format name is a per-version axis, on both the request
+// and the response.
+//
+// v1's format enum is `markdown | rawHtml | screenshot`. Sending `html` to it
+// returns a 400 and fails the *entire* scrape, so the unconditional
+// `formats: ["markdown", "html"]` this replaces meant every tier-1 request
+// failed under FIRECRAWL_API_VERSION=v1. That is latent under the current v2
+// deployment and live the moment anyone rolls back — which is a supported
+// operation, not a dead branch.
+//
+// The read side carries the same defect independently: `data.data.html` is
+// undefined under v1 even once the request is accepted, so TierResult.html came
+// back empty and post-extraction had nothing to work with.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const ENV = ["FIRECRAWL_API_VERSION", "FIRECRAWL_URL", "FIRECRAWL_WAIT_FOR_MS"];
+
+function clearEnv() {
+  for (const k of ENV) delete process.env[k];
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  clearEnv();
+});
+
+afterEach(clearEnv);
+
+const URL_ = "https://example.com/page";
+
+/** A backend that answers in `field`, as the real one of that version does. */
+function scrapeResponse(field: "html" | "rawHtml", markup: string) {
+  return new Response(
+    JSON.stringify({
+      success: true,
+      data: {
+        markdown: "# Title\n\nContent here",
+        [field]: markup,
+        metadata: { title: "Title", sourceURL: URL_, statusCode: 200 },
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+async function loadScrape(version: "v1" | "v2") {
+  process.env.FIRECRAWL_API_VERSION = version;
+  vi.resetModules();
+  const { firecrawlScrape } = await import("../../src/tiers/firecrawl.js");
+  return firecrawlScrape;
+}
+
+function sentFormats(): unknown {
+  const init = mockFetch.mock.calls[0]?.[1] as { body: string };
+  return JSON.parse(init.body).formats;
+}
+
+describe("firecrawlScrape — request format name", () => {
+  it("asks v1 for rawHtml, the only HTML format its enum accepts", async () => {
+    const scrape = await loadScrape("v1");
+    mockFetch.mockResolvedValueOnce(scrapeResponse("rawHtml", "<p>v1</p>"));
+    await scrape(URL_);
+    expect(sentFormats()).toEqual(["markdown", "rawHtml"]);
+  });
+
+  it("asks v2 for html", async () => {
+    const scrape = await loadScrape("v2");
+    mockFetch.mockResolvedValueOnce(scrapeResponse("html", "<p>v2</p>"));
+    await scrape(URL_);
+    expect(sentFormats()).toEqual(["markdown", "html"]);
+  });
+
+  it("never sends v2's spelling to v1 — this is what 400s the whole scrape", async () => {
+    const scrape = await loadScrape("v1");
+    mockFetch.mockResolvedValueOnce(scrapeResponse("rawHtml", "<p>v1</p>"));
+    await scrape(URL_);
+    expect(sentFormats()).not.toContain("html");
+  });
+});
+
+describe("firecrawlScrape — response field name", () => {
+  it("reads rawHtml back from v1", async () => {
+    const scrape = await loadScrape("v1");
+    mockFetch.mockResolvedValueOnce(
+      scrapeResponse("rawHtml", "<h1>from v1</h1>"),
+    );
+    const result = await scrape(URL_);
+    expect(result.html).toBe("<h1>from v1</h1>");
+  });
+
+  it("reads html back from v2", async () => {
+    const scrape = await loadScrape("v2");
+    mockFetch.mockResolvedValueOnce(scrapeResponse("html", "<h1>from v2</h1>"));
+    const result = await scrape(URL_);
+    expect(result.html).toBe("<h1>from v2</h1>");
+  });
+
+  it("does not silently accept the other version's field", async () => {
+    // The bug being pinned: a v1 backend answering in `rawHtml` while the
+    // reader looked at `html` produced `undefined` rather than an error, so
+    // post-extraction degraded quietly instead of failing loudly.
+    const scrape = await loadScrape("v1");
+    mockFetch.mockResolvedValueOnce(scrapeResponse("html", "<h1>wrong</h1>"));
+    const result = await scrape(URL_);
+    expect(result.html).toBeUndefined();
+  });
+
+  it("still returns markdown text when the HTML field is absent", async () => {
+    // html is optional in TierResult; a missing one must not fail the scrape.
+    const scrape = await loadScrape("v2");
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            markdown: "# Title\n\nContent here",
+            metadata: { title: "Title", sourceURL: URL_, statusCode: 200 },
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    const result = await scrape(URL_);
+    expect(result.text).toContain("Content here");
+    expect(result.html).toBeUndefined();
+  });
+});

--- a/tests/tiers/firecrawl.test.ts
+++ b/tests/tiers/firecrawl.test.ts
@@ -12,13 +12,19 @@ beforeEach(() => {
 const URL = "https://example.com/page";
 
 // Real Response so firecrawlScrape's readBoundedText(res) has a body to read.
+//
+// The HTML field is `rawHtml`, not `html`: this file imports firecrawlScrape
+// statically, so it runs at the FIRECRAWL_API_VERSION default, which is v1, and
+// a v1 backend answers in `rawHtml`. The fixture previously said `html` — a v2
+// shape against a v1 client — which only passed because the reader ignored the
+// version. Both spellings are covered per-version in firecrawl-html-format.test.ts.
 function mockSuccess(overrides?: object) {
   return new Response(
     JSON.stringify({
       success: true,
       data: {
         markdown: "# Title\n\nContent here",
-        html: "<h1>Title</h1><p>Content here</p>",
+        rawHtml: "<h1>Title</h1><p>Content here</p>",
         metadata: {
           title: "Title",
           sourceURL: URL,
@@ -67,7 +73,7 @@ describe("firecrawlScrape", () => {
 
   it("returns empty text when markdown is empty (not a throw)", async () => {
     mockFetch.mockResolvedValueOnce(
-      mockSuccess({ markdown: "", html: "<p>x</p>" }),
+      mockSuccess({ markdown: "", rawHtml: "<p>x</p>" }),
     );
     const result = await firecrawlScrape(URL);
     expect(result.text).toBe("");

--- a/tests/tiers/raw.test.ts
+++ b/tests/tiers/raw.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -104,18 +104,87 @@ describe("rawFetch", () => {
     expect(result.text.length).toBeLessThanOrEqual(10);
   });
 
-  it("throws descriptive error on PDF content-type", async () => {
+  it("throws a descriptive error on a real PDF — header AND %PDF- signature", async () => {
+    // Note the real body stream. The previous version of this test passed
+    // `body: null` with a `text()` stub, so readBoundedText took its no-reader
+    // path and returned "" — the assertion passed on the Content-Type alone and
+    // never once exercised a PDF body.
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
       statusText: "OK",
       headers: new Headers({ "Content-Type": "application/pdf" }),
-      body: null,
-      text: () => Promise.resolve("%PDF-1.4"),
+      body: bodyStream("%PDF-1.4\n%\xE2\xE3\xCF\xD3\n1 0 obj"),
     });
     await expect(rawFetch(URL)).rejects.toThrow(
       "PDF content cannot be extracted by raw fetch",
     );
+  });
+
+  it("does not claim PDF for a body declared application/pdf that is not one", async () => {
+    // An error page or interstitial served with the wrong Content-Type. Keying
+    // on the header alone turned these into a hard "this is a PDF" failure when
+    // Readability could extract them perfectly well (vikunja#682).
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "Content-Type": "application/pdf" }),
+      body: bodyStream(
+        "<html><body><article><h1>Document unavailable</h1>" +
+          "<p>The requested document has been moved to the archive.</p>" +
+          "</article></body></html>",
+      ),
+    });
+    const result = await rawFetch(URL);
+    expect(result.text).toContain("moved to the archive");
+  });
+});
+
+describe("rawFetch — PDF failure message names the real cause", () => {
+  // The old message read "use Crawl4AI", which was wrong twice over: Crawl4AI
+  // cannot parse PDFs either, and reaching tier 3 at all means tier 1 already
+  // declined. What the operator needs to know is which of those two situations
+  // they are in, and that depends on the configured backend version.
+  const pdfResponse = () => ({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: new Headers({ "Content-Type": "application/pdf" }),
+    body: bodyStream("%PDF-1.4\ntrailer"),
+  });
+
+  afterEach(() => {
+    delete process.env.FIRECRAWL_API_VERSION;
+    vi.resetModules();
+  });
+
+  it("under v1, points at the backend version — no config change will help", async () => {
+    process.env.FIRECRAWL_API_VERSION = "v1";
+    vi.resetModules();
+    const { rawFetch: freshRawFetch } = await import("../../src/tiers/raw.js");
+    mockFetch.mockResolvedValueOnce(pdfResponse());
+    await expect(freshRawFetch(URL)).rejects.toThrow(
+      /FIRECRAWL_API_VERSION is v1, which has no PDF support/,
+    );
+  });
+
+  it("under v2, points at tier 1 — PDFs are supported, so this URL is the problem", async () => {
+    process.env.FIRECRAWL_API_VERSION = "v2";
+    vi.resetModules();
+    const { rawFetch: freshRawFetch } = await import("../../src/tiers/raw.js");
+    mockFetch.mockResolvedValueOnce(pdfResponse());
+    await expect(freshRawFetch(URL)).rejects.toThrow(
+      /tier 1 \(Firecrawl\) handles PDFs but returned nothing/,
+    );
+  });
+
+  it("never tells the operator to use Crawl4AI, which cannot parse PDFs", async () => {
+    process.env.FIRECRAWL_API_VERSION = "v2";
+    vi.resetModules();
+    const { rawFetch: freshRawFetch } = await import("../../src/tiers/raw.js");
+    mockFetch.mockResolvedValueOnce(pdfResponse());
+    await expect(freshRawFetch(URL)).rejects.not.toThrow(/Crawl4AI/);
   });
 });
 

--- a/tests/user-agent-drift.test.ts
+++ b/tests/user-agent-drift.test.ts
@@ -1,0 +1,83 @@
+// vikunja#641 — the outbound User-Agent must come from package.json, always.
+//
+// This is the third time the class has appeared. src/version.ts was introduced
+// to end it, and its own header records the first round: "they used to be
+// hardcoded to 3.10.0 / 3.5.0 / 3.7.0 independently". Three more had drifted
+// again by 3.23.0 — llms-txt.ts claiming 3.8.0, reddit.ts and youtube.ts both
+// claiming 3.15.0. The ticket named only the first.
+//
+// So the fix is not three more edits; it is a check that fails the next one.
+// Every outbound request from this server identifies the software to a third
+// party, and a version that is fifteen releases stale is a plain untruth about
+// who is calling — the thing a User-Agent exists to say.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { USER_AGENT } from "../src/fetch-utils.js";
+import { VERSION } from "../src/version.js";
+
+const SRC = fileURLToPath(new URL("../src", import.meta.url));
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) out.push(...tsFiles(path));
+    else if (entry.endsWith(".ts")) out.push(path);
+  }
+  return out;
+}
+
+describe("outbound User-Agent", () => {
+  it("is built from the package version", () => {
+    expect(USER_AGENT).toContain(`searxng-mcp/${VERSION}`);
+  });
+
+  it("reports the version package.json actually declares", () => {
+    // Read package.json directly rather than trusting VERSION, which is what
+    // resolveVersion() returns and would agree with itself even if the walk-up
+    // silently fell through to its "0.0.0" default.
+    const pkg = JSON.parse(
+      readFileSync(
+        fileURLToPath(new URL("../package.json", import.meta.url)),
+        "utf8",
+      ),
+    ) as { version: string };
+    expect(VERSION).toBe(pkg.version);
+    expect(VERSION).not.toBe("0.0.0");
+  });
+
+  it("is not hardcoded anywhere in src/", () => {
+    // The guard. A literal `searxng-mcp/<semver>` in source is a version that
+    // cannot follow a release, which is exactly how all six previous instances
+    // came about.
+    const offenders: string[] = [];
+    for (const file of tsFiles(SRC)) {
+      const body = readFileSync(file, "utf8");
+      for (const [i, line] of body.split("\n").entries()) {
+        // Skip comments — the version.ts header legitimately quotes the old
+        // hardcoded values while explaining why they must not come back.
+        const code = line.trim();
+        if (code.startsWith("//") || code.startsWith("*")) continue;
+        if (/["'`]searxng-mcp\/\d+\.\d+\.\d+/.test(line)) {
+          offenders.push(`${file.slice(SRC.length + 1)}:${i + 1}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("is the same string on every outbound path", () => {
+    // reddit.ts and youtube.ts each had their own constant, which is how they
+    // drifted together to 3.15.0 while llms-txt.ts sat at 3.8.0. There should
+    // be exactly one definition.
+    const definitions = tsFiles(SRC).filter((file) =>
+      /^\s*export const USER_AGENT\s*=/m.test(readFileSync(file, "utf8")),
+    );
+    expect(definitions.map((f) => f.slice(SRC.length + 1))).toEqual([
+      "fetch-utils.ts",
+    ]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,15 +11,26 @@ export default defineConfig({
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.d.ts", "src/index.ts"],
-      // Floor set from the measured baseline (2026-07-12, domain-stats build),
-      // not a guessed target: statements 73.28%, branches 66.06%, functions
-      // 75.17%, lines 75.32%. Small margin below each so normal fluctuation
-      // doesn't fail CI; ratchet up as coverage grows.
+      // Floor set from the measured baseline (2026-09-06, consolidated fix
+      // pass), not a guessed target: statements 85.51%, branches 78.54%,
+      // functions 84.86%, lines 87.83%. Roughly 1.5 points below each, so
+      // normal fluctuation does not fail CI.
+      //
+      // Previous floor was 72/65/74/74, measured 2026-07-12 against
+      // statements 73.28 / branches 66.06 / functions 75.17 / lines 75.32.
+      // It then went ten releases without being touched while real coverage
+      // climbed twelve points, so by v3.23.0 the gate permitted a silent
+      // twelve-point regression — the comment already said "ratchet up as
+      // coverage grows" and nothing did it (vikunja#680).
+      //
+      // Record the measured numbers with each bump. Without them the next
+      // person has no way to tell an intentional floor from a stale one, which
+      // is exactly how this drifted.
       thresholds: {
-        lines: 74,
-        statements: 72,
-        functions: 74,
-        branches: 65,
+        lines: 86,
+        statements: 84,
+        functions: 83,
+        branches: 77,
       },
     },
   },


### PR DESCRIPTION
Seven commits closing ten Vikunja tickets. Build plan: `searxng-mcp-fix-pass-2026-09`.

Phase order was load-bearing and is preserved: the coverage ratchet follows the phases that add tests, the README split follows the phases that change documented behaviour, and the image publish is last so the first published image contains the fixes.

## What changed

| Commit | Tickets | |
|---|---|---|
| `ec8471a` | #682, #649 | Restore PDF fetching; version-key the Firecrawl HTML format |
| `aadb393` | #684 | Fix the crawl4ai job poll — route *and* payload shape |
| `094ad1a` | #682 pt4, #641 | Name why each tier failed; end the User-Agent drift |
| `8f73cb7` | #686 | `domain_stats`: real window, schema version, thin-sample marker |
| `24da325` | #683, #646 | Split the README into `docs/` |
| `0a4bb8a` | #634, #680 | Gate the dev tree; ratchet the coverage floor |
| `014d73b` | #681 | Publish the container image to GHCR on release tags |

## The headline is a deletion

`src/fetch.ts` carried a comment saying *"Firecrawl can't extract PDF text"* and routed every `.pdf` URL straight to tier 2 on that basis. True of trieve/firecrawl v0.0.55; false of the v2 backend deployed since. Meanwhile Crawl4AI — the tier it diverted to — renders the PDF in a browser, finds no text nodes, trips its anti-bot heuristic, and the resulting `null` surfaced as `"CRAWL4AI_URL not configured"` on containers where it plainly was. So every PDF was routed to the one tier that could not serve it, and the error sent investigators to check config that was already correct.

Verified end to end against the live v2 backend, through the MCP surface:

- **Positive:** RFC 9110's PDF returns extracted text, served by tier 1, no tier misses.
- **Negative control:** with tier 1 pointed at a dead port, tier1/2/3 all miss and the result is `"All fetch tiers failed"`. That both validates the tier narration as a signal and independently reproduces the old routing's failure.

## Four things the plan did not anticipate

1. **#684 is two defects, not one.** Repointing the route alone would have turned a 404 into a 200 that still produced no text — a completed crawl4ai job nests the result one level deeper than the old code read. Both fixtures are captured from the deployed instance, not hand-authored. Separately: `POST /crawl` on 0.8.6 is synchronous and never returns a `task_id`, so this branch is a compatibility path the deployed backend does not currently enter. Said so in the code rather than letting the tests imply otherwise. Contract handed to #654 so `jobsearch-mcp` need not re-derive it.
2. **#641 had four occurrences, not one.** `reddit.ts` and `youtube.ts` also claimed 3.15.0 against a repo at 3.23.0. This is the second round of the class — `src/version.ts` was created to end the first — so the fix is a check that fails the next one, confirmed red on `main`.
3. **#646 is already fixed** (`git log -S` → `f04be82`), like #644. The plan cited "19 adblock/CDP references" as evidence it was live; those 19 mentions are the corrected text. A reference count is not a correctness check.
4. **`pnpm.overrides` does not move `vite`.** It is vitest's *peer*, and pnpm does not apply overrides to auto-installed peers — the lockfile sat at 8.0.7 through `install`, `update` and `install --force` while printing `unmet peer vite@>=8.0.16: found 8.0.7`. An explicit devDependency is what actually moved it.

One plan step was dropped as already done: #686 asked to promote per-tier sample counts to `structuredContent` as `n_ok`/`n_total`, but `attempts`/`ok`/`fail` are already there and already declared in the output schema. The genuinely missing fields were `schema_version` and the window.

## Verification

Every gate was observed working, not assumed:

- **PDF routing guard** confirmed red on `main` — 4 of 5 cases fail; the fifth is the extensionless-URL case the old suffix matcher could not see.
- **User-agent guard** confirmed red on `main`, listing exactly `llms-txt.ts:22`, `reddit.ts:13`, `youtube.ts:14`.
- **Coverage gate** proven to fail: against a copy of the config with the branches floor at 95 it exits 1 with `Coverage for branches (78.54%) does not meet global threshold (95%)`. Restored and re-verified green.
- **Dev audit gate**: `pnpm audit --dev` exit 1 → 0 across the vite bump. That before/after *is* the control.
- **Phase 3** through the MCP surface: `CRAWL4AI_URL` unset gives `tier2_crawl4ai: skipped (not_configured)`; set-but-unreachable gives `attempted, no content`.
- **Phase 4** against the live domain database: the header would have claimed "30d window" over a window 33 hours old.
- **Phase 7** rehearsed locally against the real image — all five smoke assertions pass. On port 38401, because 3001 was already bound on that host and a smoke test against someone else's listener passes while describing the wrong process.
- **README split** checked mechanically: a script resolves every intra-repo link and anchor against the target file's real headings and asserts no orphaned docs. Content conservation diffed against `HEAD`.

Three stale tests were retargeted rather than deleted. Notably `tests/tiers/raw.test.ts`'s PDF case passed `body: null` with a `text()` stub, so `readBoundedText` took its no-reader path and the assertion never once exercised a PDF body.

Tests 883 → 925. Coverage floor 72/65/74/74 → 84/77/83/86, measured at 85.51 / 78.54 / 84.86 / 87.83.

## Filed, not fixed here

- **#687** — the crawl4ai tier swallows connection errors, so an unreachable backend still reads as "attempted, no content".
- **#688** — 92% of live domain-db records are stale-schema: dropped on read but never deleted, so each bump leaves a dead generation resident for 90 days.

## Deliberately untouched

The domain-db schema-bump reset (documented, accepted 2026-09-02), and `pnpm audit --prod`'s threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)