### PR TITLE
Restore tier 2, ready the client for crawl4ai 0.9.3, vendor the reranker (v3.25.0)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,9 @@ on:
 
 env:
   IMAGE: ghcr.io/tadmstr/searxng-mcp
+  # Not bare `reranker`: this lands in a shared namespace alongside every other
+  # package, and a rename after publication is worse than a long name.
+  RERANKER_IMAGE: ghcr.io/tadmstr/searxng-mcp-reranker
 
 jobs:
   publish:
@@ -148,5 +151,135 @@ jobs:
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  # A sibling job rather than more steps in `publish`: it is a different image
+  # with a different contract, and keeping it separate means a reranker failure
+  # names itself instead of appearing as "the publish job broke". It shares the
+  # release tag, because the reranker is versioned by the repo that vendors it
+  # (vikunja#692).
+  publish-reranker:
+    name: Build, smoke test, publish reranker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # amd64 only, consistent with the main image.
+      - name: Build reranker image
+        run: docker build -t "$RERANKER_IMAGE:candidate" ./docker/reranker
+
+      # Asserts the CONTRACT, not the boot. A reranker that starts and returns
+      # the documents in the order it received them passes any liveness check
+      # while silently doing nothing — which is the exact failure this service
+      # degrades into, since searxng-mcp falls back to SearXNG's ordering when
+      # reranking is absent and says so only in a throttled log line.
+      - name: Smoke test the reranker image
+        run: |
+          set -euo pipefail
+
+          # --network none is the assertion that the model is genuinely baked
+          # into the image. If the pre-bake ever silently stops working, the
+          # container cannot reach the download and this step fails here rather
+          # than becoming a 30-60s cold start in production.
+          docker run -d --name rr-publish --network none "$RERANKER_IMAGE:candidate"
+
+          for i in $(seq 1 30); do
+            if docker exec rr-publish python -c "
+          import urllib.request, json, sys
+          sys.exit(0 if json.load(urllib.request.urlopen('http://127.0.0.1:8787/health'))['model_loaded'] else 1)
+          " 2>/dev/null; then break; fi
+            if [ "$i" = 30 ]; then
+              echo "reranker never became ready"; docker logs rr-publish; exit 1
+            fi
+            sleep 1
+          done
+          echo "model_loaded true with no network — the model is baked in"
+
+          docker exec rr-publish python -c "
+          import urllib.request, json, sys
+          body = json.dumps({
+              'query': 'how do I train a dog',
+              'documents': [
+                  'Bananas are a yellow fruit that grows in tropical climates.',
+                  'Puppy obedience training uses positive reinforcement and short daily sessions.',
+              ],
+              'return_documents': True,
+          }).encode()
+          req = urllib.request.Request(
+              'http://127.0.0.1:8787/v1/rerank', data=body,
+              headers={'Content-Type': 'application/json'})
+          d = json.load(urllib.request.urlopen(req))
+
+          results = d['results']
+          print('results:', json.dumps(results, indent=2))
+
+          # The relevant document is index 1, so a service that preserved input
+          # order — i.e. reranked nothing — fails here.
+          assert results[0]['index'] == 1, 'not reordered: reranking is a no-op'
+          assert results[0]['relevance_score'] > results[1]['relevance_score'], 'scores not ordered'
+          assert all('relevance_score' in r for r in results), 'missing relevance_score'
+          assert len(results) == 2, 'documents lost'
+          print('rerank contract OK')
+          "
+
+          uid=$(docker exec rr-publish id -u)
+          echo "runtime uid -> $uid"
+          [ "$uid" = 10001 ]
+
+      - name: Reranker logs
+        if: always()
+        run: docker logs rr-publish || true
+
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$GHCR_TOKEN" \
+            | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+
+      # Same tag policy as the main image, for the same reasons: both `v`-
+      # prefixed and bare tags, and floating tags that do not move for a
+      # prerelease.
+      - name: Tag and push reranker
+        id: push
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          V="${REF_NAME#v}"
+          MINOR="$(echo "$V" | cut -d. -f1,2)"
+
+          TAGS=("$REF_NAME" "$V")
+          case "$V" in
+            *-*) echo "prerelease $V — publishing exact tags only, not :$MINOR or :latest" ;;
+            *)   TAGS+=("$MINOR" "latest") ;;
+          esac
+
+          for t in "${TAGS[@]}"; do
+            echo "pushing $RERANKER_IMAGE:$t"
+            docker tag "$RERANKER_IMAGE:candidate" "$RERANKER_IMAGE:$t"
+            docker push "$RERANKER_IMAGE:$t"
+          done
+
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$RERANKER_IMAGE:$V" | cut -d@ -f2)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "pushed digest $DIGEST"
+
+      # vikunja#689 (provenance not attached as an OCI referrer) applies here
+      # exactly as it does to the main image. Not re-derived, and registry-
+      # native verification is not a gate until #689 is resolved.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.RERANKER_IMAGE }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -229,6 +229,35 @@ jobs:
           print('rerank contract OK')
           "
 
+          # Request bounds. Asserted here because they are a property of the
+          # published artefact, not of the compose file that happens to bind it
+          # to loopback — an adopter can front this image however they like.
+          docker exec rr-publish python -c "
+          import urllib.request, urllib.error, json
+
+          def post(payload):
+              body = json.dumps(payload).encode()
+              req = urllib.request.Request(
+                  'http://127.0.0.1:8787/v1/rerank', data=body,
+                  headers={'Content-Type': 'application/json'})
+              try:
+                  return urllib.request.urlopen(req).status
+              except urllib.error.HTTPError as e:
+                  return e.code
+
+          # The real caller's measured shape must be unaffected: the live
+          # SearXNG feeding this sends ~30 documents of ~430 chars.
+          real = {'query': 'q', 'documents': ['title. ' + 'x' * 420 for _ in range(34)]}
+          assert post(real) == 200, 'the real caller shape was rejected'
+
+          assert post({'query': 'q', 'documents': ['d'] * 1000}) == 200, 'cap is too tight'
+          assert post({'query': 'q', 'documents': ['d'] * 1001}) == 422, 'document cap not enforced'
+          assert post({'query': 'q' * 20001, 'documents': ['d']}) == 422, 'query cap not enforced'
+          # Oversized documents truncate rather than reject.
+          assert post({'query': 'q', 'documents': ['x' * 50000]}) == 200, 'long document should truncate'
+          print('request bounds OK')
+          "
+
           uid=$(docker exec rr-publish id -u)
           echo "runtime uid -> $uid"
           [ "$uid" = 10001 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,69 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.25.0] - 2026-09-06
+
+**Fetch tier 2 was failing 100% of crawls and is restored.** Not a regression introduced here —
+it had been dead for as long as `ADBLOCK_PROXY_URL` was set, and was invisible because the tier
+recorded every backend failure as an ordinary empty result. The rest of the release makes the
+client safe for a Crawl4AI 0.9.3 server upgrade and vendors the reranker, which until now was
+documented but unobtainable.
+
+### Fixed
+- **Tier 2 crawled nothing, and said nothing** (vikunja#690). Every request carried
+  `proxy_config: {server: ADBLOCK_PROXY_URL}`. That proxy address is resolved by *Crawl4AI*, in
+  Crawl4AI's container — not by this process — and `adblock-proxy` sits on a network Crawl4AI is
+  not on. `getent hosts adblock-proxy` from inside Crawl4AI does not resolve, so every crawl
+  returned `net::ERR_PROXY_CONNECTION_FAILED`. Confirmed against the live backend with a
+  control: the identical request without the field succeeds. The field is gone. Tier 3's use of
+  `ADBLOCK_PROXY_URL` is unchanged and does work, because tier 3 resolves the proxy in-process —
+  the two look alike and are not the same thing, which is why the reasoning now sits in a
+  comment at the call site.
+- **Tier 2 reported backend failures as "attempted, no content"** (narrows vikunja#687). It
+  returned `null` for non-2xx responses, failed jobs, poll timeouts and transport errors alike,
+  and `runTier` books `null` as `empty_result`. A total outage was therefore indistinguishable
+  from pages that happened to be empty — which is how `ERR_PROXY_CONNECTION_FAILED` sat in the
+  response body for weeks without anyone seeing it. Tier 1 always threw here; tier 2 now does
+  too, and returns `null` only for a genuinely empty result. Two details decide whether the
+  reason is usable: the `net::ERR_*` token is lifted out of Crawl4AI's traceback and led with,
+  so it survives the 200-char bound applied downstream, and transport failures report
+  `cause.code` (`ECONNRESET`, `ENOTFOUND`, …) rather than Node's bare `"fetch failed"`.
+  #687 is **narrowed, not closed** — this fixes the concrete instance; whether the general
+  swallow-the-error defect survives elsewhere needs its own evidence.
+
+### Changed
+- **Crawl4AI target version 0.8.6 → 0.9.3** (vikunja#691), established by probing a scratch
+  0.9.3 rather than by reading the changelog. The synchronous response shape is unchanged —
+  0.9.x was billed as an untested third possibility and is not one. `crawler_config` still
+  passes the trust boundary that rejects `proxy_config`, so selector tuning survives. Both
+  OpenAPI fixtures are kept and both asserted: this client ships *before* the server upgrade, so
+  "works on 0.9.3" must not quietly become "no longer works on 0.8.6".
+- **A tokenless 0.9.x server is now called out when it refuses a request.** On 0.9.x with no
+  `CRAWL4AI_API_TOKEN`, Crawl4AI binds the *container's* loopback: `docker ps` reports healthy,
+  the container's own `/health` returns 200, and the published port answers with a connection
+  reset. `/health` is unauthenticated even when a token is set, so no healthcheck anywhere
+  distinguishes it. searxng-mcp now explains this the first time a crawl is refused, covering
+  both shapes the failure takes — HTTP 401, and a connection reset with no status at all. It
+  fires on an observed failure rather than pre-emptively, so it stays silent against the 0.8.6
+  that is still deployed.
+- **0.9.x's generic 5xx `correlation_id` is surfaced** in the tier failure reason, ahead of the
+  prose so truncation cannot remove it. Without it a 0.9.x server error carries no way to find
+  the real cause in the server's own logs. A 422's array-shaped `detail` is no longer dropped.
+
+### Added
+- **The reranker ships in this repo** (vikunja#692), at `docker/reranker/`, and is published as
+  `ghcr.io/tadmstr/searxng-mcp-reranker`. `docs/configuration.md` previously pointed adopters at
+  another repository's `docker/reranker/`, which tracks one file — a compose file saying
+  `build: .` with no Dockerfile beside it. Following the documented path produced a build
+  failure, on the single feature separating this project from every other SearXNG MCP server.
+  Acceptance was a fresh clone and `docker compose up`, with no reference to any other repo.
+- **The reranker model is baked into the image.** A first-run download leaves the reranker
+  absent for 30–60s on every fresh boot, and searxng-mcp silently falls back to SearXNG's
+  ordering behind one throttled log line. ~100MB of image buys a container ready in ~2s that
+  needs no network to start — verified under `docker run --network none`, which is a test the
+  pre-bake cannot pass if the model is missing. Its CI smoke test asserts that documents come
+  back *reordered* with `relevance_score`, not merely that the container started.
+
 ## [3.24.0] - 2026-09-06
 
 Consolidated fix pass closing ten tickets (build `searxng-mcp-fix-pass-2026-09`). **PDF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,20 @@ documented but unobtainable.
   prose so truncation cannot remove it. Without it a 0.9.x server error carries no way to find
   the real cause in the server's own logs. A 422's array-shaped `detail` is no longer dropped.
 
+### Security
+- **The reranker container is hardened and its requests are bounded.** `cap_drop: ALL`,
+  `no-new-privileges`, a read-only root filesystem, an explicit non-root user, and mem/cpu
+  limits; plus caps on document count (1000), document and query length (20000 chars) and
+  request body size (4 MB), all env-tunable. The service has no authentication by design and
+  reranking is CPU-bound on caller-supplied text, so an uncapped request was a denial-of-service
+  surface for anything that could reach the port. Defaults were measured against the live
+  SearXNG that feeds it — ~30 documents of ~430 chars, ~6.7 KB per rerank — leaving 30–600×
+  headroom, so normal traffic cannot reach them. Oversized documents are truncated rather than
+  rejected, since anything past the cap is already beyond FlashRank's 512-token window.
+- **Crawl4AI's relayed error text is recorded as its own accepted risk** rather than inheriting
+  the v3.24.0 acceptance, which was scoped to Firecrawl's `data.error`. Same trust model,
+  separate row, per SC-23.
+
 ### Added
 - **The reranker ships in this repo** (vikunja#692), at `docker/reranker/`, and is published as
   `ghcr.io/tadmstr/searxng-mcp-reranker`. `docs/configuration.md` previously pointed adopters at

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ docker pull ghcr.io/tadmstr/searxng-mcp:latest
 
 Tags, uid, and provenance verification: [Deployment](docs/deployment.md#container-image).
 
+The reranker ships in this repo — `cd docker/reranker && docker compose up`, or pull `ghcr.io/tadmstr/searxng-mcp-reranker`. It is CPU-only, needs no API key, and has the model baked in so there is no cold start. See [`docker/reranker/README.md`](docker/reranker/README.md).
+
 For a full local topology including Firecrawl, Crawl4AI, Ollama, Kiwix, the adblock proxy, and NATS, see [`docker-compose.full.yml`](docker-compose.full.yml).
 
 ## Tools
@@ -74,7 +76,7 @@ differentiators here are in what happens *after* the search:
 | | searxng-mcp | Typical SearXNG MCP server |
 |---|---|---|
 | SearXNG search | yes | yes |
-| ML reranking of results | local cross-encoder, reorders by relevance | SearXNG's own ordering |
+| ML reranking of results | local cross-encoder, reorders by relevance — ships in [`docker/reranker/`](docker/reranker/) | SearXNG's own ordering |
 | Full-page content retrieval | three-tier cascade — Firecrawl, Crawl4AI, in-process raw fetch + Readability | none, or a single raw fetch |
 | Per-domain routing | domain capability database learns which tier works per domain and skips the ones that do not | none |
 | Summarisation | Ollama, with citations back to source URLs | none |
@@ -105,7 +107,7 @@ flowchart TD
     robots["robots.txt pre-check — tiers 1–3\ndisallowed → RobotsDisallowedError (cached 24h)"]
     tier_skip(["Per-domain tier skip\nsuccess rate &lt;30% over ≥10 tries\nor tier_skip operator override"])
     t1["Tier 1 — Firecrawl\n$FIRECRAWL_URL\nserves PDFs under FIRECRAWL_API_VERSION=v2"]
-    t2["Tier 2 — Crawl4AI\n$CRAWL4AI_URL · optional\nadblock proxy if $ADBLOCK_PROXY_URL"]
+    t2["Tier 2 — Crawl4AI\n$CRAWL4AI_URL · optional\ndirect — no adblock proxy"]
     t3["Tier 3 — Raw HTTP + Readability\nfallback: raw HTML slice\nadblock proxy if $ADBLOCK_PROXY_URL"]
     challenge(["Challenge detected\non this URL, this request?"])
     solver["Solver — Byparr\n$SOLVER_URL · opt-in, SOLVER_ENABLED=true\nSSRF-guarded replay"]

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -32,8 +32,8 @@ services:
 #   FIRECRAWL_URL         http://localhost:3002    # Tier-1 JS-render fetch
 #   FIRECRAWL_API_KEY     placeholder-local        # Firecrawl API key
 #   CRAWL4AI_URL          http://localhost:11235   # Tier-2 fetch fallback
-#   CRAWL4AI_API_TOKEN                             # Crawl4AI bearer token (if protected)
-#   RERANKER_URL          http://localhost:8787    # ML reranking (cross-encoder)
+#   CRAWL4AI_API_TOKEN                             # Crawl4AI bearer token — REQUIRED on crawl4ai 0.9.x
+#   RERANKER_URL          http://localhost:8787    # ML reranking — ships in docker/reranker/
 #   OLLAMA_URL            http://localhost:11434   # Query expansion + summarization
 #   OLLAMA_API_KEY                                 # Bearer token for authenticated Ollama proxies
 #   OLLAMA_EXPAND_MODEL   qwen3:4b                 # Model for query expansion

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -120,20 +120,23 @@ services:
     #           capabilities: [gpu]
 
   # ── Reranker (ML cross-encoder reranking) ────────────────────────────────────
-  # Options:
+  # This repo's own reranker: CPU-only, no API key, model baked into the image
+  # so there is no cold start. Source and contract in docker/reranker/.
+  #
+  # Alternatives, if you would rather run something else on port 8787:
   #   - Jina Reranker: docker pull jinaai/jina-reranker-v2-base-multilingual
   #   - Infinity with a cross-encoder model: https://github.com/michaelfeil/infinity
-  #   - Any OpenAI-compatible reranker API at port 8787
+  #   - Any service exposing a Jina-compatible /v1/rerank
   reranker:
-    image: michaelf34/infinity:latest # SECURITY[accepted]: latest tag — example file; pin for production
+    image: ghcr.io/tadmstr/searxng-mcp-reranker:latest # SECURITY[accepted]: latest tag — example file; pin for production
+    # To build from source instead of pulling:
+    # build: ./docker/reranker
     restart: unless-stopped
     ports:
-      - "127.0.0.1:8787:7997"
-    command:
-      - v2
-      - --model-id
-      - cross-encoder/ms-marco-MiniLM-L-6-v2
-    # GPU support: add deploy.resources.reservations.devices as above
+      # Loopback-only: the reranker has no authentication.
+      - "127.0.0.1:8787:8787"
+    environment:
+      - RERANKER_MODEL=ms-marco-MiniLM-L-12-v2
 
   # ── Kiwix (offline Wikipedia / Stack Overflow / Arch Wiki) ──────────────────
   # Requires ZIM files in ./kiwix-data/ — see https://download.kiwix.org/

--- a/docker/reranker/Dockerfile
+++ b/docker/reranker/Dockerfile
@@ -1,0 +1,43 @@
+FROM python:3.12-slim
+
+# Versions pinned to what the four-week-running deployment resolved to on
+# 2026-09-06. The original was unpinned, which is fine for a compose file you
+# rebuild yourself and not fine for an image other people pull: an adopter
+# pulling this tag a year from now should get the reranker that was tested,
+# not whatever FlashRank has since become.
+ENV RERANKER_MODEL=ms-marco-MiniLM-L-12-v2 \
+    RERANKER_CACHE_DIR=/opt/flashrank \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir \
+      fastapi==0.141.1 \
+      "uvicorn[standard]==0.52.4" \
+      FlashRank==0.2.10
+
+COPY main.py .
+
+# Bake the model into the image (~100MB) rather than downloading it on first
+# start. The cold start it removes is 30-60s during which the reranker is
+# absent and results quietly fall back to SearXNG's own ordering behind a
+# single throttled log line — a silent quality regression on every fresh boot,
+# which is the failure shape this repo keeps finding elsewhere. It also drops
+# a runtime network dependency, so the container works on an air-gapped host.
+#
+# RERANKER_CACHE_DIR is read here and by main.py, so the baked path and the
+# loaded path cannot drift. Baking into FlashRank's /tmp default would be
+# undone by any runtime that mounts a tmpfs over /tmp.
+RUN python -c "import os; from flashrank import Ranker; \
+      Ranker(model_name=os.environ['RERANKER_MODEL'], cache_dir=os.environ['RERANKER_CACHE_DIR'])"
+
+# Unprivileged at runtime. The model directory is read-only to this user by
+# design — everything it needs was baked above, so a write attempt here would
+# mean the pre-bake had silently missed.
+RUN useradd --system --uid 10001 --no-create-home reranker \
+    && chown -R root:root "$RERANKER_CACHE_DIR" \
+    && chmod -R a+rX "$RERANKER_CACHE_DIR"
+USER 10001
+
+EXPOSE 8787
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8787"]

--- a/docker/reranker/README.md
+++ b/docker/reranker/README.md
@@ -1,0 +1,112 @@
+# searxng-mcp reranker
+
+A small CPU-only reranking service. searxng-mcp sends it a query and a list of
+search-result snippets; it returns them reordered by relevance.
+
+This is the component that separates searxng-mcp from a plain SearXNG wrapper,
+and until v3.25.0 it was the one component an adopter could not obtain — the
+docs pointed at a compose file in another repository whose `build: .` had no
+`Dockerfile` beside it (vikunja#692). It now lives here.
+
+## Run it
+
+```bash
+docker compose up          # from this directory
+```
+
+Or pull the published image instead of building:
+
+```bash
+docker run -d -p 127.0.0.1:8787:8787 ghcr.io/tadmstr/searxng-mcp-reranker:latest
+```
+
+Then point searxng-mcp at it:
+
+```bash
+RERANKER_URL=http://localhost:8787     # this is already the default
+```
+
+Nothing else is required. There is no API key, no GPU, and no external service.
+
+## The contract
+
+`POST /v1/rerank` — Jina-compatible, so anything that speaks Jina's reranking
+API can talk to it.
+
+```jsonc
+// request
+{
+  "query": "how do I train a dog",
+  "documents": ["Bananas are a yellow fruit.", "Puppy obedience training uses ..."],
+  "top_n": 5,               // optional, truncates the result list
+  "return_documents": false // optional, echoes the text back
+}
+```
+
+```jsonc
+// response — sorted by relevance_score, descending
+{
+  "model": "flashrank",
+  "results": [
+    { "index": 1, "relevance_score": 0.9633, "document": null },
+    { "index": 0, "relevance_score": 0.0000, "document": null }
+  ],
+  "usage": { "total_tokens": 39 }
+}
+```
+
+`index` refers to the position in the request's `documents` array, so the
+caller can map scores back to its own objects. `usage.total_tokens` is a rough
+character-count estimate, present for API compatibility — nothing is billed.
+
+`documents` accepts plain strings or objects with a `text` key; anything else
+is stringified.
+
+`GET /health` returns `{"status": "ok", "model_loaded": true}`. Prefer
+`model_loaded` over the bare status: it is the field that distinguishes a
+container that is serving from one that is up but reranking nothing.
+
+## Configuration
+
+| Variable | Default | Notes |
+|---|---|---|
+| `RERANKER_MODEL` | `ms-marco-MiniLM-L-12-v2` | Any FlashRank model name. Changing it discards the pre-baked model — see below. |
+| `RERANKER_CACHE_DIR` | `/opt/flashrank` | Where the model lives. Read at build *and* run time. |
+
+## The model is baked into the image
+
+The default model (~100 MB) is downloaded at build time, not on first start.
+
+This is deliberate. With a first-run download, a fresh boot leaves the reranker
+absent for 30–60 seconds, during which searxng-mcp degrades to SearXNG's own
+result ordering behind a single throttled log line — results get quietly worse
+and nothing says so. Baking costs image size and buys a container that is
+ready in about two seconds and needs no network to start at all.
+
+Verified: the image starts and serves under `docker run --network none`.
+
+Two consequences worth knowing:
+
+- **Setting `RERANKER_MODEL` to something else re-introduces the download.**
+  Only the default model is baked. A different model will be fetched on first
+  start, with the cold start and the network dependency that implies.
+- **`RERANKER_CACHE_DIR` is read by both the build and the app**, so they
+  cannot drift. Do not point it at `/tmp` — that is FlashRank's own default
+  and is exactly the path a runtime is most likely to replace with a tmpfs,
+  which would hide the baked model and silently restore the download.
+
+## Security
+
+**There is no authentication.** Any caller that can reach the port can submit
+arbitrary text and consume CPU. The compose file publishes on `127.0.0.1` only,
+and that is not incidental — do not move it to `0.0.0.0` without putting
+something in front of it.
+
+The container runs as an unprivileged user (uid 10001) and the model directory
+is read-only to it. Python dependencies are pinned so that pulling this tag
+later gives the versions it was tested with.
+
+## Cost
+
+Zero. It is a CPU cross-encoder — no API key, no per-request charge, no
+external call. Reranking a page of results takes tens of milliseconds.

--- a/docker/reranker/README.md
+++ b/docker/reranker/README.md
@@ -72,6 +72,31 @@ container that is serving from one that is up but reranking nothing.
 |---|---|---|
 | `RERANKER_MODEL` | `ms-marco-MiniLM-L-12-v2` | Any FlashRank model name. Changing it discards the pre-baked model — see below. |
 | `RERANKER_CACHE_DIR` | `/opt/flashrank` | Where the model lives. Read at build *and* run time. |
+| `RERANKER_MAX_DOCUMENTS` | `1000` | Requests with more documents are rejected with 422. |
+| `RERANKER_MAX_DOC_CHARS` | `20000` | Longer documents are **truncated**, not rejected. Also caps `query` length, which *is* rejected. |
+| `RERANKER_MAX_BODY_BYTES` | `4194304` (4 MB) | Bodies over this are rejected with 413. |
+
+### Request bounds
+
+The defaults are far above real use and exist for the deployment you have not
+thought about yet. Measured against the SearXNG that feeds this service: ~30
+documents per rerank, longest document ~430 characters, ~6.7 KB total — so the
+caps leave roughly 30×, 45× and 600× headroom and cannot affect normal traffic.
+
+Oversized *documents* are truncated rather than refused, because anything past
+this length is already beyond what the cross-encoder reads (FlashRank's
+`max_length` is 512 tokens) and refusing would turn a harmless long snippet
+into a failed search.
+
+Two things the body cap does not do, stated because "there is a size limit"
+reads as stronger than it is:
+
+- It reads `Content-Length`, so a **chunked** request slips past it. Such a
+  request is still bounded by the document caps once parsed — later, not never.
+- A body **substantially** over the cap is answered while the client is still
+  sending, so the client sees a connection reset rather than the 413. A body
+  slightly over gets a clean 413. Either way the request is rejected without
+  being processed.
 
 ## The model is baked into the image
 

--- a/docker/reranker/docker-compose.yml
+++ b/docker/reranker/docker-compose.yml
@@ -22,6 +22,14 @@ services:
       # endpoint that any caller can drive.
       - "127.0.0.1:8787:8787"
     restart: unless-stopped
+    # SECURITY[deferred]: this is the only compose file in the repo carrying the
+    # hardening below — docker-compose.full.yml, docker-compose.example.yml and
+    # docker/adblock-proxy/ have none, so the repo now models good practice in
+    # one place and not the others. Retrofitting the rest is vikunja#693 (id
+    # 776). Note `read_only` is NOT a blanket addition there: several of those
+    # services genuinely write to disk. Audit:
+    # 2026-09-06/searxng-mcp-crawl4ai-reranker-2026-09, INFO 2.
+    #
     # The image already runs as uid 10001; naming it here means a `docker run`
     # that overrides the entrypoint cannot quietly regain root.
     user: "10001"

--- a/docker/reranker/docker-compose.yml
+++ b/docker/reranker/docker-compose.yml
@@ -22,6 +22,25 @@ services:
       # endpoint that any caller can drive.
       - "127.0.0.1:8787:8787"
     restart: unless-stopped
+    # The image already runs as uid 10001; naming it here means a `docker run`
+    # that overrides the entrypoint cannot quietly regain root.
+    user: "10001"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    # The model is baked in and read at startup, so nothing needs to write to
+    # the filesystem. /tmp is still given a tmpfs because FlashRank's own
+    # default cache_dir is /tmp and a library that falls back to it should hit
+    # a writable path rather than a confusing permission error.
+    read_only: true
+    tmpfs:
+      - /tmp
+    # Bounds on an endpoint with no authentication. Reranking is CPU-bound and
+    # the request body is caller-controlled, so an unbounded container is a
+    # denial-of-service surface for anything that can reach the port.
+    mem_limit: 2g
+    cpus: 2.0
     healthcheck:
       # The model is baked into the image, so this reports ready in seconds
       # rather than after a 30-60s download. model_loaded is the field that

--- a/docker/reranker/docker-compose.yml
+++ b/docker/reranker/docker-compose.yml
@@ -1,0 +1,39 @@
+# Standalone reranker. Run it from this directory with `docker compose up`.
+#
+# This file is deliberately self-contained: no external network, no reference
+# to any other repository. vikunja#692 existed because the documented adoption
+# path led to a compose file whose `build: .` had no Dockerfile beside it, so
+# "clone and up" is the acceptance criterion, not an incidental convenience.
+#
+# To integrate with a full searxng-mcp stack instead, see the reranker service
+# in ../../docker-compose.full.yml, which pulls the published image rather
+# than building.
+services:
+  reranker:
+    build: .
+    # Or skip the build entirely:
+    # image: ghcr.io/tadmstr/searxng-mcp-reranker:latest
+    container_name: reranker
+    environment:
+      - RERANKER_MODEL=ms-marco-MiniLM-L-12-v2
+    ports:
+      # Loopback-only. The service has no authentication of any kind — see the
+      # README. Publishing it on 0.0.0.0 exposes an unauthenticated CPU-bound
+      # endpoint that any caller can drive.
+      - "127.0.0.1:8787:8787"
+    restart: unless-stopped
+    healthcheck:
+      # The model is baked into the image, so this reports ready in seconds
+      # rather than after a 30-60s download. model_loaded is the field that
+      # distinguishes "serving" from "up but reranking nothing".
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request,json,sys; sys.exit(0 if json.load(urllib.request.urlopen('http://127.0.0.1:8787/health'))['model_loaded'] else 1)",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s

--- a/docker/reranker/main.py
+++ b/docker/reranker/main.py
@@ -1,0 +1,72 @@
+"""
+Jina-compatible reranker API using FlashRank (CPU-only, zero-cost local reranking).
+POST /v1/rerank -- drop-in for Jina's API.
+"""
+import os, logging
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import Optional
+from contextlib import asynccontextmanager
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("reranker")
+ranker = None
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global ranker
+    from flashrank import Ranker
+    model_name = os.getenv("RERANKER_MODEL", "ms-marco-MiniLM-L-12-v2")
+    # FlashRank defaults cache_dir to /tmp. The Dockerfile bakes the model at
+    # build time, and /tmp is the path a runtime is most likely to replace — a
+    # tmpfs mount or a read-only rootfs would hide the baked copy and send the
+    # container back to downloading ~100MB on boot, silently. Naming the
+    # directory is what makes the pre-bake hold; build and runtime read the
+    # same variable, so they cannot drift apart.
+    cache_dir = os.getenv("RERANKER_CACHE_DIR", "/opt/flashrank")
+    logger.info(f"Loading FlashRank model: {model_name} (cache_dir={cache_dir})")
+    ranker = Ranker(model_name=model_name, cache_dir=cache_dir)
+    logger.info("FlashRank model loaded")
+    yield
+
+app = FastAPI(title="Local Reranker (Jina-compatible)", lifespan=lifespan)
+
+class RerankRequest(BaseModel):
+    model: Optional[str] = "flashrank"
+    query: str
+    documents: list
+    top_n: Optional[int] = None
+    return_documents: Optional[bool] = False
+
+class RerankResultItem(BaseModel):
+    index: int
+    relevance_score: float
+    document: Optional[dict] = None
+
+class RerankResponse(BaseModel):
+    model: str = "flashrank"
+    results: list[RerankResultItem]
+    usage: dict = {"total_tokens": 0}
+
+@app.post("/v1/rerank", response_model=RerankResponse)
+async def rerank(req: RerankRequest):
+    from flashrank import RerankRequest as FRRequest
+    passages = []
+    for i, doc in enumerate(req.documents):
+        if isinstance(doc, str): passages.append({"id": i, "text": doc})
+        elif isinstance(doc, dict) and "text" in doc: passages.append({"id": i, "text": doc["text"]})
+        else: passages.append({"id": i, "text": str(doc)})
+    raw = ranker.rerank(FRRequest(query=req.query, passages=passages))
+    sorted_r = sorted(raw, key=lambda r: r["score"], reverse=True)
+    if req.top_n: sorted_r = sorted_r[:req.top_n]
+    results = [RerankResultItem(
+        index=r["id"], relevance_score=r["score"],
+        document={"text": r["text"]} if req.return_documents else None
+    ) for r in sorted_r]
+    total_chars = len(req.query) + sum(len(p["text"]) for p in passages)
+    return RerankResponse(model=req.model or "flashrank", results=results,
+                          usage={"total_tokens": total_chars // 4})
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "model_loaded": ranker is not None}

--- a/docker/reranker/main.py
+++ b/docker/reranker/main.py
@@ -3,14 +3,29 @@ Jina-compatible reranker API using FlashRank (CPU-only, zero-cost local rerankin
 POST /v1/rerank -- drop-in for Jina's API.
 """
 import os, logging
-from fastapi import FastAPI
-from pydantic import BaseModel
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, field_validator
 from typing import Optional
 from contextlib import asynccontextmanager
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("reranker")
 ranker = None
+
+# Request bounds. This endpoint has no authentication and reranking is CPU-bound
+# on caller-supplied text, so an uncapped request is a denial-of-service surface
+# for anything that can reach the port. The compose file binds loopback only,
+# but that is a property of one deployment — this image is published, and a cap
+# that lives in the artefact holds however someone chooses to run it.
+#
+# Defaults are far above real use. Measured against the live SearXNG that feeds
+# this service: ~30 documents per rerank, longest document ~430 chars, ~6.7 KB
+# total. So these leave roughly 30x, 45x and 600x headroom respectively and
+# cannot affect the caller this was built for.
+MAX_DOCUMENTS = int(os.getenv("RERANKER_MAX_DOCUMENTS", "1000"))
+MAX_DOC_CHARS = int(os.getenv("RERANKER_MAX_DOC_CHARS", "20000"))
+MAX_BODY_BYTES = int(os.getenv("RERANKER_MAX_BODY_BYTES", str(4 * 1024 * 1024)))
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -31,12 +46,59 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Local Reranker (Jina-compatible)", lifespan=lifespan)
 
+@app.middleware("http")
+async def limit_body_size(request: Request, call_next):
+    """Reject an oversized body before it is buffered and parsed.
+
+    Two honest limits on what this does, both measured rather than assumed:
+
+    1. Content-Length only. A chunked request declares no length, so this
+       cannot see it. That case is caught one layer later by the document caps
+       below, which apply to the parsed request whatever framing delivered it —
+       so the request is still bounded, just not as early.
+    2. The client does not always get to read the 413. A body slightly over the
+       cap is answered cleanly (measured: 4.2 MB -> 413 with the JSON detail),
+       but a substantially oversized one is answered while the client is still
+       sending, and the client sees a connection reset instead (measured: 6 MB
+       and 20 MB -> reset). The body is rejected either way and the server stays
+       healthy; only the symptom differs. Recorded because a bare "connection
+       reset" is precisely the kind of unexplained failure this codebase keeps
+       having to diagnose.
+    """
+    declared = request.headers.get("content-length")
+    if declared is not None:
+        try:
+            size = int(declared)
+        except ValueError:
+            return JSONResponse({"detail": "Invalid Content-Length"}, status_code=400)
+        if size > MAX_BODY_BYTES:
+            return JSONResponse(
+                {"detail": f"Request body exceeds {MAX_BODY_BYTES} bytes"},
+                status_code=413,
+            )
+    return await call_next(request)
+
+
 class RerankRequest(BaseModel):
     model: Optional[str] = "flashrank"
     query: str
     documents: list
     top_n: Optional[int] = None
     return_documents: Optional[bool] = False
+
+    @field_validator("documents")
+    @classmethod
+    def _bound_documents(cls, v: list) -> list:
+        if len(v) > MAX_DOCUMENTS:
+            raise ValueError(f"documents exceeds {MAX_DOCUMENTS} items")
+        return v
+
+    @field_validator("query")
+    @classmethod
+    def _bound_query(cls, v: str) -> str:
+        if len(v) > MAX_DOC_CHARS:
+            raise ValueError(f"query exceeds {MAX_DOC_CHARS} characters")
+        return v
 
 class RerankResultItem(BaseModel):
     index: int
@@ -53,9 +115,16 @@ async def rerank(req: RerankRequest):
     from flashrank import RerankRequest as FRRequest
     passages = []
     for i, doc in enumerate(req.documents):
-        if isinstance(doc, str): passages.append({"id": i, "text": doc})
-        elif isinstance(doc, dict) and "text" in doc: passages.append({"id": i, "text": doc["text"]})
-        else: passages.append({"id": i, "text": str(doc)})
+        if isinstance(doc, str): text = doc
+        elif isinstance(doc, dict) and "text" in doc: text = doc["text"]
+        else: text = str(doc)
+        # Truncate rather than reject. A document longer than this is past
+        # anything the cross-encoder reads anyway — FlashRank's own max_length
+        # is 512 tokens — so refusing the whole request would turn a harmless
+        # oversized snippet into a failed search, while the cost this bounds
+        # (holding and tokenising the text) is already paid by truncating.
+        if len(text) > MAX_DOC_CHARS: text = text[:MAX_DOC_CHARS]
+        passages.append({"id": i, "text": text})
     raw = ranker.rerank(FRRequest(query=req.query, passages=passages))
     sorted_r = sorted(raw, key=lambda r: r["score"], reverse=True)
     if req.top_n: sorted_r = sorted_r[:req.top_n]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ MCP client (stdio)
       │                     ├→ Kiwix ($KIWIX_URL)         → ZIM content (Wikipedia/SO/Arch Wiki, fast path)
       │                     ├→ Hister ($HISTER_URL)       → browsing-history index (login-walled/JS-heavy fast path)
       │                     ├→ Firecrawl ($FIRECRAWL_URL) → page markdown (tier 1)
-      │                     ├→ Crawl4AI ($CRAWL4AI_URL)  → page markdown (tier 2, optional; via $ADBLOCK_PROXY_URL if set)
+      │                     ├→ Crawl4AI ($CRAWL4AI_URL)  → page markdown (tier 2, optional; direct — no proxy, see below)
       │                     ├→ Raw HTTP + Readability     → page markdown (tier 3 fallback; via $ADBLOCK_PROXY_URL if set)
       │                     ├→ Byparr solver (opt-in)     → challenge-solved page markdown (only on a detected challenge, $SOLVER_ENABLED)
       │                     └→ Wayback Machine (opt-in)  → archived page markdown (tier 4, $WAYBACK_ENABLED)
@@ -40,7 +40,7 @@ flowchart TD
     robots["robots.txt pre-check — tiers 1–3\ndisallowed → RobotsDisallowedError (cached 24h)"]
     tier_skip(["Per-domain tier skip\nsuccess rate &lt;30% over ≥10 tries\nor tier_skip operator override"])
     t1["Tier 1 — Firecrawl\n$FIRECRAWL_URL\nserves PDFs under FIRECRAWL_API_VERSION=v2"]
-    t2["Tier 2 — Crawl4AI\n$CRAWL4AI_URL · optional\nadblock proxy if $ADBLOCK_PROXY_URL"]
+    t2["Tier 2 — Crawl4AI\n$CRAWL4AI_URL · optional\ndirect — no adblock proxy"]
     t3["Tier 3 — Raw HTTP + Readability\nfallback: raw HTML slice\nadblock proxy if $ADBLOCK_PROXY_URL"]
     challenge(["Challenge detected\non this URL, this request?"])
     solver["Solver — Byparr\n$SOLVER_URL · opt-in, SOLVER_ENABLED=true\nSSRF-guarded replay"]
@@ -101,7 +101,7 @@ searxng-mcp ships two adblocking sidecars, but only one of them applies to every
 
 | Sidecar | Tier | Mechanism | Applies when |
 |---------|------|-----------|--------------|
-| `docker/adblock-proxy/` | Tiers 2+3 (Crawl4AI, raw fetch) | HTTP forward proxy — filters plain-HTTP ad domains | `ADBLOCK_PROXY_URL` is set |
+| `docker/adblock-proxy/` | Tier 3 (raw fetch) only | HTTP forward proxy — filters plain-HTTP ad domains | `ADBLOCK_PROXY_URL` is set |
 | `docker/puppeteer-adblock/` | Tier 1 (Firecrawl) | CDP-level interception in the browser service | **Only** on a `v1` firecrawl-simple stack built from `docker-compose.full.yml` |
 
 ### Tier 1 — Puppeteer adblock (v1 stacks only)
@@ -135,9 +135,11 @@ docker compose -f docker-compose.full.yml up -d --build firecrawl-puppeteer
 
 **Per-domain bypass:** `domains.json` reserves an `adblock_skip` slot for future operator overrides. Wiring isn't implemented — it would require Firecrawl to forward a custom header through to the browser service, which isn't part of its API. Tracked as scope-creep item I.
 
-### Tier 2+3 — Adblock proxy
+### Tier 3 — Adblock proxy
 
-Set `ADBLOCK_PROXY_URL` (e.g. `http://adblock-proxy:8118`) to route Crawl4AI and raw Node fetch requests through an HTTP forward proxy that filters ad and tracker requests. HTTPS CONNECT tunnels are passed through unmodified — no MITM, so filtering applies to plain-HTTP ad domains only. Where the tier-1 hook above is in play it handles HTTPS filtering for that tier; where it is not — including every `v2` deployment — nothing filters tier 1 at all.
+Set `ADBLOCK_PROXY_URL` (e.g. `http://adblock-proxy:8118`) to route raw Node fetch requests through an HTTP forward proxy that filters ad and tracker requests.
+
+**This applies to tier 3 only. Tier 2 does not use it, and must not.** Tier 3 resolves the proxy hostname *in this process*; a proxy passed to Crawl4AI is resolved by *Crawl4AI*, inside its own container, which is a different network position entirely. Sending it was a 100% tier-2 outage until v3.25.0 — every crawl returned `net::ERR_PROXY_CONNECTION_FAILED` and was recorded as an ordinary empty result (vikunja#690). Crawl4AI 0.9.x additionally rejects the field at its trust boundary with HTTP 400. Adblocking for tier 2 would have to be configured server-side on Crawl4AI, which is a deployment change rather than a client one. HTTPS CONNECT tunnels are passed through unmodified — no MITM, so filtering applies to plain-HTTP ad domains only. Where the tier-1 hook above is in play it handles HTTPS filtering for that tier; where it is not — including every `v2` deployment — nothing filters tier 1 at all.
 
 As of v3.19.0, the proxy validates the **resolved** address — not just the requested hostname string — on both its CONNECT and plain-HTTP paths before connecting, closing a DNS-rebinding gap (audit finding SSRF-10).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,10 +176,21 @@ does not request them.
 [Crawl4AI](https://github.com/unclecode/crawl4ai) is an optional second-tier fetch fallback used when Firecrawl returns empty content (bot-blocked pages, JS-heavy sites). Set `CRAWL4AI_URL` to enable it. If unset, the cascade skips to raw HTTP fetch.
 
 ```bash
-docker run -d -p 11235:11235 unclecode/crawl4ai:0.8.6
+docker run -d -p 11235:11235 \
+  -e CRAWL4AI_API_TOKEN="$(openssl rand -hex 32)" \
+  unclecode/crawl4ai:0.9.3
 ```
 
-If your instance requires API token authentication, set `CRAWL4AI_API_TOKEN`.
+Set `CRAWL4AI_API_TOKEN` to the same value on searxng-mcp.
+
+**On 0.9.x the token is not optional, and omitting it fails invisibly.** With no token, the server binds the *container's* loopback: `docker ps` reports the container healthy, its own `/health` returns 200, and the published port answers with a connection reset. `/health` is unauthenticated even when a token *is* set, so no healthcheck at any layer distinguishes a working server from a dead one — only `/crawl` returns 401. searxng-mcp says so explicitly the first time a crawl is refused.
+
+Two other things changed in 0.9.0 that matter if you are upgrading from 0.8.x:
+
+- `proxy_config` and `proxy` are rejected at the network trust boundary with HTTP 400. searxng-mcp no longer sends either (see [Architecture](architecture.md#tier-3--adblock-proxy)).
+- 5xx responses are generic — `{"error": "...", "correlation_id": "..."}`. searxng-mcp surfaces the correlation id in the tier failure reason so it can be matched against the server's own logs.
+
+0.9.1 and 0.9.2 have no changelog entries upstream; 0.9.3 is the version this client is written and tested against.
 
 On the `search_and_summarize` path, Crawl4AI requests use `fit_markdown` for noise-filtered content extraction. Other callers (`search_and_fetch`, `fetch_url`) use `raw_markdown`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,7 +121,14 @@ search:
 
 ## Reranker (recommended)
 
-The reranker must expose a Jina-compatible `/v1/rerank` endpoint. A lightweight FlashRank wrapper works well — see the [`docker/reranker/`](https://github.com/TadMSTR/homelab-agent/tree/main/docker/reranker) reference in [homelab-agent](https://github.com/TadMSTR/homelab-agent).
+The reranker must expose a Jina-compatible `/v1/rerank` endpoint. One ships in this repo — a CPU-only FlashRank wrapper needing no API key and no GPU:
+
+```bash
+cd docker/reranker && docker compose up      # or, without building:
+docker run -d -p 127.0.0.1:8787:8787 ghcr.io/tadmstr/searxng-mcp-reranker:latest
+```
+
+`RERANKER_URL` already defaults to `http://localhost:8787`, so nothing else needs configuring. [`docker/reranker/README.md`](../docker/reranker/README.md) covers the request/response contract, the model, and why it is baked into the image. Any other service speaking the same endpoint works too.
 
 ## Firecrawl (optional — fetch tier 1)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ past that point lives here.
 | [Tools](tools.md) | Full per-tool parameter reference for all seven MCP tools, plus GitHub URL handling. |
 | [Deployment](deployment.md) | Install from npm or source, stdio and HTTP transports, HTTP authentication, and MCP client recipes for Claude Code, Claude Desktop and LibreChat. |
 | [Architecture](architecture.md) | The fetch cascade and tier semantics, adblocking, data-driven tier routing, the domain capability database, every fast path, resilience, and observability. |
+| [Reranker](../docker/reranker/README.md) | The bundled CPU-only reranking service: the `/v1/rerank` contract, the model, why it is baked into the image, and how to run or pull it. |
 | [Security](security.md) | SSRF handling, redirect protection, transport exposure, bounded reads, dependency auditing, credential handling and input validation. Vulnerability reporting is in [`SECURITY.md`](../SECURITY.md). |
 
 ## Where to start

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tadmstr/searxng-mcp",
-  "version": "3.24.0",
+  "version": "3.25.0",
   "description": "MCP server for SearXNG \u2014 private web search for Claude Code",
   "main": "build/src/index.js",
   "bin": {

--- a/src/tiers/crawl4ai.ts
+++ b/src/tiers/crawl4ai.ts
@@ -1,8 +1,4 @@
-import {
-  ADBLOCK_PROXY_URL,
-  CRAWL4AI_API_TOKEN,
-  CRAWL4AI_URL,
-} from "../config.js";
+import { CRAWL4AI_API_TOKEN, CRAWL4AI_URL } from "../config.js";
 import {
   preferReadability,
   runReadability,
@@ -24,6 +20,80 @@ import {
  * fixture captured from this version's live /openapi.json.
  */
 export const CRAWL4AI_TARGET_VERSION = "0.8.6";
+
+/**
+ * Upper bound on how much of crawl4ai's error prose is relayed into a tier
+ * failure reason. Matches MAX_TIER_REASON_CHARS in fetch.ts; bounded here as
+ * well so this function is safe on its own rather than relying on its caller.
+ */
+const MAX_UPSTREAM_DETAIL_CHARS = 200;
+
+/**
+ * Chromium surfaces transport failures as a stable `net::ERR_*` vocabulary,
+ * and crawl4ai passes them through inside a long Python traceback. The token
+ * is the whole diagnostic — `net::ERR_PROXY_CONNECTION_FAILED` is what
+ * identified vikunja#690 — but it sits ~200 chars into the prose, i.e. exactly
+ * where a head-truncated relay cuts it off. Lift it out and lead with it so
+ * the signal survives any downstream bound.
+ */
+const NET_ERROR = /net::ERR_[A-Z_]+/;
+
+/**
+ * Turn a crawl4ai error response body into one bounded, single-line reason.
+ *
+ * Relaying upstream prose at all is a deliberate choice with a precedent: the
+ * same decision was taken for Firecrawl's `data.error` and accepted at audit
+ * (OE-02, 2026-09-06) on the grounds that this server is loopback-only and its
+ * callers already hold the URL they asked for. The alternative — a canned
+ * reason — is what made vikunja#690 invisible for weeks.
+ */
+export function crawl4aiErrorReason(label: string, body: string): string {
+  let detail = "";
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    // 0.8.6 answers `{detail}`. 0.9.x's generic 5xx shape is handled in the
+    // Phase 2 change; both are read here so neither version is silent.
+    if (typeof parsed.detail === "string") detail = parsed.detail;
+    else if (typeof parsed.error === "string") detail = parsed.error;
+  } catch {
+    detail = body;
+  }
+
+  const flat = detail.replace(/\s+/g, " ").trim();
+  const netErr = flat.match(NET_ERROR)?.[0];
+  const head = flat.slice(0, MAX_UPSTREAM_DETAIL_CHARS);
+  const prose = flat.length > MAX_UPSTREAM_DETAIL_CHARS ? `${head}…` : head;
+
+  return [label, netErr, prose].filter(Boolean).join(" ");
+}
+
+/**
+ * Name a transport failure well enough to act on.
+ *
+ * Node's fetch reports every one of these as the bare string "fetch failed"
+ * and hides the useful part on `cause.code`. The distinction is the whole
+ * point of the Phase 7 negative control: a crawl4ai 0.9.x server started
+ * without CRAWL4AI_API_TOKEN binds the container's loopback and answers with
+ * ECONNRESET while its healthcheck stays green, and "fetch failed" would leave
+ * an investigator no way to tell that from a DNS typo.
+ */
+function describeTransportFailure(err: unknown): string {
+  const base = err instanceof Error ? err.message : String(err);
+  const cause = (err as { cause?: { code?: unknown; message?: unknown } })
+    ?.cause;
+  // `code` is present for the network failures (ECONNRESET, ECONNREFUSED,
+  // ENOTFOUND, …). Some causes carry only a message — Node rejects a request
+  // to a blocked port that way — so fall back to it rather than to nothing.
+  const detail =
+    typeof cause?.code === "string"
+      ? cause.code
+      : typeof cause?.message === "string"
+        ? cause.message
+        : undefined;
+  return detail
+    ? `Crawl4AI unreachable: ${detail} (${base})`
+    : `Crawl4AI: ${base}`;
+}
 
 /**
  * Pull a TierResult out of one crawl4ai result object — the element of the
@@ -78,7 +148,9 @@ export async function pollCrawl4aiTask(
 
   while (Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, 2000));
-    if (signal.aborted) return null;
+    // The only signal reaching here is crawl4aiFetch's own 45s controller, so
+    // an abort is this client giving up rather than a caller cancelling.
+    if (signal.aborted) throw new Error("Crawl4AI timeout while polling job");
 
     try {
       const resp = await fetch(`${CRAWL4AI_URL}/crawl/job/${taskId}`, {
@@ -94,7 +166,12 @@ export async function pollCrawl4aiTask(
               `route or task expiry changed? this tier targets crawl4ai ${CRAWL4AI_TARGET_VERSION}`,
           );
         }
-        return null;
+        throw new Error(
+          crawl4aiErrorReason(
+            `Crawl4AI error: ${resp.status}`,
+            await readBoundedText(resp),
+          ),
+        );
       }
 
       const data = JSON.parse(await readBoundedText(resp)) as Record<
@@ -110,13 +187,33 @@ export async function pollCrawl4aiTask(
           : undefined;
         return resultToTier(nested ?? envelope, url, maxChars, preferFit);
       }
-      if (data.status === "failed") return null;
-    } catch {
-      return null;
+      // A failed job is the backend reporting it could not crawl the page —
+      // the proxy failure in #690 arrives this way on backends that answer
+      // asynchronously. Surface its own error text rather than booking a miss.
+      if (data.status === "failed") {
+        const detail =
+          typeof data.error === "string"
+            ? data.error
+            : JSON.stringify(data.result ?? {});
+        throw new Error(
+          crawl4aiErrorReason(
+            "Crawl4AI job failed:",
+            JSON.stringify({ detail }),
+          ),
+        );
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") {
+        throw new Error("Crawl4AI timeout while polling job");
+      }
+      throw err;
     }
   }
 
-  return null;
+  // Falling out of the loop means the job never reached a terminal state
+  // inside the poll budget. That is a backend that is too slow or stuck, not
+  // a page with no content.
+  throw new Error("Crawl4AI job poll deadline exceeded (40s)");
 }
 
 export async function crawl4aiFetch(
@@ -148,11 +245,31 @@ export async function crawl4aiFetch(
     const resp = await fetch(`${CRAWL4AI_URL}/crawl`, {
       method: "POST",
       headers: crawlHeaders,
+      // DO NOT re-add `proxy_config` (or `proxy`) here, under any crawl4ai
+      // version. It looks like it belongs — tier 3 does route through
+      // ADBLOCK_PROXY_URL and it works there — but the two are not the same
+      // thing. Tier 3 resolves the proxy hostname *in this process*; a
+      // proxy_config in this body is resolved by *crawl4ai*, in its own
+      // container, and the containers are on disjoint networks:
+      //
+      //   searxng-mcp    forge-net, searxng_fetch-net
+      //   crawl4ai       forge-net, jobsearch-deps
+      //   adblock-proxy  searxng_fetch-net ONLY
+      //
+      // So crawl4ai cannot resolve `adblock-proxy`, and every tier-2 crawl
+      // returned net::ERR_PROXY_CONNECTION_FAILED — 100% failure, booked as an
+      // ordinary empty result, for as long as ADBLOCK_PROXY_URL had been set
+      // (vikunja#690). Probed live 2026-09-06 against 0.8.6 with a control:
+      // the identical request without this field succeeded.
+      //
+      // Removing it is also a hard prerequisite for crawl4ai 0.9.x, which
+      // rejects both spellings at the network trust boundary with HTTP 400.
+      // Adblock filtering for tier 2 would have to be configured server-side
+      // on crawl4ai and needs a network change that is not this process's to
+      // make. Asserted by tests/tiers/crawl4ai-no-proxy.test.ts, which is the
+      // only test file that sets ADBLOCK_PROXY_URL.
       body: JSON.stringify({
         urls: [url],
-        ...(ADBLOCK_PROXY_URL
-          ? { proxy_config: { server: ADBLOCK_PROXY_URL } }
-          : {}),
         ...(Object.keys(crawlerConfig).length > 0
           ? { crawler_config: crawlerConfig }
           : {}),
@@ -160,7 +277,20 @@ export async function crawl4aiFetch(
       signal: controller.signal,
     });
 
-    if (!resp.ok) return null;
+    // A non-2xx here is the backend refusing the crawl, not the page being
+    // empty. Returning null booked it as `empty_result` — "attempted, no
+    // content" — which is how a 100% tier outage read as ordinary misses for
+    // weeks (vikunja#690, the concrete instance of #687). Tier 1 has always
+    // thrown on this and runTier already records a thrown reason as an
+    // `error` outcome; tier 2 was the outlier.
+    if (!resp.ok) {
+      throw new Error(
+        crawl4aiErrorReason(
+          `Crawl4AI error: ${resp.status}`,
+          await readBoundedText(resp),
+        ),
+      );
+    }
     // Bounded read (2 MB cap) before JSON.parse — consistency with the rest of
     // the fetch layer; caps memory even on an unexpected oversized response.
     const data = JSON.parse(await readBoundedText(resp)) as Record<
@@ -183,7 +313,11 @@ export async function crawl4aiFetch(
 
     // Asynchronous response — poll for completion
     if (typeof data.task_id === "string") {
-      if (!/^[a-zA-Z0-9_-]{1,64}$/.test(data.task_id)) return null;
+      // Path-traversal guard on a value that goes into a URL path. Unchanged
+      // in what it refuses; it now says so instead of passing for a miss.
+      if (!/^[a-zA-Z0-9_-]{1,64}$/.test(data.task_id)) {
+        throw new Error("Crawl4AI returned a malformed task_id");
+      }
       return await pollCrawl4aiTask(
         data.task_id,
         url,
@@ -194,8 +328,18 @@ export async function crawl4aiFetch(
     }
 
     return null;
-  } catch {
-    return null;
+  } catch (err) {
+    // Transport failures reach here: connection refused, connection reset, DNS
+    // failure, TLS rejection — and our own 45s abort. None of them mean the
+    // page was empty, and all of them were previously indistinguishable from
+    // one. This matters beyond #690: a crawl4ai 0.9.x server started without
+    // CRAWL4AI_API_TOKEN binds the container's loopback and answers published
+    // ports with a connection reset *while reporting healthy*, so a silent
+    // null here would be the only symptom of a dead tier.
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error("Crawl4AI timeout after 45s");
+    }
+    throw new Error(describeTransportFailure(err));
   } finally {
     clearTimeout(timeout);
   }

--- a/src/tiers/crawl4ai.ts
+++ b/src/tiers/crawl4ai.ts
@@ -121,6 +121,21 @@ const NET_ERROR = /net::ERR_[A-Z_]+/;
  * callers already hold the URL they asked for. The alternative — a canned
  * reason — is what made vikunja#690 invisible for weeks.
  */
+// SECURITY[accepted]: relaying Crawl4AI's upstream `detail` / `error` /
+// `correlation_id` is accepted rather than classified down to a canned reason.
+// Filed as its OWN accepted-risks.md row rather than inheriting the Firecrawl
+// one in src/fetch.ts: that row names "Firecrawl's upstream data.error" and is
+// scoped to that relay, and per SC-23 a new relay source gets its own row. Same
+// trust model — this server is loopback-only and its callers already hold the
+// URL they asked for, so the text discloses nothing they do not have. The
+// diagnostic value is the entire point: a canned reason is what let a 100% tier
+// outage read as ordinary empty results for weeks (vikunja#690).
+// Audit: 2026-09-06/searxng-mcp-crawl4ai-reranker-2026-09, finding OE-02 (Low).
+// Decision: Ted, 2026-09-06.
+// SECURITY[control]: bounded twice — 200 chars here at the source, and again by
+// boundReason() at the fetch boundary; `correlation_id` is server-generated,
+// opaque, and capped at 64. Crawl4AI no longer receives an internal proxy
+// hostname to echo back, because this build removed the field that sent one.
 export function crawl4aiErrorReason(label: string, body: string): string {
   let detail = "";
   let correlationId: string | undefined;

--- a/src/tiers/crawl4ai.ts
+++ b/src/tiers/crawl4ai.ts
@@ -18,8 +18,82 @@ import {
  * and each was indistinguishable from "the page had no content". The route and
  * shape assertions in tests/tiers/crawl4ai-job-api.test.ts run against a
  * fixture captured from this version's live /openapi.json.
+ *
+ * Moved 0.8.6 → 0.9.3 against a scratch 0.9.3 container, not against the
+ * changelog. What that probe established, and what this tier now relies on:
+ *
+ *   - `/crawl/job/{task_id}` still exists; `/task/{task_id}` still does not.
+ *     Both fixtures are kept and both are asserted, so "works on 0.9.3" cannot
+ *     quietly become "no longer works on 0.8.6" — the deployed server is still
+ *     0.8.6 when this ships.
+ *   - The synchronous response is the *same* shape, `{results: [{markdown:
+ *     {raw_markdown, fit_markdown, …}, metadata}]}`. 0.9.x was the untested
+ *     third possibility; it turned out not to be one.
+ *   - `proxy_config` is refused with HTTP 400 "field 'proxy_config' is not
+ *     permitted on BrowserConfig from an untrusted request". `crawler_config`
+ *     with css_selector and wait_for is accepted, so tuning still works.
+ *   - 4xx keeps `{detail}`; only 5xx becomes `{error, correlation_id}`.
  */
-export const CRAWL4AI_TARGET_VERSION = "0.8.6";
+export const CRAWL4AI_TARGET_VERSION = "0.9.3";
+
+/**
+ * An error this tier raised about the backend, as opposed to one thrown at it.
+ *
+ * The distinction exists so the outer transport handler can tell "the network
+ * failed" from "we already described what went wrong" — without it a 401 came
+ * out as `Crawl4AI: Crawl4AI error: 401 …`, wrapped by the handler meant for
+ * raw fetch rejections.
+ */
+class Crawl4aiError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "Crawl4aiError";
+  }
+}
+
+let warnedAboutMissingToken = false;
+
+/**
+ * Explain a tokenless auth failure, once, at the moment one actually happens.
+ *
+ * The plan asked for this to fire pre-emptively whenever the target version is
+ * 0.9.x and no token is set. Built that way first, and it was wrong: this
+ * client ships *before* the server upgrade, so for the whole window between
+ * the two it would warn on every crawl against a healthy 0.8.6 that needs no
+ * token and works perfectly. Verified against the deployed 0.8.6 — a false
+ * alarm on a working system, which is how a warning gets trained away exactly
+ * before the release where it matters.
+ *
+ * Firing on an observed failure instead is both quieter and stronger: it does
+ * not depend on the target constant being accurate about the live server. It
+ * covers the two shapes a tokenless 0.9.x actually presents, which are not the
+ * same failure:
+ *
+ *   - HTTP 401, when the server did bind its published port.
+ *   - A connection reset, when it did not. With no token, 0.9.x binds the
+ *     *container's* loopback; `docker ps` reports healthy, the container's own
+ *     /health returns 200, and the published port resets. Reproduced on a
+ *     scratch 0.9.3: healthy at 45s uptime, curl exit 56 from the host.
+ *
+ * /health is unauthenticated even when a token IS set, so no healthcheck at
+ * any layer distinguishes either case. This line is the only signal.
+ */
+function warnTokenlessAuthFailure(observed: string): void {
+  if (warnedAboutMissingToken || CRAWL4AI_API_TOKEN) return;
+  warnedAboutMissingToken = true;
+  console.error(
+    `[searxng-mcp] crawl4ai refused the request (${observed}) and CRAWL4AI_API_TOKEN is not set. ` +
+      `crawl4ai ${CRAWL4AI_TARGET_VERSION} requires auth: with no token it binds the container's ` +
+      "loopback, so the published port answers with a connection reset while the container still " +
+      "reports healthy, and /health stays unauthenticated so no healthcheck will show it. " +
+      "Set the same token on both crawl4ai and searxng-mcp.",
+  );
+}
+
+/** Test seam: the warning fires once per process by design. */
+export function resetCrawl4aiTokenWarning(): void {
+  warnedAboutMissingToken = false;
+}
 
 /**
  * Upper bound on how much of crawl4ai's error prose is relayed into a tier
@@ -49,12 +123,24 @@ const NET_ERROR = /net::ERR_[A-Z_]+/;
  */
 export function crawl4aiErrorReason(label: string, body: string): string {
   let detail = "";
+  let correlationId: string | undefined;
   try {
     const parsed = JSON.parse(body) as Record<string, unknown>;
-    // 0.8.6 answers `{detail}`. 0.9.x's generic 5xx shape is handled in the
-    // Phase 2 change; both are read here so neither version is silent.
+    // Both server generations, verified against each: 0.8.6 and 0.9.x 4xx use
+    // `{detail}`, and 0.9.x 5xx becomes `{error, correlation_id}` with the
+    // message deliberately generic. `detail` is not always a string — a 422
+    // validation failure makes it an array of objects, which read as a string
+    // would silently drop the entire reason.
     if (typeof parsed.detail === "string") detail = parsed.detail;
+    else if (parsed.detail !== undefined)
+      detail = JSON.stringify(parsed.detail);
     else if (typeof parsed.error === "string") detail = parsed.error;
+
+    // The generic 5xx text says nothing on its own — the correlation id is the
+    // only way to find the real error in the server's logs, so it is the one
+    // part that must not be dropped.
+    if (typeof parsed.correlation_id === "string")
+      correlationId = parsed.correlation_id;
   } catch {
     detail = body;
   }
@@ -63,8 +149,13 @@ export function crawl4aiErrorReason(label: string, body: string): string {
   const netErr = flat.match(NET_ERROR)?.[0];
   const head = flat.slice(0, MAX_UPSTREAM_DETAIL_CHARS);
   const prose = flat.length > MAX_UPSTREAM_DETAIL_CHARS ? `${head}…` : head;
+  const corr = correlationId
+    ? `[correlation_id=${correlationId.slice(0, 64)}]`
+    : undefined;
 
-  return [label, netErr, prose].filter(Boolean).join(" ");
+  // corr goes before the prose for the same reason netErr does: it has to
+  // survive a downstream truncation, and it is the actionable half.
+  return [label, netErr, corr, prose].filter(Boolean).join(" ");
 }
 
 /**
@@ -150,7 +241,8 @@ export async function pollCrawl4aiTask(
     await new Promise((r) => setTimeout(r, 2000));
     // The only signal reaching here is crawl4aiFetch's own 45s controller, so
     // an abort is this client giving up rather than a caller cancelling.
-    if (signal.aborted) throw new Error("Crawl4AI timeout while polling job");
+    if (signal.aborted)
+      throw new Crawl4aiError("Crawl4AI timeout while polling job");
 
     try {
       const resp = await fetch(`${CRAWL4AI_URL}/crawl/job/${taskId}`, {
@@ -166,7 +258,7 @@ export async function pollCrawl4aiTask(
               `route or task expiry changed? this tier targets crawl4ai ${CRAWL4AI_TARGET_VERSION}`,
           );
         }
-        throw new Error(
+        throw new Crawl4aiError(
           crawl4aiErrorReason(
             `Crawl4AI error: ${resp.status}`,
             await readBoundedText(resp),
@@ -195,7 +287,7 @@ export async function pollCrawl4aiTask(
           typeof data.error === "string"
             ? data.error
             : JSON.stringify(data.result ?? {});
-        throw new Error(
+        throw new Crawl4aiError(
           crawl4aiErrorReason(
             "Crawl4AI job failed:",
             JSON.stringify({ detail }),
@@ -203,8 +295,9 @@ export async function pollCrawl4aiTask(
         );
       }
     } catch (err) {
+      if (err instanceof Crawl4aiError) throw err;
       if (err instanceof Error && err.name === "AbortError") {
-        throw new Error("Crawl4AI timeout while polling job");
+        throw new Crawl4aiError("Crawl4AI timeout while polling job");
       }
       throw err;
     }
@@ -213,7 +306,7 @@ export async function pollCrawl4aiTask(
   // Falling out of the loop means the job never reached a terminal state
   // inside the poll budget. That is a backend that is too slow or stuck, not
   // a page with no content.
-  throw new Error("Crawl4AI job poll deadline exceeded (40s)");
+  throw new Crawl4aiError("Crawl4AI job poll deadline exceeded (40s)");
 }
 
 export async function crawl4aiFetch(
@@ -224,6 +317,10 @@ export async function crawl4aiFetch(
 ): Promise<TierResult | null> {
   if (!CRAWL4AI_URL) return null;
 
+  // Well inside 0.9.x's 300s per-crawl wall clock, so the server's cap is
+  // never what ends a request here — this client always gives up first. The
+  // poll deadline below is 40s, so a crawl slower than that is abandoned
+  // client-side; that is unchanged from 0.8.6 and is deliberate.
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 45_000);
 
@@ -284,7 +381,10 @@ export async function crawl4aiFetch(
     // thrown on this and runTier already records a thrown reason as an
     // `error` outcome; tier 2 was the outlier.
     if (!resp.ok) {
-      throw new Error(
+      if (resp.status === 401 || resp.status === 403) {
+        warnTokenlessAuthFailure(`HTTP ${resp.status}`);
+      }
+      throw new Crawl4aiError(
         crawl4aiErrorReason(
           `Crawl4AI error: ${resp.status}`,
           await readBoundedText(resp),
@@ -316,7 +416,7 @@ export async function crawl4aiFetch(
       // Path-traversal guard on a value that goes into a URL path. Unchanged
       // in what it refuses; it now says so instead of passing for a miss.
       if (!/^[a-zA-Z0-9_-]{1,64}$/.test(data.task_id)) {
-        throw new Error("Crawl4AI returned a malformed task_id");
+        throw new Crawl4aiError("Crawl4AI returned a malformed task_id");
       }
       return await pollCrawl4aiTask(
         data.task_id,
@@ -336,10 +436,19 @@ export async function crawl4aiFetch(
     // CRAWL4AI_API_TOKEN binds the container's loopback and answers published
     // ports with a connection reset *while reporting healthy*, so a silent
     // null here would be the only symptom of a dead tier.
+    // Already described by this tier — re-wrapping produced the duplicated
+    // "Crawl4AI: Crawl4AI error: 401 …" that the live 0.9.3 probe surfaced.
+    if (err instanceof Crawl4aiError) throw err;
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error("Crawl4AI timeout after 45s");
+      throw new Crawl4aiError("Crawl4AI timeout after 45s");
     }
-    throw new Error(describeTransportFailure(err));
+    const described = describeTransportFailure(err);
+    // A connection reset with no token configured is the other face of the
+    // same misconfiguration as a 401 — the server bound container-loopback.
+    if (/ECONNRESET|ECONNREFUSED/.test(described)) {
+      warnTokenlessAuthFailure(described);
+    }
+    throw new Crawl4aiError(described);
   } finally {
     clearTimeout(timeout);
   }

--- a/src/tiers/index.ts
+++ b/src/tiers/index.ts
@@ -14,11 +14,16 @@ import type { Tier } from "./types.js";
 
 // Tier 1 and tier 2 reach the origin through an external fetcher, so they hand
 // back a rendered document with no origin status or headers — only the body
-// rules in detectChallenge can apply. The check has to sit here at the tier
-// boundary rather than inside firecrawlScrape/crawl4aiFetch: crawl4aiFetch
-// swallows every throw and returns null, which would erase the signal. Both
+// rules in detectChallenge can apply. The check sits here at the tier boundary
+// rather than inside firecrawlScrape/crawl4aiFetch so one rule covers both
+// tiers and raises ChallengeDetectedError by the same path for each. Both
 // representations are passed because the markers live in the markup and the
 // markdown/text projection strips them.
+//
+// This used to carry a second reason: that crawl4aiFetch swallowed every throw
+// and returned null, so the signal had to be raised outside it. That is no
+// longer true. As of vikunja#690 tier 2 throws its backend failures the way
+// tier 1 always has, and returns null only for a genuinely empty result.
 
 /** Tier 1 — Firecrawl (Puppeteer-rendered, best quality). */
 export const tier1: Tier = {

--- a/tests/fixtures/crawl4ai-0.9.3-crawl-sync.json
+++ b/tests/fixtures/crawl4ai-0.9.3-crawl-sync.json
@@ -1,0 +1,29 @@
+{
+  "_captured": {
+    "captured": "2026-09-06",
+    "crawl4ai_version": "0.9.3",
+    "source": "POST /crawl {\"urls\":[\"https://example.com\"]} on a scratch unclecode/crawl4ai:0.9.3, bearer set",
+    "note": "Trimmed to the fields this tier reads; nesting is unmodified. Full html/cleaned_html elided for size."
+  },
+  "success": true,
+  "results": [
+    {
+      "url": "https://example.com",
+      "success": true,
+      "markdown": {
+        "raw_markdown": "# Example Domain\nThis domain is for use in documentation examples without needing permission. Avoid use in operations.\n[Learn more](https://iana.org/domains/example)\n",
+        "markdown_with_citations": "# Example Domain\nThis domain is for use in documentation examples without needing permission. Avoid use in operations.\nLearn more\u27e81\u27e9\n",
+        "references_markdown": "\n\n## References\n\n\u27e81\u27e9 https://iana.org/domains/example: Learn more\n",
+        "fit_markdown": "",
+        "fit_html": ""
+      },
+      "metadata": {
+        "title": "Example Domain",
+        "description": null,
+        "keywords": null,
+        "author": null
+      },
+      "html": "<!DOCTYPE html><html lang=\"en\"><head><title>Example Domain</title><link rel=\"icon\" href=\"data:,\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:6"
+    }
+  ]
+}

--- a/tests/fixtures/crawl4ai-0.9.3-openapi.json
+++ b/tests/fixtures/crawl4ai-0.9.3-openapi.json
@@ -1,0 +1,178 @@
+{
+  "_captured": {
+    "captured": "2026-09-06",
+    "crawl4ai_version": "0.9.3",
+    "source": "GET /openapi.json on a scratch unclecode/crawl4ai:0.9.3 started with CRAWL4AI_API_TOKEN set"
+  },
+  "info": {
+    "title": "Crawl4AI API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "root__get"
+      }
+    },
+    "/artifacts/{artifact_id}": {
+      "get": {
+        "operationId": "get_artifact_artifacts__artifact_id__get"
+      }
+    },
+    "/ask": {
+      "get": {
+        "operationId": "get_context_ask_get"
+      }
+    },
+    "/config/dump": {
+      "post": {
+        "operationId": "config_dump_config_dump_post"
+      }
+    },
+    "/crawl": {
+      "post": {
+        "operationId": "crawl_crawl_post"
+      }
+    },
+    "/crawl/job": {
+      "post": {
+        "operationId": "crawl_job_enqueue_crawl_job_post"
+      }
+    },
+    "/crawl/job/{task_id}": {
+      "get": {
+        "operationId": "crawl_job_status_crawl_job__task_id__get"
+      }
+    },
+    "/crawl/stream": {
+      "post": {
+        "operationId": "crawl_stream_crawl_stream_post"
+      }
+    },
+    "/execute_js": {
+      "post": {
+        "operationId": "execute_js_execute_js_post"
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "health_health_get"
+      }
+    },
+    "/hooks/info": {
+      "get": {
+        "operationId": "get_hooks_info_hooks_info_get"
+      }
+    },
+    "/html": {
+      "post": {
+        "operationId": "generate_html_html_post"
+      }
+    },
+    "/llm/job": {
+      "post": {
+        "operationId": "llm_job_enqueue_llm_job_post"
+      }
+    },
+    "/llm/job/{task_id}": {
+      "get": {
+        "operationId": "llm_job_status_llm_job__task_id__get"
+      }
+    },
+    "/llm/{url}": {
+      "get": {
+        "operationId": "llm_endpoint_llm__url__get"
+      }
+    },
+    "/mcp/schema": {
+      "get": {
+        "operationId": "_schema_endpoint_mcp_schema_get"
+      }
+    },
+    "/md": {
+      "post": {
+        "operationId": "get_markdown_md_post"
+      }
+    },
+    "/metrics": {
+      "get": {
+        "operationId": "metrics_metrics_get"
+      }
+    },
+    "/monitor/actions/cleanup": {
+      "post": {
+        "operationId": "force_cleanup_monitor_actions_cleanup_post"
+      }
+    },
+    "/monitor/actions/kill_browser": {
+      "post": {
+        "operationId": "kill_browser_monitor_actions_kill_browser_post"
+      }
+    },
+    "/monitor/actions/restart_browser": {
+      "post": {
+        "operationId": "restart_browser_monitor_actions_restart_browser_post"
+      }
+    },
+    "/monitor/browsers": {
+      "get": {
+        "operationId": "get_browsers_monitor_browsers_get"
+      }
+    },
+    "/monitor/endpoints/stats": {
+      "get": {
+        "operationId": "get_endpoint_stats_monitor_endpoints_stats_get"
+      }
+    },
+    "/monitor/health": {
+      "get": {
+        "operationId": "get_health_monitor_health_get"
+      }
+    },
+    "/monitor/logs/errors": {
+      "get": {
+        "operationId": "get_errors_log_monitor_logs_errors_get"
+      }
+    },
+    "/monitor/logs/janitor": {
+      "get": {
+        "operationId": "get_janitor_log_monitor_logs_janitor_get"
+      }
+    },
+    "/monitor/requests": {
+      "get": {
+        "operationId": "get_requests_monitor_requests_get"
+      }
+    },
+    "/monitor/stats/reset": {
+      "post": {
+        "operationId": "reset_stats_monitor_stats_reset_post"
+      }
+    },
+    "/monitor/timeline": {
+      "get": {
+        "operationId": "get_timeline_monitor_timeline_get"
+      }
+    },
+    "/pdf": {
+      "post": {
+        "operationId": "generate_pdf_pdf_post"
+      }
+    },
+    "/schema": {
+      "get": {
+        "operationId": "get_schema_schema_get"
+      }
+    },
+    "/screenshot": {
+      "post": {
+        "operationId": "generate_screenshot_screenshot_post"
+      }
+    },
+    "/token": {
+      "post": {
+        "operationId": "get_token_token_post"
+      }
+    }
+  }
+}

--- a/tests/tiers/crawl4ai-0-9-compat.test.ts
+++ b/tests/tiers/crawl4ai-0-9-compat.test.ts
@@ -1,0 +1,161 @@
+// vikunja#691 — crawl4ai 0.9.x client compatibility.
+//
+// Every fixture here was captured from a real scratch `unclecode/crawl4ai:0.9.3`
+// container, not from the changelog. That distinction earned its keep: the
+// changelog says 0.9.x "rejects proxy_config at the trust boundary", which is
+// true, but it does not say that `crawler_config` is still accepted, that
+// /health stays unauthenticated while /crawl 401s, or that the synchronous
+// response shape is unchanged — and all three decide whether this tier works.
+//
+// The 0.8.6 fixture is deliberately kept and still asserted. This client ships
+// BEFORE the server is upgraded, so "works on 0.9.3" must not quietly become
+// "no longer works on 0.8.6".
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+vi.hoisted(() => {
+  process.env.CRAWL4AI_URL = "http://crawl4ai:11235";
+});
+
+import {
+  CRAWL4AI_TARGET_VERSION,
+  crawl4aiErrorReason,
+  crawl4aiFetch,
+} from "../../src/tiers/crawl4ai.js";
+
+function fixture(name: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(
+      fileURLToPath(new URL(`../fixtures/${name}.json`, import.meta.url)),
+      "utf-8",
+    ),
+  );
+}
+
+type OpenApi = {
+  paths: Record<string, unknown>;
+  _captured: { crawl4ai_version: string };
+};
+
+const oa093 = fixture("crawl4ai-0.9.3-openapi") as OpenApi;
+const oa086 = fixture("crawl4ai-0.8.6-openapi") as OpenApi;
+const sync093 = fixture("crawl4ai-0.9.3-crawl-sync");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("target version", () => {
+  it("targets the version the 0.9.3 fixture was captured from", () => {
+    expect(CRAWL4AI_TARGET_VERSION).toBe(oa093._captured.crawl4ai_version);
+  });
+
+  it("has actually moved off 0.8.6", () => {
+    // Without this, a fixture refreshed from the old server would satisfy the
+    // assertion above while leaving the constant stale.
+    expect(CRAWL4AI_TARGET_VERSION).not.toBe(oa086._captured.crawl4ai_version);
+  });
+});
+
+describe("routes this tier depends on, across both server versions", () => {
+  // The client ships before the server upgrade, so it has to hold on both.
+  for (const [version, oa] of [
+    ["0.8.6", oa086],
+    ["0.9.3", oa093],
+  ] as const) {
+    it(`${version} exposes the job route this tier polls`, () => {
+      expect(Object.keys(oa.paths)).toContain("/crawl/job/{task_id}");
+    });
+
+    it(`${version} does not expose the retired /task/{task_id} route`, () => {
+      expect(Object.keys(oa.paths)).not.toContain("/task/{task_id}");
+    });
+  }
+});
+
+describe("0.9.3 synchronous response shape", () => {
+  it("is the same shape 0.8.6 returned, and the tier reads it", async () => {
+    // The plan called 0.9.x "an untested third possibility". Captured live, it
+    // is not one — but that is only worth knowing because it was checked.
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(sync093), { status: 200 }),
+    );
+
+    const result = await crawl4aiFetch("https://example.com");
+
+    expect(result).not.toBeNull();
+    expect(result?.title).toBe("Example Domain");
+    expect(result?.text.length).toBeGreaterThan(0);
+  });
+
+  it("still prefers fit_markdown when asked, on the captured payload", () => {
+    const md = (sync093.results as Record<string, unknown>[])[0]
+      .markdown as Record<string, string>;
+    // Both keys are present on 0.9.3, so preferFit has something to choose.
+    expect(md.raw_markdown).toBeTruthy();
+    expect(md.fit_markdown).toBeDefined();
+  });
+});
+
+describe("0.9.x error shapes", () => {
+  it("surfaces the correlation_id from a generic 5xx", () => {
+    // 0.9.x replaces server error text with `{error, correlation_id}`; the id
+    // is the only way to find the real error in the server log, so losing it
+    // would leave a 500 with nothing actionable at all.
+    const reason = crawl4aiErrorReason(
+      "Crawl4AI error: 500",
+      JSON.stringify({
+        error: "Internal server error",
+        correlation_id: "c4a1-9f3e-77bd",
+      }),
+    );
+    expect(reason).toContain("correlation_id=c4a1-9f3e-77bd");
+    expect(reason).toContain("Internal server error");
+  });
+
+  it("keeps the correlation_id ahead of the prose so a bound cannot cut it", () => {
+    const reason = crawl4aiErrorReason(
+      "Crawl4AI error: 500",
+      JSON.stringify({ error: "x".repeat(400), correlation_id: "abc123" }),
+    );
+    expect(reason.slice(0, 200)).toContain("correlation_id=abc123");
+  });
+
+  it("does not drop a non-string detail (422 validation)", () => {
+    // Captured live: a 422 makes `detail` an array of objects. Read as a
+    // string it is undefined, and the whole reason silently becomes empty.
+    const reason = crawl4aiErrorReason(
+      "Crawl4AI error: 422",
+      JSON.stringify({
+        detail: [
+          {
+            type: "too_short",
+            loc: ["body", "urls"],
+            msg: "List should have at least 1 item",
+          },
+        ],
+      }),
+    );
+    expect(reason).toContain("too_short");
+    expect(reason).not.toBe("Crawl4AI error: 422");
+  });
+
+  it("relays the trust-boundary rejection verbatim enough to act on", () => {
+    // The exact 400 body a 0.9.3 returns for proxy_config. If this ever fires
+    // in production it means the field came back; the reason has to say so.
+    const reason = crawl4aiErrorReason(
+      "Crawl4AI error: 400",
+      JSON.stringify({
+        detail:
+          "Rejected request: field 'proxy_config' is not permitted on BrowserConfig from an untrusted request",
+      }),
+    );
+    expect(reason).toContain("proxy_config");
+    expect(reason).toContain("not permitted");
+  });
+});

--- a/tests/tiers/crawl4ai-job-api.test.ts
+++ b/tests/tiers/crawl4ai-job-api.test.ts
@@ -113,14 +113,17 @@ describe("pollCrawl4aiTask — route", () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     mockFetch.mockResolvedValue(new Response("not found", { status: 404 }));
 
-    const result = await pollCrawl4aiTask(
-      "crawl_gone",
-      "https://example.com",
-      8000,
-      new AbortController().signal,
-    );
+    // It now reports twice: the console line that names a route rename, and a
+    // thrown reason that reaches domain_stats instead of an `empty_result`.
+    await expect(
+      pollCrawl4aiTask(
+        "crawl_gone",
+        "https://example.com",
+        8000,
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow(/Crawl4AI error: 404/);
 
-    expect(result).toBeNull();
     expect(spy).toHaveBeenCalledWith(expect.stringContaining("404"));
     spy.mockRestore();
   });
@@ -218,20 +221,21 @@ describe("pollCrawl4aiTask — completed job payload", () => {
     expect(result?.text).toBe("only nested");
   });
 
-  it("returns null on a failed job", async () => {
+  it("throws on a failed job rather than booking it as a miss", async () => {
     mockFetch.mockResolvedValue(
       new Response(JSON.stringify({ status: "failed", task_id: "crawl_f" }), {
         status: 200,
       }),
     );
 
-    const result = await pollCrawl4aiTask(
-      "crawl_f",
-      "https://example.com",
-      8000,
-      new AbortController().signal,
-    );
-
-    expect(result).toBeNull();
+    // A job the backend itself marked failed is not "the page had no content".
+    await expect(
+      pollCrawl4aiTask(
+        "crawl_f",
+        "https://example.com",
+        8000,
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow(/Crawl4AI job failed/);
   });
 });

--- a/tests/tiers/crawl4ai-job-api.test.ts
+++ b/tests/tiers/crawl4ai-job-api.test.ts
@@ -55,10 +55,17 @@ beforeEach(() => {
 });
 
 describe("crawl4ai job route, against the deployed OpenAPI document", () => {
-  it("targets the crawl4ai version the fixture was captured from", () => {
-    // If someone refreshes the fixture from a newer instance without revisiting
-    // this tier, this is what says so.
-    expect(CRAWL4AI_TARGET_VERSION).toBe(openapi._captured.crawl4ai_version);
+  it("still supports the 0.8.6 server this fixture was captured from", () => {
+    // The version-equality assertion moved to crawl4ai-0-9-compat.test.ts when
+    // the target became 0.9.3. It cannot live here any more, but this file's
+    // fixture is not stale: 0.8.6 is what is *deployed*, and this client ships
+    // before the server upgrade. So the surviving obligation is backward
+    // compatibility — the route this tier polls must exist on 0.8.6 too.
+    expect(openapi._captured.crawl4ai_version).toBe("0.8.6");
+    expect(CRAWL4AI_TARGET_VERSION).not.toBe(
+      openapi._captured.crawl4ai_version,
+    );
+    expect(Object.keys(openapi.paths)).toContain("/crawl/job/{task_id}");
   });
 
   it("exposes the job status route this tier polls", () => {

--- a/tests/tiers/crawl4ai-no-proxy.test.ts
+++ b/tests/tiers/crawl4ai-no-proxy.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tier 2 must never send `proxy_config`, and this file is the only place that
+ * can prove it — every other crawl4ai test mocks `ADBLOCK_PROXY_URL` to null,
+ * so the proxy branch was unreachable from the suite while it was breaking
+ * 100% of crawls in production (vikunja#690).
+ *
+ * The mock therefore sets the variable, which is the deployed configuration.
+ */
+vi.mock("../../src/config.js", () => ({
+  CRAWL4AI_URL: "http://crawl4ai:8000",
+  CRAWL4AI_API_TOKEN: undefined,
+  ADBLOCK_PROXY_URL: "http://adblock-proxy:8118",
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { crawl4aiFetch } from "../../src/tiers/crawl4ai.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const URL = "https://example.com/page";
+
+const syncResponse = () =>
+  new Response(
+    JSON.stringify({
+      results: [
+        {
+          markdown: { raw_markdown: "# Page\n\nSome text" },
+          metadata: { title: "Page Title" },
+        },
+      ],
+    }),
+    { status: 200 },
+  );
+
+describe("crawl4ai request body with ADBLOCK_PROXY_URL set", () => {
+  it("does not send proxy_config even when ADBLOCK_PROXY_URL is configured", async () => {
+    mockFetch.mockResolvedValueOnce(syncResponse());
+    await crawl4aiFetch(URL);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.proxy_config).toBeUndefined();
+  });
+
+  it("does not send the proxy under any key crawl4ai reads", async () => {
+    // 0.9.x rejects both spellings at the trust boundary with HTTP 400, and
+    // browser_config is where a future reader would most plausibly re-add it.
+    mockFetch.mockResolvedValueOnce(syncResponse());
+    await crawl4aiFetch(URL);
+
+    const raw = mockFetch.mock.calls[0][1].body as string;
+    expect(raw).not.toContain("proxy");
+    expect(raw).not.toContain("adblock-proxy");
+  });
+
+  it("still sends the fields tier 2 depends on", async () => {
+    // A body that dropped everything would pass the assertions above.
+    mockFetch.mockResolvedValueOnce(syncResponse());
+    await crawl4aiFetch(URL, 8000, false, { targetSelector: "main" });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.urls).toEqual([URL]);
+    expect(body.crawler_config).toEqual({ css_selector: "main" });
+  });
+});

--- a/tests/tiers/crawl4ai-token-warning.test.ts
+++ b/tests/tiers/crawl4ai-token-warning.test.ts
@@ -1,0 +1,145 @@
+// vikunja#691 — the tokenless-auth-failure warning.
+//
+// Its own file because it needs CRAWL4AI_API_TOKEN mocked absent, which is the
+// opposite of what the other crawl4ai suites want, and vi.mock is per-file.
+//
+// Why this warning exists, reproduced on a scratch 0.9.3: started with no
+// CRAWL4AI_API_TOKEN, the container reported `Up 45 seconds (healthy)`, its own
+// loopback answered `{"status":"ok","version":"0.9.3"}`, and the published port
+// gave curl exit 56 — connection reset. /health is unauthenticated even when a
+// token IS set, so no healthcheck at any layer can tell the difference.
+//
+// It fires on an observed failure, not on the target-version constant. The
+// pre-emptive version was built first and rejected: this client ships before
+// the server upgrade, so it warned on every crawl against the healthy 0.8.6
+// that is actually deployed. The no-false-alarm case below is that regression.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/config.js", () => ({
+  CRAWL4AI_URL: "http://crawl4ai:11235",
+  CRAWL4AI_API_TOKEN: undefined,
+  ADBLOCK_PROXY_URL: null,
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import {
+  CRAWL4AI_TARGET_VERSION,
+  crawl4aiFetch,
+  resetCrawl4aiTokenWarning,
+} from "../../src/tiers/crawl4ai.js";
+
+let spy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetCrawl4aiTokenWarning();
+  spy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  spy.mockRestore();
+});
+
+const okResponse = () =>
+  new Response(
+    JSON.stringify({
+      results: [
+        { markdown: { raw_markdown: "content" }, metadata: { title: "T" } },
+      ],
+    }),
+    { status: 200 },
+  );
+
+const unauthorized = () =>
+  new Response(JSON.stringify({ detail: "Authentication required" }), {
+    status: 401,
+  });
+
+describe("tokenless auth-failure warning", () => {
+  it("only matters because the version targeted is a 0.9.x", () => {
+    // Guards the guard: if the constant is rolled back to 0.8.x, this file is
+    // asserting a branch that no longer matters and should say so.
+    expect(CRAWL4AI_TARGET_VERSION).toMatch(/^0\.9\./);
+  });
+
+  it("warns on an observed 401 when no token is configured", async () => {
+    mockFetch.mockResolvedValueOnce(unauthorized());
+    await expect(crawl4aiFetch("https://example.com")).rejects.toThrow(/401/);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const msg = String(spy.mock.calls[0][0]);
+    expect(msg).toContain("CRAWL4AI_API_TOKEN");
+    // The three facts that make it actionable rather than noise.
+    expect(msg).toContain(CRAWL4AI_TARGET_VERSION);
+    expect(msg).toMatch(/connection reset/i);
+    expect(msg).toMatch(/healthy/i);
+  });
+
+  it("warns on a connection reset — the shape with no 401 to observe", async () => {
+    // The primary failure mode: a tokenless 0.9.x binds container-loopback, so
+    // there is no HTTP status at all, only a reset. Asserting the 401 path
+    // alone would leave this one unproven.
+    mockFetch.mockRejectedValueOnce(
+      Object.assign(new TypeError("fetch failed"), {
+        cause: { code: "ECONNRESET" },
+      }),
+    );
+    await expect(crawl4aiFetch("https://example.com")).rejects.toThrow(
+      /ECONNRESET/,
+    );
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(String(spy.mock.calls[0][0])).toContain("CRAWL4AI_API_TOKEN");
+  });
+
+  it("does NOT warn when the tokenless request succeeds", async () => {
+    // The regression that killed the pre-emptive design. A tokenless client
+    // against the deployed 0.8.6 works, and must stay silent — a warning on a
+    // healthy system is how the signal gets ignored before it matters.
+    mockFetch.mockResolvedValueOnce(okResponse());
+    const result = await crawl4aiFetch("https://example.com");
+
+    expect(result?.text).toBe("content");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does not warn on a failure that is not auth-shaped", async () => {
+    // A 500 says nothing about the token; claiming it does would send the
+    // reader after the wrong cause.
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Internal server error" }), {
+        status: 500,
+      }),
+    );
+    await expect(crawl4aiFetch("https://example.com")).rejects.toThrow(/500/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("warns once, not on every failed crawl", async () => {
+    // Fresh Response per call — one instance has its body stream locked after
+    // the first read and the later crawls would fail for the wrong reason.
+    mockFetch.mockImplementation(async () => unauthorized());
+    for (const u of [
+      "https://a.example",
+      "https://b.example",
+      "https://c.example",
+    ]) {
+      await expect(crawl4aiFetch(u)).rejects.toThrow(/401/);
+    }
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the 401 once, without double-wrapping the message", async () => {
+    // Observed live against the scratch 0.9.3 before this was fixed:
+    // "Crawl4AI: Crawl4AI error: 401 Authentication required".
+    mockFetch.mockResolvedValueOnce(unauthorized());
+    const err = (await crawl4aiFetch("https://example.com").catch(
+      (e: Error) => e,
+    )) as Error;
+
+    expect(err.message).toContain("Crawl4AI error: 401");
+    expect(err.message).not.toMatch(/Crawl4AI.*Crawl4AI error/);
+  });
+});

--- a/tests/tiers/crawl4ai.test.ts
+++ b/tests/tiers/crawl4ai.test.ts
@@ -55,23 +55,82 @@ describe("crawl4aiFetch", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null for invalid task_id format (path traversal guard)", async () => {
+  it("refuses an invalid task_id format (path traversal guard)", async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ task_id: "../../etc/passwd" }), {
         status: 200,
       }),
     );
-    const result = await crawl4aiFetch(URL);
-    expect(result).toBeNull();
+    // Still refused; it now reports rather than passing for an empty page.
+    await expect(crawl4aiFetch(URL)).rejects.toThrow(/malformed task_id/);
+    // The guard's whole point: the traversal path is never requested.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  it("returns null when response is not-ok", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      json: () => Promise.resolve({}),
-    });
-    const result = await crawl4aiFetch(URL);
-    expect(result).toBeNull();
+  // Previously asserted `null` here. A non-2xx is the backend refusing the
+  // crawl, and booking that as an empty result is what hid a 100% tier outage
+  // (vikunja#690, the concrete instance of #687).
+  it("throws when response is not-ok", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: "boom" }), { status: 500 }),
+    );
+    await expect(crawl4aiFetch(URL)).rejects.toThrow(/Crawl4AI error: 500/);
+  });
+
+  it("leads the reason with the net::ERR_ token so a bound cannot cut it off", async () => {
+    // Shape captured from the live 0.8.6 response to #690's probe: the
+    // diagnostic token sits ~200 chars into a Python traceback, exactly where
+    // a head-truncated relay loses it.
+    const detail =
+      "Crawl request failed: Unexpected error in _crawl_web at line 778 in " +
+      "_crawl_web (../usr/local/lib/python3.12/site-packages/crawl4ai/" +
+      "async_crawler_strategy.py):\nError: Failed on navigating ACS-GOTO:\n" +
+      "Page.goto: net::ERR_PROXY_CONNECTION_FAILED at https://example.com/";
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ detail }), { status: 500 }),
+    );
+
+    const err = (await crawl4aiFetch(URL).catch((e: Error) => e)) as Error;
+    expect(err.message).toContain("net::ERR_PROXY_CONNECTION_FAILED");
+    // And it survives the 200-char bound applied at the fetch boundary.
+    expect(err.message.slice(0, 200)).toContain(
+      "net::ERR_PROXY_CONNECTION_FAILED",
+    );
+  });
+
+  it("throws on a transport failure rather than reporting an empty page", async () => {
+    // Connection reset / DNS failure / TLS rejection all arrive this way —
+    // including the tokenless crawl4ai 0.9.x mode that reports healthy.
+    mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+    await expect(crawl4aiFetch(URL)).rejects.toThrow(/fetch failed/);
+  });
+
+  it("names the transport failure code, not just 'fetch failed'", async () => {
+    // Node reports every transport failure as the bare string "fetch failed"
+    // and puts the actionable part on cause.code. ECONNRESET specifically is
+    // how a tokenless crawl4ai 0.9.x presents while reporting healthy.
+    mockFetch.mockRejectedValueOnce(
+      Object.assign(new TypeError("fetch failed"), {
+        cause: { code: "ECONNRESET" },
+      }),
+    );
+    await expect(crawl4aiFetch(URL)).rejects.toThrow(
+      /Crawl4AI unreachable: ECONNRESET/,
+    );
+  });
+
+  it("falls back to the cause message when there is no code", async () => {
+    // Observed live: Node rejects a request to a blocked port with a cause
+    // that has a message and no code. Asserting only the code branch would
+    // have passed while the real path produced a bare "fetch failed".
+    mockFetch.mockRejectedValueOnce(
+      Object.assign(new TypeError("fetch failed"), {
+        cause: { message: "bad port" },
+      }),
+    );
+    await expect(crawl4aiFetch(URL)).rejects.toThrow(
+      /Crawl4AI unreachable: bad port/,
+    );
   });
 
   it("omits crawler_config from the request body by default", async () => {
@@ -124,30 +183,58 @@ describe("pollCrawl4aiTask", () => {
     expect(result?.text).toBe("page content");
   });
 
-  it("returns null when status is failed", async () => {
+  // Previously asserted `null`. A failed job is the backend saying it could
+  // not crawl the page — on an async backend, #690's proxy failure arrives
+  // exactly here — so it must not be recorded as "attempted, no content".
+  it("throws when status is failed, carrying the job's own error", async () => {
     mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({ status: "failed" }), { status: 200 }),
+      new Response(
+        JSON.stringify({
+          status: "failed",
+          error:
+            "Page.goto: net::ERR_PROXY_CONNECTION_FAILED at https://example.com/",
+        }),
+        { status: 200 },
+      ),
     );
 
     vi.useFakeTimers();
     const controller = new AbortController();
     const promise = pollCrawl4aiTask("task123", URL, 8000, controller.signal);
+    const settled = expect(promise).rejects.toThrow(
+      /net::ERR_PROXY_CONNECTION_FAILED/,
+    );
     await vi.advanceTimersByTimeAsync(2500);
-    const result = await promise;
+    await settled;
     vi.useRealTimers();
-
-    expect(result).toBeNull();
   });
 
-  it("returns null when aborted", async () => {
+  it("throws when aborted — the only signal here is our own 45s deadline", async () => {
     vi.useFakeTimers();
     const controller = new AbortController();
     controller.abort();
     const promise = pollCrawl4aiTask("task123", URL, 8000, controller.signal);
+    const settled = expect(promise).rejects.toThrow(/Crawl4AI timeout/);
     // abort check runs after the 2s sleep, so advance past it
     await vi.advanceTimersByTimeAsync(2500);
-    const result = await promise;
+    await settled;
     vi.useRealTimers();
-    expect(result).toBeNull();
+  });
+
+  it("throws when the job never reaches a terminal state in the budget", async () => {
+    // A fresh Response per poll — one instance would have its body stream
+    // locked after the first read and fail for the wrong reason.
+    mockFetch.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ status: "processing" }), { status: 200 }),
+    );
+
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const promise = pollCrawl4aiTask("task123", URL, 8000, controller.signal);
+    const settled = expect(promise).rejects.toThrow(/poll deadline exceeded/);
+    await vi.advanceTimersByTimeAsync(45_000);
+    await settled;
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
Closes vikunja#690, #691, #692. Narrows #687.

**Tier 2 was failing 100% of crawls before this branch**, and had been for as long as `ADBLOCK_PROXY_URL` was set. The headline fix is a deletion.

## Why tier 2 was dead

`proxy_config: {server: ADBLOCK_PROXY_URL}` was attached to every request. That address is resolved by **crawl4ai**, inside crawl4ai's container — not by this process — and `adblock-proxy` sits on a network crawl4ai is not on:

| Container | Networks |
|---|---|
| `searxng-mcp` | `forge-net`, `searxng_fetch-net` |
| `crawl4ai` | `forge-net`, `jobsearch-deps` |
| `adblock-proxy` | `searxng_fetch-net` **only** |

Re-probed live against the deployed 0.8.6, with a control:

```
WITH proxy_config    -> Page.goto: net::ERR_PROXY_CONNECTION_FAILED
WITHOUT (control)    -> success: true, 166 chars of markdown
```

Tier 3's `ADBLOCK_PROXY_URL` use is untouched and does work — it resolves the proxy in-process. The two look alike and are not the same thing, so the reasoning now lives in a comment at the call site.

## Why nobody saw it

The tier returned `null` for non-2xx responses, failed jobs, poll timeouts and transport errors alike, and `runTier` books `null` as `empty_result` — "attempted, no content". A total outage was indistinguishable from pages that happened to be empty. `ERR_PROXY_CONNECTION_FAILED` was sitting in the response body the whole time.

Tier 1 always threw here; tier 2 now does too, and returns `null` only for a genuinely empty result. Two details decide whether the reason is usable:

- The `net::ERR_*` token sits ~200 chars into crawl4ai's Python traceback, exactly where the 200-char bound at the fetch boundary cuts it off. It is lifted out and led with.
- Node reports every transport failure as the bare string `"fetch failed"` and hides the actionable part on `cause.code`. `ECONNRESET` / `ENOTFOUND` are now surfaced.

**#687 is narrowed, not closed** — this fixes the concrete instance; whether the general defect survives elsewhere needs its own evidence.

## crawl4ai 0.9.3 readiness

Established by probing a scratch `unclecode/crawl4ai:0.9.3`, not by reading the changelog. Four things the probe settled that the changelog does not say:

- The **synchronous response shape is unchanged**. 0.9.x was billed as an untested third possibility; it is not one.
- `crawler_config` still passes the trust boundary that rejects `proxy_config`, so selector tuning survives.
- `/health` is **unauthenticated even when a token is set**, while `/crawl` 401s. No healthcheck at any layer distinguishes a working server from a dead one.
- 4xx keeps `{detail}`; only 5xx becomes `{error, correlation_id}`. And `detail` is not always a string — a 422 makes it an array, which read as a string dropped the entire reason.

Both OpenAPI fixtures are kept and both asserted. This client ships **before** the server upgrade, so "works on 0.9.3" must not quietly become "no longer works on 0.8.6".

### The tokenless warning deviates from the plan, deliberately

The plan asked for a warning whenever the target is 0.9.x and no token is set. Built that way first, then verified it against the deployed 0.8.6 — where it was a false alarm on a healthy system. Because the client ships first, that design would warn on every crawl for the entire window before the server upgrade, which is how a warning gets trained away exactly before the release it exists for.

It now fires on an **observed** failure, which is quieter and stronger — it does not depend on the target constant being right about the live server. It covers both shapes a tokenless 0.9.x presents, which are different failures: HTTP 401 when the server bound its published port, and a connection reset when it bound container-loopback instead.

That second mode is confirmed, not quoted:

| Signal | Tokenless 0.9.3 |
|---|---|
| `docker ps` | `Up 45 seconds (healthy)` |
| Published port from host | `curl` exit **56** (connection reset), no HTTP code |
| Container's own loopback | `200 {"status":"ok","version":"0.9.3"}` |

## The reranker

`docs/configuration.md` sent adopters to another repo's `docker/reranker/`, which tracks exactly one file — a compose file saying `build: .` with no Dockerfile beside it. Following the documented path produced a build failure, on the single feature separating this project from every other SearXNG MCP server.

It now lives at `docker/reranker/` and publishes as `ghcr.io/tadmstr/searxng-mcp-reranker`. The model is **baked into the image**: a first-run download leaves the reranker absent for 30–60s on every fresh boot while searxng-mcp silently falls back to SearXNG's ordering behind one throttled log line.

## Verification

Live, against real backends rather than only mocks:

| Case | Result |
|---|---|
| Fixed client, `ADBLOCK_PROXY_URL` still set, live 0.8.6 | 166 chars — tier 2 restored |
| 0.9.3 + correct token | 166 chars |
| 0.9.3 + wrong token | `Crawl4AI error: 401 Authentication required` |
| 0.9.3 + no token | warns with the explanation, then fails loudly |
| 0.8.6 + no token | 166 chars, **silent** — no false alarm |
| Closed port / bad host | `ECONNREFUSED` / `ENOTFOUND` (both previously `null`) |
| Fresh clone → `docker compose up` | healthy in ~1s, contract verified reordering |
| Reranker under `--network none` | ready ~2s, `model_loaded` true, no download |

The reranker's CI smoke script was extracted from the YAML and run verbatim — it passes, and it **fails (exit 1) against a deliberately un-baked build**, with the container reaching for `huggingface.co`. Worth flagging: the first attempt at that negative control failed to *build*, leaving `:candidate` pointing at the previous good image, and the smoke test duly passed — a green result about the wrong artefact entirely.

Suite: 954 passed, 6 skipped. `tsc --noEmit`, `biome check`, `pnpm audit --prod` and `--dev` all clean. Coverage moved **up** against the v3.24.0 floor (lines 88.02/86, statements 85.71/84, functions 85.06/83, branches 78.74/77).

The regression test for the proxy removal was confirmed **red before the fix**. It is the only test file that sets `ADBLOCK_PROXY_URL` — every existing crawl4ai test mocked it to `null`, so the proxy branch was unreachable from the suite the entire time it was breaking production. Tests that asserted the old swallow behaviour are retargeted onto the new contract rather than deleted.

## Not in this PR

- **The crawl4ai server upgrade.** Deliberately not pre-queued: the client must be deployed first or the upgrade takes tier 2 down. It goes to sysadmin after this merges and releases, with the token generation called out as the most likely failure.
- **Server-side egress proxy for tier 2.** Comes from a changelog line; `MIGRATION.md@v0.9.3` has no proxy section at all. Would also need a network change that is not this repo's to make.
- **`homelab-agent`'s copy of the reranker** — different repo, raised rather than edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)