### PR TITLE
Pin compose project names so a clone cannot destroy another stack (v3.25.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.25.1] - 2026-09-06
+
+Patch for a trap shipped in v3.25.0. Released on its own, ahead of the rest of the
+observability work, because the defective file is published and destroys production
+containers on a host that already runs a stack of the same name.
+
+### Fixed
+- **`docker compose down` in `docker/reranker/` removed another stack's containers**
+  (vikunja#694). Compose derives the project name from the directory basename, and both this
+  directory and the conventional deployment directory are called `reranker`. Project names are
+  global to the Docker host, so `down` here matched the *other* stack's containers by label and
+  removed them — no warning, no prompt. That is how a production reranker was removed for ~4.5h
+  on 2026-09-06. The project name is now pinned with a top-level `name: searxng-mcp-reranker`,
+  which decouples it from the directory entirely.
+
+  Measured rather than reasoned: with the v3.25.0 file in a directory named `reranker`,
+  `docker compose down --dry-run` reports `Container reranker Stopping / Stopped / Removing /
+  Removed` against the live production container. With the fix, from the same directory, it
+  matches nothing. Clone-and-up now starts a second container
+  (`searxng-mcp-reranker-reranker-1`, healthy, `model_loaded: true`) beside a running
+  production reranker, and tearing the clone down leaves production serving.
+
+  **Note the ticket's stated mechanism was wrong, and the fix it prescribed would not have
+  worked.** `container_name` was blamed, but a fixed container name causes `up` to fail
+  *loudly* with a name conflict; it is the directory-derived *project* name that makes `down`
+  destructive and silent. Deleting `container_name` alone would have left this behaviour
+  untouched — and made `up` from a clone silently adopt the production container instead of
+  erroring.
+- **`container_name: reranker` removed** from the same file. It is the loud half of the same
+  collision: `up` fails with a conflict whose suggested remedy is `docker rm -f reranker`,
+  which is the other way the outage happened. A comment records why it is absent.
+- **`docker-compose.full.yml` and `docker-compose.example.yml` pinned to `name: searxng-mcp`**,
+  matching their conventional default, so neither can inherit a colliding project name from
+  whatever a clone directory is called.
+
+### Changed
+- The standalone reranker's host port is now `RERANKER_HOST_PORT`, defaulting to `8787`. The
+  default is unchanged so the copy-paste path still works; the variable exists so a host
+  already serving 8787 has a documented way out that is not "remove the other container".
+
 ## [3.25.0] - 2026-09-06
 
 **Fetch tier 2 was failing 100% of crawls and is restored.** Not a regression introduced here —

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -7,6 +7,13 @@
 # For a full topology (Firecrawl, Crawl4AI, Ollama, Kiwix, NATS),
 # see docker-compose.full.yml.
 
+# Pinned so the project name comes from this file rather than from whatever
+# the clone directory happens to be called. Compose project names are global to
+# the Docker host, and a directory-derived one silently shares a namespace with
+# any other stack of the same name — `down` in one removes the other's
+# containers. vikunja#694.
+name: searxng-mcp
+
 services:
   cache:
     image: docker.dragonflydb.io/dragonflydb/dragonfly:latest # SECURITY[accepted]: latest tag — example file; pin for production

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -18,6 +18,13 @@
 #       docker exec ollama ollama pull qwen3:14b
 #   - NATS: update NATS_CREDS path if using credential-based auth.
 
+# Pinned so the project name comes from this file rather than from whatever
+# the clone directory happens to be called. Compose project names are global to
+# the Docker host, and a directory-derived one silently shares a namespace with
+# any other stack of the same name — `down` in one removes the other's
+# containers. vikunja#694.
+name: searxng-mcp
+
 services:
   # ── Cache backend (Redis-compatible) ────────────────────────────────────────
   cache:

--- a/docker/reranker/README.md
+++ b/docker/reranker/README.md
@@ -28,6 +28,25 @@ RERANKER_URL=http://localhost:8787     # this is already the default
 
 Nothing else is required. There is no API key, no GPU, and no external service.
 
+### If you already run something on 8787
+
+8787 is `RERANKER_URL`'s default, so this file keeps it — the copy-paste path
+should work unmodified. On a host already serving something there, the bind
+fails with `address already in use`. That is deliberate: two rerankers on one
+port is a mistake worth surfacing rather than routing around. Move this one and
+tell searxng-mcp where it went:
+
+```bash
+RERANKER_HOST_PORT=8788 docker compose up -d
+RERANKER_URL=http://localhost:8788
+```
+
+The compose project is pinned to `searxng-mcp-reranker`, so running this from a
+clone is isolated from any other stack on the host regardless of what the
+directory is called — including one of your own called `reranker`. Before
+v3.25.1 it was not, and `docker compose down` here would have removed that
+other stack's containers without asking (vikunja#694).
+
 ## The contract
 
 `POST /v1/rerank` — Jina-compatible, so anything that speaks Jina's reranking

--- a/docker/reranker/docker-compose.yml
+++ b/docker/reranker/docker-compose.yml
@@ -8,19 +8,43 @@
 # To integrate with a full searxng-mcp stack instead, see the reranker service
 # in ../../docker-compose.full.yml, which pulls the published image rather
 # than building.
+#
+# Compose derives the project name from this directory's basename — "reranker"
+# — and container/project names are GLOBAL to the Docker host. A host already
+# running a stack from any other directory called `reranker` therefore shares a
+# namespace with this file: `docker compose down` here removes THAT stack's
+# containers, and `docker compose up` adopts or recreates them with this file's
+# config. Measured 2026-09-06, both behaviours reproduced. vikunja#694.
+#
+# Pinning `name:` decouples the project from the directory, so a clone in any
+# location is isolated from whatever else the host is running.
+name: searxng-mcp-reranker
+
 services:
   reranker:
     build: .
     # Or skip the build entirely:
     # image: ghcr.io/tadmstr/searxng-mcp-reranker:latest
-    container_name: reranker
+    # No `container_name:` — deliberately. A fixed name is global to the host,
+    # so it collides with any other `reranker` container and makes `up` fail
+    # with a conflict whose suggested remedy is `docker rm -f reranker`. That
+    # is how a production reranker was removed for ~4.5h on 2026-09-06.
+    # Compose derives `searxng-mcp-reranker-reranker-1`; nothing references the
+    # container by name. Do not restore it. vikunja#694.
     environment:
       - RERANKER_MODEL=ms-marco-MiniLM-L-12-v2
     ports:
       # Loopback-only. The service has no authentication of any kind — see the
       # README. Publishing it on 0.0.0.0 exposes an unauthenticated CPU-bound
       # endpoint that any caller can drive.
-      - "127.0.0.1:8787:8787"
+      #
+      # 8787 is RERANKER_URL's default, so it is kept here to make the
+      # copy-paste path work unmodified. On a host already serving a reranker
+      # on 8787 this bind fails — loudly, with "address already in use", which
+      # is the intended behaviour: two rerankers on one port is a mistake worth
+      # surfacing. Override with `RERANKER_HOST_PORT=8788 docker compose up`
+      # and point RERANKER_URL at it.
+      - "127.0.0.1:${RERANKER_HOST_PORT:-8787}:8787"
     restart: unless-stopped
     # SECURITY[deferred]: this is the only compose file in the repo carrying the
     # hardening below — docker-compose.full.yml, docker-compose.example.yml and

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tadmstr/searxng-mcp",
-  "version": "3.25.0",
-  "description": "MCP server for SearXNG \u2014 private web search for Claude Code",
+  "version": "3.25.1",
+  "description": "MCP server for SearXNG — private web search for Claude Code",
   "main": "build/src/index.js",
   "bin": {
     "searxng-mcp": "build/src/index.js"
@@ -65,7 +65,8 @@
     "ajv": "^8.20.0",
     "typescript": "^5.9.3",
     "vite": "^8.0.16",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "yaml": "^2.9.0"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.2(@types/node@22.20.1)(yaml@2.9.0))
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
 packages:
 

--- a/tests/compose-namespace.test.ts
+++ b/tests/compose-namespace.test.ts
@@ -1,0 +1,83 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+/**
+ * Docker compose project names and container names are GLOBAL to the host.
+ *
+ * Compose derives the project name from the compose file's directory basename
+ * unless a top-level `name:` overrides it. `docker/reranker/` and the
+ * conventional deployment directory are both called `reranker`, so before
+ * v3.25.1 a `docker compose down` run from a clone of this repo matched the
+ * *deployment's* containers by project label and removed them — silently. That
+ * is how a production reranker was removed for ~4.5h on 2026-09-06
+ * (vikunja#694).
+ *
+ * Measured, not reasoned: with the v3.25.0 file in a directory named
+ * `reranker`, `docker compose down --dry-run` reported `Container reranker
+ * Stopping / Stopped / Removing / Removed` against the live container. With a
+ * pinned `name:`, from the same directory, it matched nothing.
+ *
+ * These assertions are the guard against either half being helpfully restored.
+ * They are static because the live behaviour cannot be exercised in CI — the
+ * behavioural proof is recorded in the CHANGELOG and in this comment, and the
+ * invariant they encode is what produced it.
+ */
+
+function composeFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === ".git" || entry === "dist")
+      continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) composeFiles(full, found);
+    else if (/^docker-compose.*\.ya?ml$/.test(entry)) found.push(full);
+  }
+  return found;
+}
+
+const root = join(__dirname, "..");
+const files = composeFiles(root);
+
+describe("compose files cannot collide with another stack on the host", () => {
+  it("finds every compose file in the repo", () => {
+    // A guard that silently scans nothing is worse than no guard. If this
+    // number changes, the new file needs the two assertions below applied to
+    // it deliberately — update the count in the same commit.
+    expect(files.length).toBe(3);
+  });
+
+  it.each(
+    files.map((f) => [f.slice(root.length + 1), f]),
+  )("%s pins a top-level project name", (_rel, file) => {
+    const doc = parse(readFileSync(file, "utf8")) as { name?: unknown };
+    expect(typeof doc.name).toBe("string");
+    expect((doc.name as string).trim()).not.toBe("");
+  });
+
+  it.each(
+    files.map((f) => [f.slice(root.length + 1), f]),
+  )("%s sets no container_name on any service", (_rel, file) => {
+    const doc = parse(readFileSync(file, "utf8")) as {
+      services?: Record<string, Record<string, unknown>>;
+    };
+    for (const [name, svc] of Object.entries(doc.services ?? {})) {
+      expect(
+        svc?.container_name,
+        `service "${name}" sets container_name — it is global to the host`,
+      ).toBeUndefined();
+    }
+  });
+
+  it("the standalone reranker's project name is not the bare directory name", () => {
+    // The specific collision that caused the outage. `reranker` is what the
+    // directory basename would have produced and what the deployment uses.
+    const file = files.find((f) =>
+      f.endsWith("docker/reranker/docker-compose.yml"),
+    );
+    if (!file) throw new Error("docker/reranker/docker-compose.yml not found");
+    const doc = parse(readFileSync(file, "utf8")) as { name?: string };
+    expect(doc.name).not.toBe("reranker");
+    expect(doc.name).toBe("searxng-mcp-reranker");
+  });
+});


### PR DESCRIPTION
Patch release, shipped on its own ahead of the rest of the observability work, because the defective file is published and destroys production containers on a host that already runs a stack of the same name.

## The bug

v3.25.0 published `docker/reranker/docker-compose.yml`, and the README tells adopters to clone and `up`.

Compose derives the project name from the compose file's **directory basename** unless a top-level `name:` overrides it. That directory is called `reranker` — and so is the conventional deployment directory. Compose project names are **global to the Docker host**, so `docker compose down` run from a clone matched the *deployment's* containers by project label and removed them. No warning, no prompt. That is how a production reranker was removed for ~4.5h on 2026-09-06.

## The ticket's stated mechanism was wrong, and its prescribed fix would not have worked

vikunja#694 blamed `container_name: reranker` and asked for it to be deleted. Probed all four behaviours on forge before writing any code:

| From a clone, against a running production stack | Result |
|---|---|
| `up` with `container_name` set | Fails **loudly**: `Conflict. The container name "/reranker" is already in use` |
| `down` with `container_name` set, different project name | **No-op** — `down` matches by project label, not container name |
| `down` with the **same** project name | **Removes the production containers**, silently |
| `up` with the same project name, no `container_name` | **Adopts** the production container (same container id, "Running") |

So `container_name` is the loud half. The directory-derived **project name** is the silent, destructive half — and deleting `container_name` alone would have left it entirely in place, while *also* converting the loud `up` failure into a silent adoption. Both halves are fixed here.

## Measured proof

Positive control, v3.25.0 file in a directory named `reranker`:

```
$ docker compose down --dry-run
 Container reranker Stopping
 Container reranker Stopped
 Container reranker Removing
 Container reranker Removed          # <- the live production container
```

Same directory, this branch:

```
$ docker compose down --dry-run
                                     # matches nothing
$ docker ps --filter name=reranker
reranker   Up 2 hours                # production untouched
```

And the acceptance criterion end-to-end — clone-and-up on a host already running a production reranker:

```
Container searxng-mcp-reranker-reranker-1 Started
clone /health (8788): {"status":"ok","model_loaded":true}
prod  /health (8787): {"status":"ok","model_loaded":true}

$ docker compose down          # from the clone
 Container searxng-mcp-reranker-reranker-1 Removed
$ docker ps --filter name=reranker
reranker   reranker   Up 2 hours     # still serving
```

No production compose file was executed at any point; the collision mechanism was first reproduced with throwaway `busybox` stacks under names unrelated to `reranker`, and the live assertions are `--dry-run` or scoped to the pinned project.

## Changes

- `name: searxng-mcp-reranker` pinned on `docker/reranker/docker-compose.yml`, decoupling the project from the directory.
- `name: searxng-mcp` pinned on `docker-compose.full.yml` and `docker-compose.example.yml` — their conventional default, so behaviour is unchanged but can no longer be inherited from a clone directory's name.
- `container_name: reranker` removed, with a comment recording why it is absent so it is not helpfully restored.
- Host port is now `RERANKER_HOST_PORT`, defaulting to `8787`. The default is unchanged so the copy-paste path still works. The variable exists so a host already serving 8787 has a documented escape that is **not** "remove the other container" — which is the remedy Docker's own conflict message suggests, and the other way this outage happened.
- `docker/reranker/README.md` documents both.

## Test

`tests/compose-namespace.test.ts` asserts every compose file in the repo pins a project name and sets no `container_name`, plus the specific assertion that the reranker's project is not `reranker`.

Verified capable of failing: against the v3.25.0 file, 3 of its 8 assertions go red. It also asserts the file count, so a new compose file added without these properties fails rather than being silently skipped.

## Checks

- `pnpm test` — 962 passed, 6 skipped (was 954; the 8 new ones are picked up)
- `pnpm exec tsc --noEmit` — no errors
- `pnpm lint` — clean
- All three compose files re-validated with `docker compose config`

## Out of scope, worth raising

`~/docker/reranker/docker-compose.yml` — sysadmin's deployment copy, different repo — is the *other* participant in the collision and still derives its project name from its directory. Pinning `name:` there too would close the remaining direction. Filing that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)