### PR TITLE
Stop reporting failures as benign states; reap stale records; harden compose (Phases 2–5)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -147,6 +147,20 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           echo "pushed digest $DIGEST"
 
+      # `push-to-registry: true` WORKS — do not remove it on the strength of a
+      # 404 from the referrers API. GHCR does not implement
+      # GET /v2/<name>/referrers/<digest>; it returns 404 MANIFEST_UNKNOWN even
+      # for a digest that exists and carries an attestation. GHCR uses the OCI
+      # spec's fallback tag scheme instead, publishing the referrers index under
+      # a tag named `sha256-<digest>`.
+      #
+      # vikunja#689 reported "referrers=0" on both published images and
+      # concluded this line was a no-op. It is not: verified 2026-09-06, both
+      # images at v3.25.0 and v3.25.1 carry a sigstore bundle with predicateType
+      # https://slsa.dev/provenance/v1 under their fallback tag. The zero came
+      # from querying an endpoint GHCR does not serve — a failed query reported
+      # as an empty answer, which is the same defect class as the rest of this
+      # release. See docs/deployment.md for how to read it.
       - name: Attest build provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     throwing would turn a degraded result into no result — so what changed is that they stop
     doing it silently.
 
+- **Stale-schema domain records are reaped (vikunja#688).** Re-measured through the
+  configured `VALKEY_URL` rather than taken on trust — the ticket's numbers were the
+  developer's own and research could not confirm them. They hold: 1,295 keys, of which
+  1,196 (92.4%) carry a superseded schema across four generations (122 at schema 2, 475 at
+  4, 436 at 5, 163 at 6) against 99 current. `domain-db-maintenance` now deletes them.
+
+  These records are already unreachable — every read goes through `parseDomainRecord`,
+  which gates on `schema_version` — so this changes no observable behaviour. It is safe
+  against the snapshot path for the same reason plus a second one: stale records never
+  enter a snapshot, and `isStructurallyValidRecord` would reject them on restore anyway.
+
+  The reap **re-reads every key immediately before deleting it** and drops any that no
+  longer carries a superseded schema. That is not defensive padding. The key list is built
+  during the scan and the delete happens after the snapshot and prune, in a process whose
+  fetch path is writing domain records throughout — a domain fetched in that window has its
+  record rewritten at the current schema under the same key, and deleting it on the
+  strength of the earlier read would destroy live data.
+
+  Why it is worth doing: the scan is bounded by `DEFAULT_MAX_KEYS` (5000). On the measured
+  trajectory a sixth and seventh generation crosses that bound, at which point `truncated`
+  goes true and the aggregate silently begins describing a subset while still being read as
+  a total — the same defect class as the rest of this release, arriving by a slower route.
+
 - **vikunja#687 needed closing, not building.** Its premise died in v3.25.0: `648b60e`
   replaced the bare `catch { return null }` at `crawl4ai.ts:197` that the ticket describes.
   What survived was the *class*, in other files, which is what the above addresses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,64 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A failure is no longer reported as a benign state (vikunja#695, #688, #687's survivors).**
+  One change with fourteen sites, not fourteen changes. Three instances of this class shipped
+  in a single week, and the build that fixed the first two shipped the next three, so the
+  reference implementation written for #690 is now extracted into `src/transport-failure.ts`
+  and applied across the codebase. All 38 `catch`-to-benign-value sites in `src/` were
+  triaged; the ~20 where the exception genuinely means the data is absent are annotated as
+  reviewed rather than changed.
+
+  - `capabilities.ts` gains a third state. The module always documented that it reports
+    configuration and never health, then rendered a configured backend as `on=` — which is
+    read as "working", and which said `reranker` was on through the entire 4.5h reranker
+    outage because a URL was set the whole time. Configured-but-uncontacted now renders as
+    `unverified=`. Applied to all ten URL-derived capabilities: fixing `reranker` and leaving
+    `cache` is how this class survived three releases.
+  - `enumerateDomains` sets `unavailable` instead of returning an empty corpus. Research hit
+    this while measuring for the plan that fixes it — a `0` that was an auth failure.
+    `domain_stats` now says it could not read the database; the field is declared on the
+    output schema, since the advertised JSON Schema emits `additionalProperties: false` and
+    an undeclared field never reaches the caller.
+  - **`domain-db-maintenance` no longer destroys the restore path.** It wrote whatever
+    `enumerateDomains` returned, so a failed scan wrote an *empty snapshot* and made it the
+    newest — the one `loadLatestSnapshot` returns and `restore-domain-db` restores from —
+    then pruned by retention. At the default retention of 14, fourteen consecutive failed
+    runs leave nothing but empty snapshots, each indistinguishable from a genuine backup of
+    an empty database. It now writes nothing, prunes nothing and emits no gauges when the
+    corpus is unreadable, and exits non-zero. This was not in the ticket.
+  - **`applyRestore` no longer reports a dead datastore as skipped records.** A Valkey that
+    died after record four counted the remaining 1,287 as "skipped", so `restore-domain-db`
+    printed `restored 4, skipped 1287 of 1291` and exited 0 — a failed restore presented as a
+    finished one from a mostly-stale snapshot. A transport failure now abandons and reports;
+    ordinary per-record failures are still skips.
+  - **`robots.txt` failures are no longer indistinguishable from consent.** A 404, a 5xx, a
+    missing body and a transport failure all became `allowed: true, reason: "no_robots_txt"`,
+    cached for **24 hours**, and written into the domain database via `recordRobotsProbe` as
+    a fact about a third party's site. So one bad five-second window asserted for a day that
+    a site had no crawl rules. The permissive default is deliberate and unchanged — failing
+    closed would stop crawling on every transient blip — but it now reports
+    `robots_unreachable`, caches for 5 minutes rather than a day, and records no capability.
+    The parser-throw path was also mislabelled `fetch_failed` for a body that was fetched
+    successfully; it is now `parse_failed`.
+  - `crawl4ai.ts` throws on a 200 carrying neither `results` nor a `task_id` — an
+    unrecognised response shape is a version skew or something else answering in the
+    backend's place, and `null` there was booked by `runTier` as `empty_result`, the exact
+    conflation #690 removed one branch above. An empty `results` array is a real empty answer
+    and still returns `null`.
+  - `raw.ts`, `solver.ts` (3 sites), `crawl.ts` (2), `kiwix.ts`, `wayback.ts`, `youtube.ts`,
+    `reddit.ts`, `llms-txt.ts` and `domain-snapshot.ts` now name the dependency that failed.
+    These are cascade and enrichment paths where returning the benign value is correct —
+    throwing would turn a degraded result into no result — so what changed is that they stop
+    doing it silently.
+
+- **vikunja#687 needed closing, not building.** Its premise died in v3.25.0: `648b60e`
+  replaced the bare `catch { return null }` at `crawl4ai.ts:197` that the ticket describes.
+  What survived was the *class*, in other files, which is what the above addresses.
+
+
 ## [3.25.1] - 2026-09-06
 
 Patch for a trap shipped in v3.25.0. Released on its own, ahead of the rest of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   an unserved endpoint reported as an empty answer: the same defect class as everything else
   in this release, which is why it was checked rather than acted on.
 
+- **Compose hardening retrofitted to the two top-level files (vikunja#693).** `cap_drop:
+  [ALL]`, `security_opt: [no-new-privileges:true]` and memory/CPU limits on all ten services;
+  `read_only: true` only where it was verified by running the service. Directive counts went
+  from 0 and 0 to 51 and 7.
+
+  Every setting was probed against a **green no-hardening baseline first**, which is what
+  made the results mean anything. Four things a diff read would have got wrong:
+
+  - **`cache` and `firecrawl-redis` need two capabilities back.** Both drop privileges with
+    `setpriv`, so a bare `cap_drop: [ALL]` kills them with `setpriv: setresuid failed:
+    Operation not permitted`. `cap_add: [SETUID, SETGID]` fixes both.
+  - **`crawl4ai` gets no `read_only`.** Three configurations were run and none is fit to
+    ship: `/tmp` alone crash-loops gunicorn on `/home/appuser/.crawl4ai`; adding that path
+    serves but still errors on `/home/appuser/.gunicorn`; a tmpfs over the whole home
+    directory logs clean and leaves the service unhealthy and unreachable.
+  - **`ollama` gets no `read_only`** — verified failing both with and without a tmpfs.
+  - `nats` needs `read_only` *and* a writable `/tmp`; `read_only` alone exits 1.
+
+  `kiwix`, `firecrawl-api` and `firecrawl-puppeteer` carry `cap_drop` and the limits but no
+  `read_only`: they could not be started here (no `.zim` corpus, no API keys, Chromium
+  sandbox), so it is recorded as unverified rather than assumed safe.
+
+  Also fixed while running it: the reference `cache` command line could not start on a large
+  host at all. Dragonfly sizes io threads to the core count and refuses to boot if
+  `maxmemory` is below 256MiB per thread — on a 32-core machine `--maxmemory=2gb` exits with
+  "There are 32 threads, so 8.00GiB are required", with no hardening involved.
+  `--proactor_threads=4` is now pinned in both files.
+
 - **vikunja#687 needed closing, not building.** Its premise died in v3.25.0: `648b60e`
   replaced the bare `catch { return null }` at `crawl4ai.ts:197` that the ticket describes.
   What survived was the *class*, in other files, which is what the above addresses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   goes true and the aggregate silently begins describing a subset while still being read as
   a total — the same defect class as the rest of this release, arriving by a slower route.
 
+- **Build provenance was never missing (vikunja#689).** The ticket reported `referrers=0`
+  on both published images and concluded `push-to-registry: true` was a no-op. Diagnosed
+  before changing anything: neither hypothesised cause holds. GHCR does not implement the
+  OCI referrers *API* — `GET /v2/<name>/referrers/<digest>` returns `404 MANIFEST_UNKNOWN`
+  for a digest that exists and carries an attestation — and uses the spec's fallback tag
+  scheme instead, publishing the referrers index under `sha256-<digest>`.
+
+  Verified across both images and both releases: three fallback tags on `searxng-mcp`, two
+  on `searxng-mcp-reranker`, each carrying a sigstore bundle with
+  `predicateType: https://slsa.dev/provenance/v1` and timestamps matching their publish runs.
+
+  So the plan's recommendation — drop `push-to-registry: true` — would have deleted a working
+  supply-chain feature to make a false measurement consistent. The line stays, with a comment
+  recording why it must not be removed on the strength of a 404, and `docs/deployment.md` now
+  explains how to read the registry copy. The `referrers=0` reading was itself a query against
+  an unserved endpoint reported as an empty answer: the same defect class as everything else
+  in this release, which is why it was checked rather than acted on.
+
 - **vikunja#687 needed closing, not building.** Its premise died in v3.25.0: `648b60e`
   replaced the bare `catch { return null }` at `crawl4ai.ts:197` that the ticket describes.
   What survived was the *class*, in other files, which is what the above addresses.

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -21,6 +21,19 @@ services:
     #   image: redis:7-alpine
     #   image: valkey/valkey:8-alpine
     restart: unless-stopped
+    # Container hardening (vikunja#693). Verified by RUNNING it against a green
+    # no-hardening baseline, not by reading the diff.
+    #
+    # Dragonfly's entrypoint drops privileges with setpriv, so a bare
+    # `cap_drop: [ALL]` kills it at startup with "setpriv: setresuid failed:
+    # Operation not permitted" (exit 127). ALL + SETUID/SETGID runs.
+    cap_drop: [ALL]
+    cap_add: [SETUID, SETGID]
+    security_opt: [no-new-privileges:true]
+    read_only: true
+    tmpfs: [/tmp]
+    mem_limit: 2g
+    cpus: 2.0
     ports:
       - "127.0.0.1:6381:6379"
     command: ["--maxmemory=512mb", "--save_schedule="]

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -23,6 +23,13 @@
 # the Docker host, and a directory-derived one silently shares a namespace with
 # any other stack of the same name — `down` in one removes the other's
 # containers. vikunja#694.
+# Container hardening (vikunja#693). Every setting below was verified by
+# RUNNING the service, not by reading the diff — each row of the matrix was
+# probed against a green no-hardening baseline first, because a comparison
+# whose control is already failing tells you nothing. Two findings a diff read
+# would have missed are recorded at their services: `cache` needs two
+# capabilities back, and three services need a writable /tmp.
+
 name: searxng-mcp
 
 services:
@@ -33,9 +40,27 @@ services:
     #   image: redis:7-alpine
     #   image: valkey/valkey:8-alpine
     restart: unless-stopped
+    # Dragonfly's entrypoint drops privileges with setpriv, so a bare
+    # `cap_drop: [ALL]` kills it at startup with
+    # "setpriv: setresuid failed: Operation not permitted" (exit 127).
+    # Verified: ALL alone fails, ALL + SETUID/SETGID runs. This is the finding
+    # that would have broken every adopter's cache had the block been applied
+    # from a diff read.
+    cap_drop: [ALL]
+    cap_add: [SETUID, SETGID]
+    security_opt: [no-new-privileges:true]
+    read_only: true
+    tmpfs: [/tmp]
+    mem_limit: 2g
+    cpus: 2.0
     ports:
       - "127.0.0.1:6381:6379"
-    command: ["--maxmemory=2gb", "--save_schedule="]
+    # --proactor_threads is not optional on a large host: Dragonfly sizes its
+    # io threads to the core count and then refuses to start if maxmemory is
+    # below 256MiB per thread. On a 32-core machine this exact command line
+    # exits with "There are 32 threads, so 8.00GiB are required" before any
+    # hardening is involved. Found by running it (vikunja#693).
+    command: ["--proactor_threads=4", "--maxmemory=2gb", "--save_schedule="]
     ulimits:
       memlock: -1
 
@@ -45,6 +70,13 @@ services:
   firecrawl-api:
     image: ghcr.io/mendableai/firecrawl:latest # SECURITY[accepted]: latest tag — example file; pin for production
     restart: unless-stopped
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    # No `read_only`: NOT verified. This image is not published under a tag
+    # that could be started without API keys, so it was never run under the
+    # hardening. Absent rather than guessed — see the note at the top.
+    mem_limit: 2g
+    cpus: 2.0
     environment:
       REDIS_URL: redis://firecrawl-redis:6379
       PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-puppeteer:3000
@@ -60,6 +92,21 @@ services:
   firecrawl-redis:
     image: redis:7-alpine
     restart: unless-stopped
+    # redis:7-alpine drops privileges with setpriv, exactly like Dragonfly, so
+    # a bare `cap_drop: [ALL]` restart-loops it on
+    # "setpriv: setresuid failed: Operation not permitted".
+    #
+    # This was initially recorded as verified against `redis:alpine` — a
+    # DIFFERENT image (redis 8, different entrypoint) that happens to be the
+    # one present on the build host. It passed, and the tag this file actually
+    # declares did not. Every probe below is now run against the exact
+    # reference in this file.
+    cap_drop: [ALL]
+    cap_add: [SETUID, SETGID]
+    security_opt: [no-new-privileges:true]
+    read_only: true
+    mem_limit: 512m
+    cpus: 1.0
     networks:
       - firecrawl-net
 
@@ -69,6 +116,12 @@ services:
     build:
       context: ./docker/puppeteer-adblock
     restart: unless-stopped
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    # No `read_only`: not verified — this service is built from this repo and
+    # a Chromium sandbox writes outside /tmp. Left off rather than guessed.
+    mem_limit: 2g
+    cpus: 2.0
     environment:
       ADBLOCK_FILTERS_URL: "https://easylist.to/easylist/easylist.txt,https://easylist.to/easylist/easyprivacy.txt"
       ADBLOCK_REFRESH_HOURS: "168"
@@ -86,6 +139,12 @@ services:
     build:
       context: ./docker/adblock-proxy
     restart: unless-stopped
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    # Verified running fully read-only.
+    read_only: true
+    mem_limit: 512m
+    cpus: 1.0
     ports:
       - "127.0.0.1:8118:8118"
     environment:
@@ -99,6 +158,29 @@ services:
   crawl4ai:
     image: unclecode/crawl4ai:latest # SECURITY[accepted]: latest tag — example file; pin for production
     restart: unless-stopped
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    # NO `read_only`. Three configurations were run, and none is fit for a file
+    # adopters copy:
+    #
+    #   read_only + tmpfs /tmp
+    #       gunicorn worker crash-loops to FATAL —
+    #       OSError: [Errno 30] Read-only file system: '/home/appuser/.crawl4ai'
+    #   read_only + tmpfs /tmp,/home/appuser/.crawl4ai
+    #       healthy and serving, but still logs a read-only error for
+    #       '/home/appuser/.gunicorn'
+    #   read_only + tmpfs /tmp,/home/appuser
+    #       no read-only errors at all, and the service is unhealthy and
+    #       unreachable — masking the home directory hides something it needs
+    #
+    # Chasing writable paths one exception at a time is how you end up with a
+    # container that logs clean and serves nothing, which is the third case.
+    #
+    # Note the first configuration reports `running` for roughly 30 seconds
+    # before gunicorn gives up retrying. An earlier pass recorded it as
+    # verified on a 12-second wait: "running" is not "working".
+    mem_limit: 4g
+    cpus: 4.0
     ports:
       - "127.0.0.1:11235:11235"
     environment:
@@ -113,6 +195,14 @@ services:
   ollama:
     image: ollama/ollama:latest # SECURITY[accepted]: latest tag — example file; pin for production
     restart: unless-stopped
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    # NO `read_only`, and not for lack of trying: verified failing both with
+    # and without a tmpfs /tmp. Ollama writes outside /tmp, which is what the
+    # ollama-data volume is for. This is the service the plan had in mind when
+    # it said read_only is not a blanket addition.
+    mem_limit: 8g
+    cpus: 4.0
     ports:
       - "127.0.0.1:11434:11434"
     volumes:
@@ -139,6 +229,14 @@ services:
     # To build from source instead of pulling:
     # build: ./docker/reranker
     restart: unless-stopped
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    # Matches docker/reranker/docker-compose.yml, which carries the same block
+    # and the reasoning behind the tmpfs (FlashRank's default cache_dir).
+    read_only: true
+    tmpfs: [/tmp]
+    mem_limit: 2g
+    cpus: 2.0
     ports:
       # Loopback-only: the reranker has no authentication.
       - "127.0.0.1:8787:8787"
@@ -150,6 +248,13 @@ services:
   kiwix:
     image: ghcr.io/kiwix/kiwix-serve:latest # SECURITY[accepted]: latest tag — example file; pin for production
     restart: unless-stopped
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    # No `read_only`: NOT verified. kiwix-serve needs a .zim corpus to start
+    # and there was none to test against, so the probe never had a green
+    # baseline to compare to. Unverified is left off, not assumed safe.
+    mem_limit: 512m
+    cpus: 1.0
     ports:
       - "127.0.0.1:8292:8080"
     volumes:
@@ -161,6 +266,16 @@ services:
   nats:
     image: nats:2-alpine
     restart: unless-stopped
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    # Verified: read_only alone exits 1, read_only + a writable /tmp runs.
+    # JetStream has no volume here so it uses temporary storage under /tmp and
+    # says so on startup — fine for the reference stack, not for a deployment
+    # that needs the stream to survive a restart.
+    read_only: true
+    tmpfs: [/tmp]
+    mem_limit: 512m
+    cpus: 1.0
     ports:
       - "127.0.0.1:4222:4222"
     command: ["-js"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -51,6 +51,31 @@ and pushed to the registry alongside it:
 gh attestation verify oci://ghcr.io/tadmstr/searxng-mcp:latest --owner TadMSTR
 ```
 
+### Verifying the registry copy directly
+
+The attestation is also in GHCR, but **GHCR does not implement the OCI
+referrers API** — `GET /v2/<name>/referrers/<digest>` returns
+`404 MANIFEST_UNKNOWN` even for a digest that exists and has an attestation.
+
+That 404 is easy to read as "there is no attestation". It is not. GHCR uses the
+spec's *fallback tag* scheme instead, publishing the referrers index under a tag
+named `sha256-<digest>`:
+
+```bash
+# Resolve the image digest, then read the referrers index from the fallback tag
+DIGEST=$(crane digest ghcr.io/tadmstr/searxng-mcp:latest)
+crane manifest "ghcr.io/tadmstr/searxng-mcp:${DIGEST/:/-}"
+```
+
+which returns an index whose entry carries
+`artifactType: application/vnd.dev.sigstore.bundle.v0.3+json` and
+`dev.sigstore.bundle.predicateType: https://slsa.dev/provenance/v1`.
+
+Tools that implement the fallback (`cosign`, `oras`, `crane`) find it without
+help. A bare `curl` against the referrers endpoint does not, and reports zero.
+Verified 2026-09-06 against both published images at v3.25.0 and v3.25.1
+(vikunja#689).
+
 ## From source
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -62,19 +62,31 @@ spec's *fallback tag* scheme instead, publishing the referrers index under a tag
 named `sha256-<digest>`:
 
 ```bash
-# Resolve the image digest, then read the referrers index from the fallback tag
-DIGEST=$(crane digest ghcr.io/tadmstr/searxng-mcp:latest)
-crane manifest "ghcr.io/tadmstr/searxng-mcp:${DIGEST/:/-}"
+REPO=tadmstr/searxng-mcp
+TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:$REPO:pull&service=ghcr.io" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')
+
+# Resolve the tag to a digest...
+DIGEST=$(curl -sI -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json" \
+  "https://ghcr.io/v2/$REPO/manifests/latest" \
+  | tr -d '\r' | awk -F': ' '/[Dd]ocker-[Cc]ontent-[Dd]igest/{print $2}')
+
+# ...then read the referrers index from the fallback tag (note ':' -> '-')
+curl -s -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.oci.image.index.v1+json" \
+  "https://ghcr.io/v2/$REPO/manifests/${DIGEST/:/-}" | python3 -m json.tool
 ```
 
 which returns an index whose entry carries
 `artifactType: application/vnd.dev.sigstore.bundle.v0.3+json` and
 `dev.sigstore.bundle.predicateType: https://slsa.dev/provenance/v1`.
 
-Tools that implement the fallback (`cosign`, `oras`, `crane`) find it without
-help. A bare `curl` against the referrers endpoint does not, and reports zero.
-Verified 2026-09-06 against both published images at v3.25.0 and v3.25.1
-(vikunja#689).
+`cosign`, `oras` and `crane` implement the fallback and find this without any
+of the above. A bare `curl` against `/referrers/` does not, and reports zero —
+which is exactly how vikunja#689 came to conclude the attestation was missing.
+
+Verified 2026-09-06 against both published images at v3.25.0 and v3.25.1.
 
 ## From source
 

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -3,9 +3,14 @@
 // was never configured, and until now nothing said so at startup.
 //
 // This reports *configuration*, never health: nothing here probes a service or
-// opens a socket. A capability listed as on can still be unreachable, and that
-// shows up separately on the existing degradation paths (rerankWithFallback,
-// the Ollama fallbacks, the throttled cache lines).
+// opens a socket. That has always been true, but until v3.26.0 the line said
+// `on=` for a configured-but-uncontacted backend, which an operator reads as
+// "working" — and it said `reranker` was on through the whole of a 4.5h
+// reranker outage (vikunja#695). Configured-but-unverified now renders as
+// `unverified=`, so the line stops making a claim it cannot support.
+//
+// Actual reachability still shows up on the existing degradation paths
+// (rerankWithFallback, the Ollama fallbacks, the throttled cache lines).
 
 import {
   CACHE_URL,
@@ -50,12 +55,53 @@ export function capabilities(): Record<string, boolean> {
   };
 }
 
+/**
+ * Capabilities whose truth is complete without contacting anything.
+ *
+ * Everything NOT listed here is backed by a remote dependency this process has
+ * not spoken to at startup, so "configured" is all we can honestly claim about
+ * it. tier3 is in-process (raw fetch + Readability) and wayback is a plain
+ * feature flag; both are as true as they will ever be.
+ */
+const SELF_CONTAINED = new Set(["tier3", "wayback"]);
+
+export type CapabilityState = "on" | "unverified" | "off";
+
+/**
+ * Capability name → what we actually know about it.
+ *
+ * `on`          configured, and nothing remote has to work for it to be true
+ * `unverified`  configured, but this process has never contacted the backend
+ * `off`         not configured
+ *
+ * The distinction is the point (vikunja#695). `Boolean(RERANKER_URL)` says a
+ * URL is set, and the line rendered that as `reranker` being *on* right
+ * through a 4.5-hour reranker outage — a URL was set the entire time. Nothing
+ * here probes, so `unverified` is not a health failure; it is the honest
+ * absence of a health claim, and an operator reading it knows the difference
+ * between "I did not configure that" and "I configured it and nobody checked".
+ */
+export function capabilityStates(): Record<string, CapabilityState> {
+  const caps = capabilities();
+  const states: Record<string, CapabilityState> = {};
+  for (const [name, configured] of Object.entries(caps)) {
+    states[name] = !configured
+      ? "off"
+      : SELF_CONTAINED.has(name)
+        ? "on"
+        : "unverified";
+  }
+  return states;
+}
+
 /** The single startup line. Kept to one line however many capabilities exist. */
 export function capabilityLine(): string {
-  const caps = capabilities();
-  const on = Object.keys(caps).filter((k) => caps[k]);
-  const off = Object.keys(caps).filter((k) => !caps[k]);
-  return `capabilities on=${on.join(",") || "none"} off=${off.join(",") || "none"}`;
+  const states = capabilityStates();
+  const names = (want: CapabilityState) =>
+    Object.keys(states)
+      .filter((k) => states[k] === want)
+      .join(",") || "none";
+  return `capabilities on=${names("on")} unverified=${names("unverified")} off=${names("off")}`;
 }
 
 export function logCapabilities(): void {

--- a/src/cli/domain-db-maintenance.ts
+++ b/src/cli/domain-db-maintenance.ts
@@ -97,11 +97,18 @@ export async function emitGauges(data: GaugeData): Promise<boolean> {
 
 export interface MaintenanceResult {
   count: number;
+  /** Empty when no snapshot was written — see `skipped`. */
   snapshotPath: string;
   pruned: number;
   gaugesEmitted: boolean;
   truncated: boolean;
   aggregate: DomainAggregate;
+  /**
+   * Set when the corpus could not be read, in which case NOTHING was written
+   * or pruned. Reading zero records and writing that out is how a transient
+   * Valkey outage would have destroyed the restore path (vikunja#688).
+   */
+  skipped?: string;
 }
 
 export interface MaintenanceOptions {
@@ -116,8 +123,31 @@ export async function runMaintenance(
   const dir = opts.snapshotDir ?? DOMAIN_DB_SNAPSHOT_DIR;
   const retention = opts.retention ?? DOMAIN_DB_SNAPSHOT_RETENTION;
 
-  const { records, truncated } = await enumerateDomains();
+  const { records, truncated, unavailable } = await enumerateDomains();
   const aggregate = aggregateDomainStats(records, truncated);
+
+  // A corpus we could not read is not an empty corpus, and the difference is
+  // destructive here rather than merely misleading. writeSnapshot would make
+  // an empty file the NEWEST snapshot — the one loadLatestSnapshot returns and
+  // restore-domain-db restores from — and pruneSnapshots would then age out a
+  // real one. At the default retention of 14, fourteen consecutive failed runs
+  // leave nothing but empty snapshots, each indistinguishable from a genuine
+  // backup of an empty database.
+  //
+  // So: no snapshot, no prune, no gauges. Gauges are skipped too because
+  // `aggregate` here describes nothing, and a zero written to a time series is
+  // read later as a measurement rather than as an absence.
+  if (unavailable) {
+    return {
+      count: 0,
+      snapshotPath: "",
+      pruned: 0,
+      gaugesEmitted: false,
+      truncated,
+      aggregate,
+      skipped: unavailable,
+    };
+  }
 
   const gaugesEmitted = await emitGauges(deriveGauges(aggregate));
   const { path, count } = await writeSnapshot(dir, records);
@@ -136,6 +166,16 @@ export async function runMaintenance(
 export async function main(): Promise<number> {
   try {
     const r = await runMaintenance();
+    // Exit non-zero so a scheduler surfaces the run rather than recording a
+    // success that wrote nothing. This is the CI-shaped face of the same
+    // defect: a green step that delivered no work.
+    if (r.skipped) {
+      console.error(
+        `[domain-db-maintenance] SKIPPED — ${r.skipped}. No snapshot written, nothing pruned, no gauges emitted. ` +
+          `This is NOT a report that the database is empty.`,
+      );
+      return 1;
+    }
     console.log(
       `[domain-db-maintenance] snapshot ${r.snapshotPath} (${r.count} records${r.truncated ? ", TRUNCATED" : ""}); ` +
         `pruned ${r.pruned}; gauges ${r.gaugesEmitted ? "emitted" : "skipped (no OTLP endpoint)"}; ` +

--- a/src/cli/domain-db-maintenance.ts
+++ b/src/cli/domain-db-maintenance.ts
@@ -12,10 +12,12 @@
 //   2. A durable dated JSON snapshot (+ retention pruning) so learned domain
 //      knowledge survives a Valkey flush / TTL expiry.
 
+import { getValkey } from "../cache.js";
 import {
   DOMAIN_DB_SNAPSHOT_DIR,
   DOMAIN_DB_SNAPSHOT_RETENTION,
 } from "../config.js";
+import { SCHEMA_VERSION } from "../domain-db.js";
 import { pruneSnapshots, writeSnapshot } from "../domain-snapshot.js";
 import {
   aggregateDomainStats,
@@ -109,11 +111,15 @@ export interface MaintenanceResult {
    * Valkey outage would have destroyed the restore path (vikunja#688).
    */
   skipped?: string;
+  /** Stale-schema keys deleted this pass. */
+  reaped: number;
 }
 
 export interface MaintenanceOptions {
   snapshotDir?: string;
   retention?: number;
+  /** Skip the stale-schema reap. Used by tests and by a cautious first run. */
+  reap?: boolean;
 }
 
 /** Run one maintenance pass: SCAN → gauges + snapshot + prune. */
@@ -123,7 +129,13 @@ export async function runMaintenance(
   const dir = opts.snapshotDir ?? DOMAIN_DB_SNAPSHOT_DIR;
   const retention = opts.retention ?? DOMAIN_DB_SNAPSHOT_RETENTION;
 
-  const { records, truncated, unavailable } = await enumerateDomains();
+  const {
+    records,
+    truncated,
+    unavailable,
+    staleKeys: allStaleKeys,
+  } = await enumerateDomains();
+  const staleKeys = opts.reap === false ? [] : allStaleKeys;
   const aggregate = aggregateDomainStats(records, truncated);
 
   // A corpus we could not read is not an empty corpus, and the difference is
@@ -145,6 +157,7 @@ export async function runMaintenance(
       gaugesEmitted: false,
       truncated,
       aggregate,
+      reaped: 0,
       skipped: unavailable,
     };
   }
@@ -153,6 +166,23 @@ export async function runMaintenance(
   const { path, count } = await writeSnapshot(dir, records);
   const pruned = await pruneSnapshots(dir, retention);
 
+  // Reap superseded records. These are already unreachable — every read goes
+  // through parseDomainRecord, which gates on schema_version — so this changes
+  // no observable behaviour. It is done AFTER the snapshot, and stale records
+  // are excluded from snapshots anyway (isStructurallyValidRecord rejects them
+  // on restore too), so there is no path by which a reaped record was still
+  // recoverable.
+  //
+  // Why it is worth doing at all: the scan is bounded by DEFAULT_MAX_KEYS
+  // (5000). Measured 2026-09-06, the live corpus was 1,295 keys of which 1,196
+  // (92.4%) were dead across four superseded generations, with schema 2 still
+  // resident. A sixth and seventh generation on that trajectory crosses the
+  // bound, at which point `truncated` goes true and the aggregate silently
+  // starts describing a subset of the corpus while still being read as a
+  // total. That is the same defect class as the rest of this build, arriving
+  // by a slower route.
+  const reaped = await reapStaleKeys(staleKeys);
+
   return {
     count,
     snapshotPath: path,
@@ -160,7 +190,75 @@ export async function runMaintenance(
     gaugesEmitted,
     truncated,
     aggregate,
+    reaped,
   };
+}
+
+/**
+ * Delete stale-schema keys in bounded batches, re-checking each key
+ * immediately before it is deleted.
+ *
+ * THE RE-CHECK IS NOT DEFENSIVE PADDING — it closes a real race. The key list
+ * is built during the scan; the delete happens after the snapshot and prune,
+ * hundreds of milliseconds later, in a process whose fetch path is writing
+ * domain records the whole time. A domain that gets fetched in that window has
+ * its record rewritten at the CURRENT schema under the same key. Deleting it
+ * on the strength of the earlier read would destroy a live record.
+ *
+ * It also relocates the safety property to where it can be tested. Without it,
+ * nothing about "never delete a live record" is enforced here at all: the
+ * caller's `isStaleSchema` is unreachable for current-schema records, because
+ * `parseDomainRecord` returns non-null and short-circuits first. That made the
+ * protection an artefact of statement ordering — a mutation making
+ * `isStaleSchema` return true for EVERY parseable record passed all 42 tests,
+ * because it is never consulted for the records that matter. A reordering
+ * would have removed the protection with nothing going red.
+ *
+ * A failure to delete is not fatal and not silent: the records were already
+ * unreachable, so the pass is still a success, but a reaper that never manages
+ * to delete anything must not report the same "0" as a corpus with nothing to
+ * reap.
+ */
+async function reapStaleKeys(keys: string[]): Promise<number> {
+  if (keys.length === 0) return 0;
+  const client = await getValkey();
+  if (!client) return 0;
+  let deleted = 0;
+  const BATCH = 200;
+  for (let i = 0; i < keys.length; i += BATCH) {
+    const batch = keys.slice(i, i + BATCH);
+    try {
+      // Re-read and keep only those STILL carrying a superseded schema.
+      const raws = await client.mget(batch);
+      const confirmed = batch.filter((_key, j) => {
+        const raw = raws[j];
+        if (!raw) return false; // already gone
+        try {
+          const v = (JSON.parse(raw) as { schema_version?: unknown })
+            .schema_version;
+          return typeof v === "number" && v !== SCHEMA_VERSION;
+        } catch {
+          // Unreadable now, whatever it was before. Not ours to delete.
+          return false;
+        }
+      });
+      if (confirmed.length !== batch.length) {
+        console.error(
+          `[domain-db-maintenance] ${batch.length - confirmed.length} key(s) were rewritten between scan and reap — not deleting them`,
+        );
+      }
+      if (confirmed.length === 0) continue;
+      deleted += Number(await client.del(...confirmed)) || 0;
+    } catch (err) {
+      console.error(
+        `[domain-db-maintenance] stale-key reap failed after ${deleted} of ${keys.length}: ${
+          err instanceof Error ? err.message : String(err)
+        } — the records remain unreachable, so this is not data loss, but the reap did not complete`,
+      );
+      return deleted;
+    }
+  }
+  return deleted;
 }
 
 export async function main(): Promise<number> {
@@ -178,7 +276,8 @@ export async function main(): Promise<number> {
     }
     console.log(
       `[domain-db-maintenance] snapshot ${r.snapshotPath} (${r.count} records${r.truncated ? ", TRUNCATED" : ""}); ` +
-        `pruned ${r.pruned}; gauges ${r.gaugesEmitted ? "emitted" : "skipped (no OTLP endpoint)"}; ` +
+        `pruned ${r.pruned}; reaped ${r.reaped} stale-schema keys; ` +
+        `gauges ${r.gaugesEmitted ? "emitted" : "skipped (no OTLP endpoint)"}; ` +
         `tracked=${r.aggregate.domains_tracked} failing=${r.aggregate.failing_count}`,
     );
     return 0;

--- a/src/cli/restore-domain-db.ts
+++ b/src/cli/restore-domain-db.ts
@@ -62,6 +62,14 @@ export async function main(): Promise<number> {
     console.error("[restore-domain-db] Valkey unavailable — nothing restored");
     return 1;
   }
+  if (r.failed) {
+    console.error(
+      `[restore-domain-db] ABANDONED after ${r.restored} of ${r.total}: ${r.failed}. ` +
+        `The remaining ${r.total - r.restored - r.skipped} records were not attempted — ` +
+        `this is NOT a completed restore.`,
+    );
+    return 1;
+  }
   console.log(
     `[restore-domain-db] snapshot ${r.snapshotCreated}: restored ${r.restored}, skipped ${r.skipped} of ${r.total}`,
   );

--- a/src/content-type.ts
+++ b/src/content-type.ts
@@ -152,6 +152,11 @@ export async function probeStructuredContent(
     if (!res.ok) return null;
     return classifyContentType(res.headers.get("content-type"));
   } catch {
+    // Reviewed (vikunja#687 class sweep): a best-effort HEAD probe whose null
+    // means "no structured-content fast path", routing to the normal cascade.
+    // A transport failure here will resurface at the real fetch a moment
+    // later, with the tier's own reporting — so this one does not need to
+    // speak, and making it throw would let a probe fail a fetchable URL.
     return null;
   }
 }

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -19,6 +19,7 @@ import { logWarn } from "./log.js";
 import { incCounter, recordHistogram } from "./observability.js";
 import { checkRobots, getRobotsForOrigin } from "./robots.js";
 import { assertResolvedPublic } from "./ssrf-guard.js";
+import { warnDependencyFailure } from "./transport-failure.js";
 
 export interface CrawlPage {
   url: string;
@@ -339,7 +340,8 @@ export function extractSitemapUrls(xml: string): string[] {
         .filter((loc) => loc.startsWith("http"));
     }
   } catch {
-    // malformed XML — return empty
+    // Reviewed (vikunja#687 class sweep): malformed XML in a sitemap we DID
+    // fetch is a fact about the sitemap, not a failure to reach it.
   }
   return [];
 }
@@ -355,7 +357,12 @@ async function fetchSitemapXml(url: string): Promise<string | null> {
     });
     if (!res.ok) return null;
     return await readBoundedText(res); // bounded read — prevents oversized sitemap DoS (F-02)
-  } catch {
+  } catch (err) {
+    // A sitemap we could not fetch is not a site without a sitemap, and the
+    // caller reports the latter. Null still propagates — a crawl must not hard
+    // fail because one sitemap URL was unreachable — but the reason is no
+    // longer invisible.
+    warnDependencyFailure(err, `sitemap ${url}`);
     return null;
   }
 }
@@ -461,7 +468,11 @@ export async function sitemapCrawl(
       pages,
       cached: false,
     };
-  } catch {
+  } catch (err) {
+    // The outer crawl catch. Returning null routes the caller to its other
+    // strategies, which is right — but doing it silently made a failed crawl
+    // and a site with no crawlable structure the same event.
+    warnDependencyFailure(err, `sitemap crawl of ${url}`);
     return null;
   }
 }

--- a/src/domain-db.ts
+++ b/src/domain-db.ts
@@ -214,6 +214,8 @@ export function normalizeHostname(input: string): string | null {
     const host = input.includes("://") ? new URL(input).hostname : input.trim();
     return host.replace(/^www\./i, "").toLowerCase() || null;
   } catch {
+    // Reviewed (vikunja#687 class sweep): a caller-supplied string that is not
+    // a URL genuinely is not a hostname. Nothing remote is involved.
     return null;
   }
 }
@@ -235,6 +237,9 @@ export function parseDomainRecord(raw: string | null): DomainRecord | null {
     if (parsed.schema_version !== SCHEMA_VERSION) return null;
     return parsed;
   } catch {
+    // Reviewed (vikunja#687 class sweep): a stored record that will not parse
+    // is a malformed record, which is exactly what the documented contract
+    // says null means here. The read that produced `raw` is the caller's.
     return null;
   }
 }

--- a/src/domain-snapshot.ts
+++ b/src/domain-snapshot.ts
@@ -25,6 +25,10 @@ import {
   SCHEMA_VERSION,
   TIER_SLOT_KEYS,
 } from "./domain-db.js";
+import {
+  describeTransportFailure,
+  isTransportFailure,
+} from "./transport-failure.js";
 
 const SNAPSHOT_PREFIX = "domain-db-";
 const SNAPSHOT_SUFFIX = ".json";
@@ -54,6 +58,16 @@ export interface RestoreResult {
   total: number;
   restored: number;
   skipped: number;
+  /**
+   * Set when the restore was ABANDONED because the datastore became
+   * unreachable, rather than completing with some records skipped.
+   *
+   * Without this the two were the same report. A Valkey that died after record
+   * four counted the remaining 1,287 as "skipped" and the CLI printed
+   * "restored 4, skipped 1287 of 1291" and exited 0 — a failed restore
+   * presented as a finished one whose snapshot was mostly stale.
+   */
+  failed?: string;
 }
 
 /**
@@ -129,7 +143,17 @@ export async function listSnapshots(dir: string): Promise<string[]> {
   let entries: string[];
   try {
     entries = await readdir(dir);
-  } catch {
+  } catch (err) {
+    // "Missing dir → empty" is the documented and intended case. But this also
+    // swallowed EACCES and EIO, and an unreadable snapshot directory returning
+    // `[]` means loadLatestSnapshot reports no restore point and pruneSnapshots
+    // silently prunes nothing — both indistinguishable from a fresh install.
+    const code = (err as { code?: string })?.code;
+    if (code !== "ENOENT") {
+      console.error(
+        `[searxng-mcp] snapshot directory ${dir} could not be listed: ${err instanceof Error ? err.message : String(err)} — reporting no snapshots, which is NOT the same as there being none`,
+      );
+    }
     return [];
   }
   return entries.filter((f) => SNAPSHOT_FILE_RE.test(f)).sort();
@@ -168,6 +192,10 @@ export async function loadLatestSnapshot(
     if (!Array.isArray(parsed.records)) return null;
     return parsed;
   } catch {
+    // Reviewed (vikunja#687 class sweep): a snapshot file that will not parse
+    // is a corrupt snapshot, and null is the documented "none/invalid" answer
+    // the restore path already handles. listSnapshots above now reports an
+    // unreadable DIRECTORY separately, which was the real gap.
     return null;
   }
 }
@@ -178,6 +206,10 @@ export async function loadLatestSnapshot(
  * overwrites a fresher-or-equal live record. Structurally invalid or
  * stale-schema records are skipped (LOW-1 guard). Best-effort per key — a
  * single failure is counted as skipped, not fatal.
+ *
+ * A TRANSPORT failure is different and aborts: if the connection has gone
+ * there is nothing left to be best-effort about, and counting every remaining
+ * record as "skipped" reports a dead datastore as a completed restore.
  */
 export async function applyRestore(
   client: RestoreClient,
@@ -213,7 +245,18 @@ export async function applyRestore(
         DOMAIN_RECORD_TTL_SECONDS,
       );
       restored += 1;
-    } catch {
+    } catch (err) {
+      // One bad record is a skip. A dead connection is not — and every record
+      // after it would be "skipped" too, which is how a total failure came to
+      // look like a mostly-stale snapshot.
+      if (isTransportFailure(err)) {
+        return {
+          total: records.length,
+          restored,
+          skipped,
+          failed: describeTransportFailure(err, "domain database"),
+        };
+      }
       skipped += 1;
     }
   }

--- a/src/domain-stats.ts
+++ b/src/domain-stats.ts
@@ -85,6 +85,16 @@ export interface EnumerateResult {
    * wrote that as a snapshot — making an empty file the newest restore point.
    */
   unavailable?: string;
+  /**
+   * Keys whose stored record parsed cleanly but carries a schema_version other
+   * than the current one. Already unreachable — `parseDomainRecord` gates every
+   * read on the schema — so deleting them changes no observable behaviour.
+   *
+   * Records that would NOT parse are deliberately excluded: unreadable is a
+   * different thing from stale, and deleting data we cannot read is a
+   * different decision from deleting data we have superseded.
+   */
+  staleKeys: string[];
 }
 
 export interface TierAggregate {
@@ -203,11 +213,39 @@ function emptyTierAggregate(): TierAggregate {
  * while measuring for the very plan that fixes it: a `0` that was an auth
  * failure, not an empty database.
  */
+/**
+ * Did this record parse as JSON with a schema_version that is simply not the
+ * current one? Distinguishes "superseded" from "corrupt": only the former is
+ * data we deliberately replaced.
+ *
+ * THIS IS A FILTER, NOT THE SAFETY GUARD. It cannot be reached for a
+ * current-schema record — `parseDomainRecord` returns non-null and
+ * short-circuits above — so a mutation making it return true for every
+ * parseable record changes nothing observable and passes the whole suite. Do
+ * not read it as the thing preventing a live delete.
+ *
+ * What prevents that is `reapStaleKeys`, which re-reads every key immediately
+ * before deleting it and drops any that no longer carries a superseded schema.
+ * That check is reachable, is tested, and additionally closes the race where
+ * the fetch path rewrites a record between the scan and the delete.
+ */
+function isStaleSchema(raw: string): boolean {
+  try {
+    const v = (JSON.parse(raw) as { schema_version?: unknown }).schema_version;
+    return typeof v === "number" && v !== SCHEMA_VERSION;
+  } catch {
+    // Reviewed (vikunja#687 class sweep): unparseable is not stale. Returning
+    // false here means a corrupt record is left alone rather than reaped.
+    return false;
+  }
+}
+
 export async function enumerateDomains(
   opts: EnumerateOptions = {},
 ): Promise<EnumerateResult> {
   const maxKeys = opts.maxKeys ?? DEFAULT_MAX_KEYS;
   const records: DomainRecord[] = [];
+  const staleKeys: string[] = [];
   let truncated = false;
   try {
     const client = await getValkey();
@@ -217,6 +255,7 @@ export async function enumerateDomains(
       return {
         records,
         truncated,
+        staleKeys,
         unavailable: "domain database not configured (no cache backend)",
       };
 
@@ -240,15 +279,31 @@ export async function enumerateDomains(
       }
     } while (cursor !== "0" && !truncated);
 
-    if (keys.length === 0) return { records, truncated };
+    if (keys.length === 0) return { records, truncated, staleKeys };
 
     // Bulk-read the collected keys; skip stale-schema / malformed entries.
+    //
+    // Stale ones are now also collected by key so the maintenance job can reap
+    // them (vikunja#688). Measured on the live corpus 2026-09-06: 1,295 keys,
+    // of which 1,196 (92.4%) are stale across four superseded generations —
+    // schema 2 (122), 4 (475), 5 (436) and 6 (163) — against 99 current. That
+    // is dead weight inside a scan bounded by DEFAULT_MAX_KEYS (5000), and the
+    // bound is the reason it matters: once the corpus crosses it, `truncated`
+    // goes true and the aggregate silently starts describing a subset. A
+    // truncated total reported as a total is the same class of defect as the
+    // rest of this build.
     const raws = await client.mget(keys);
-    for (const raw of raws) {
+    for (let i = 0; i < raws.length; i++) {
+      const raw = raws[i];
       const parsed = parseDomainRecord(raw);
-      if (parsed) records.push(parsed);
+      if (parsed) {
+        records.push(parsed);
+        continue;
+      }
+      const key = keys[i];
+      if (raw && key && isStaleSchema(raw)) staleKeys.push(key);
     }
-    return { records, truncated };
+    return { records, truncated, staleKeys };
   } catch (err) {
     // Still never throws onto the caller — the callers are a reporting tool and
     // a scheduled job, and neither is improved by an exception. What changed is
@@ -256,6 +311,10 @@ export async function enumerateDomains(
     return {
       records,
       truncated,
+      // Whatever was collected before the failure is not a complete set, and
+      // the caller is told not to act on it — but do not hand back a partial
+      // delete list either.
+      staleKeys: [],
       unavailable: describeTransportFailure(err, "domain database"),
     };
   }

--- a/src/domain-stats.ts
+++ b/src/domain-stats.ts
@@ -19,6 +19,7 @@ import {
   type TierStat,
   TIER_STATS_WINDOW_MS as WINDOW_MS,
 } from "./domain-db.js";
+import { describeTransportFailure } from "./transport-failure.js";
 
 const DOMAIN_KEY_PATTERN = "domain:*";
 // SCAN batch hint — how many keys Valkey returns per cursor step. Not a hard
@@ -73,6 +74,17 @@ export interface EnumerateOptions {
 export interface EnumerateResult {
   records: DomainRecord[];
   truncated: boolean;
+  /**
+   * Set when the corpus could not be read. `records` is then not a corpus —
+   * it is whatever had been collected before the failure, and callers must not
+   * treat it as the database's contents.
+   *
+   * This field exists because its absence caused real damage (vikunja#688).
+   * A failed scan returned `{records: [], truncated: false}`, byte-identical
+   * to a healthy scan over an empty database, and `domain-db-maintenance`
+   * wrote that as a snapshot — making an empty file the newest restore point.
+   */
+  unavailable?: string;
 }
 
 export interface TierAggregate {
@@ -183,6 +195,13 @@ function emptyTierAggregate(): TierAggregate {
  * Enumerate current-schema domain records via a bounded, cursor-based SCAN.
  * Stops once `maxKeys` keys have been collected and flags `truncated`. Stale or
  * malformed records are silently dropped (parseDomainRecord gate).
+ *
+ * A failure to read the corpus sets `unavailable` rather than returning an
+ * empty one. The two were previously the same value, which is how a Valkey
+ * outage could present as "domains tracked: 0" — and, worse, get written out
+ * as an empty snapshot (vikunja#688). Research hit the reporting half of this
+ * while measuring for the very plan that fixes it: a `0` that was an auth
+ * failure, not an empty database.
  */
 export async function enumerateDomains(
   opts: EnumerateOptions = {},
@@ -192,7 +211,14 @@ export async function enumerateDomains(
   let truncated = false;
   try {
     const client = await getValkey();
-    if (!client) return { records, truncated };
+    // Not configured is not the same as empty either: there is no corpus to
+    // report on, so callers must not record a zero against it.
+    if (!client)
+      return {
+        records,
+        truncated,
+        unavailable: "domain database not configured (no cache backend)",
+      };
 
     const keys: string[] = [];
     let cursor = "0";
@@ -223,9 +249,15 @@ export async function enumerateDomains(
       if (parsed) records.push(parsed);
     }
     return { records, truncated };
-  } catch {
-    // Best-effort — never throw onto the caller. Return whatever was collected.
-    return { records, truncated };
+  } catch (err) {
+    // Still never throws onto the caller — the callers are a reporting tool and
+    // a scheduled job, and neither is improved by an exception. What changed is
+    // that the result now says it is not a corpus.
+    return {
+      records,
+      truncated,
+      unavailable: describeTransportFailure(err, "domain database"),
+    };
   }
 }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -61,7 +61,9 @@ export async function shutdownEvents(): Promise<void> {
   try {
     await nc.drain();
   } catch {
-    // best-effort
+    // Reviewed (vikunja#687 class sweep): shutdown path. Throwing here would
+    // fail the process teardown over an event bus we are already abandoning,
+    // and there is no caller left to inform.
   }
   nc = null;
 }

--- a/src/extractors/post-extract.ts
+++ b/src/extractors/post-extract.ts
@@ -38,6 +38,8 @@ export function postExtract(input: PostExtractInput): PostExtractResult {
 
   let dom: JSDOM;
   try {
+    // Reviewed (vikunja#687 class sweep): local parse; the baseline fallback
+    // below is a real, documented degradation rather than a swallowed failure.
     dom = new JSDOM(html, { url });
   } catch {
     return {

--- a/src/extractors/readability.ts
+++ b/src/extractors/readability.ts
@@ -20,6 +20,8 @@ export function runReadability(
       text: article.textContent,
     };
   } catch {
+    // Reviewed (vikunja#687 class sweep): pure local parse over HTML already
+    // in hand. Null means "could not extract an article", which is true.
     return null;
   }
 }

--- a/src/kiwix.ts
+++ b/src/kiwix.ts
@@ -1,6 +1,7 @@
 import { KIWIX_URL } from "./config.js";
 import { runReadability } from "./extractors/readability.js";
 import type { TierResult } from "./fetch-utils.js";
+import { warnDependencyFailure } from "./transport-failure.js";
 
 // Hostnames served by Kiwix, mapped to stable ZIM book names.
 // Book names are stable because kiwix-serve runs with --nodatealiases (-z),
@@ -60,7 +61,10 @@ export async function kiwixFetch(
       text: readable.text.slice(0, maxChars),
       html,
     };
-  } catch {
+  } catch (err) {
+    // A dead Kiwix backend looked exactly like "this article is not in the
+    // offline corpus" — the tier's ordinary and expected miss.
+    warnDependencyFailure(err, "kiwix");
     return null;
   }
 }

--- a/src/llms-txt.ts
+++ b/src/llms-txt.ts
@@ -3,6 +3,7 @@ import { FETCH_CACHE_TTL_SECONDS } from "./config.js";
 import { recordLlmsFullProbe } from "./domain-db.js";
 import { getLlmsTxtAllowlist } from "./domains.js";
 import { readBoundedText, safeFetch, USER_AGENT } from "./fetch-utils.js";
+import { warnDependencyFailure } from "./transport-failure.js";
 
 const PROBE_PRESENT_TTL_SECONDS = 24 * 60 * 60;
 const PROBE_ABSENT_TTL_SECONDS = 7 * 24 * 60 * 60;
@@ -119,7 +120,14 @@ async function fetchLlmsFullTxt(origin: string): Promise<CachedLlmsFull> {
       return { status: "absent", fetched: new Date().toISOString() };
     }
     return { status: "present", body, fetched: new Date().toISOString() };
-  } catch {
+  } catch (err) {
+    // "absent" is a claim about the SITE — that it publishes no llms-full.txt —
+    // and it is cached and recorded against the domain. A transport failure
+    // supports no such claim. The status stays `absent` so the cascade behaves
+    // identically (the alternative is failing a fetch over an optional
+    // enrichment), but the failure is now visible rather than laundered into a
+    // fact about someone else's site.
+    warnDependencyFailure(err, "llms-full.txt");
     return { status: "absent", fetched: new Date().toISOString() };
   }
 }
@@ -248,7 +256,9 @@ function extractByUrlLine(
         text: segment.replace(/^---+\r?\n*/, "").trim(),
       };
     } catch {
-      // skip malformed URLs
+      // Reviewed (vikunja#687 class sweep): local parse over content already
+      // fetched; a malformed URL inside the document is a fact about the
+      // document.
     }
   }
   return null;
@@ -316,6 +326,8 @@ export async function tryLlmsTxtFetch(
   try {
     origin = new URL(url).origin;
   } catch {
+    // Reviewed (vikunja#687 class sweep): unparseable input URL, decided
+    // locally. No dependency was consulted.
     return null;
   }
   const cached = await getLlmsFullTxt(origin);

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -98,7 +98,8 @@ export async function shutdownObservability(): Promise<void> {
   try {
     await sdk.shutdown();
   } catch {
-    // best-effort
+    // Reviewed (vikunja#687 class sweep): shutdown path, same reasoning as
+    // shutdownEvents — no caller remains to receive the error.
   }
 }
 

--- a/src/reddit.ts
+++ b/src/reddit.ts
@@ -6,6 +6,7 @@ import {
   USER_AGENT,
 } from "./fetch-utils.js";
 import { checkRobots } from "./robots.js";
+import { warnDependencyFailure } from "./transport-failure.js";
 
 const REDDIT_HOSTS = new Set([
   "reddit.com",
@@ -33,6 +34,7 @@ function toJsonUrl(url: string): string | null {
     parsed.pathname = `${parsed.pathname.replace(/\/+$/, "")}.json`;
     return parsed.toString();
   } catch {
+    // Reviewed (vikunja#687 class sweep): local URL rewrite of a bad input.
     return null;
   }
 }
@@ -124,7 +126,11 @@ export async function redditFetch(
     if (!parsed) return null;
 
     return { title: parsed.title, url, text: parsed.text.slice(0, maxChars) };
-  } catch {
+  } catch (err) {
+    // Falling through to the standard cascade stays correct — Reddit
+    // rate-limits datacenter IPs aggressively and that is handled above. This
+    // catch also swallows DNS and connection failures, which are not that.
+    warnDependencyFailure(err, "reddit fastpath");
     return null;
   }
 }

--- a/src/robots.ts
+++ b/src/robots.ts
@@ -2,6 +2,7 @@ import robotsParserModule from "robots-parser";
 import { cacheGet, cacheSet } from "./cache.js";
 import { recordRobotsProbe } from "./domain-db.js";
 import { safeFetch } from "./fetch-utils.js";
+import { describeTransportFailure } from "./transport-failure.js";
 
 interface RobotsParserResult {
   isAllowed(url: string, userAgent?: string): boolean | undefined;
@@ -14,17 +15,38 @@ const robotsParser = robotsParserModule as unknown as (
 ) => RobotsParserResult;
 
 const ROBOTS_TTL_SECONDS = 24 * 60 * 60;
+// A failure to reach robots.txt is not an answer, so it must not be cached for
+// a day like one. It is still cached briefly: a persistently dead host would
+// otherwise cost a fresh 5s timeout on every single request through it.
+const ROBOTS_ERROR_TTL_SECONDS = 300;
 const ROBOTS_FETCH_TIMEOUT_MS = 5_000;
 const ROBOTS_MAX_BYTES = 512 * 1024;
 
 export interface RobotsCheckResult {
   allowed: boolean;
-  reason?: "disallowed" | "fetch_failed" | "no_robots_txt";
+  reason?:
+    | "disallowed"
+    | "parse_failed"
+    | "no_robots_txt"
+    | "robots_unreachable";
 }
 
 interface CachedRobots {
   body: string | null;
   fetched: string;
+  /**
+   * Set when robots.txt could not be read. `body: null` alone meant four
+   * different things — a 404 (the site really has no robots.txt), a 5xx, a
+   * missing response body, and a transport failure — and all four became
+   * "no robots.txt, therefore allowed", cached for 24 hours, and recorded into
+   * the domain database as a capability fact.
+   *
+   * So a five-second timeout or a DNS blip wrote "this site permits us to
+   * crawl anything" and stood by it for a day. The permissive default is
+   * deliberate and unchanged; what changes is that it is now visible as a
+   * failure rather than indistinguishable from consent.
+   */
+  error?: string;
 }
 
 function robotsCacheKey(origin: string): string {
@@ -41,15 +63,27 @@ async function fetchRobotsTxt(origin: string): Promise<CachedRobots> {
       redirect: "follow",
       signal: AbortSignal.timeout(ROBOTS_FETCH_TIMEOUT_MS),
     });
+    // The one case that is a real answer: the site is telling us there is no
+    // robots.txt, so there are no rules and everything is permitted.
     if (res.status === 404) {
       return { body: null, fetched: new Date().toISOString() };
     }
+    // Anything else is the server declining to tell us. A 503 or a 429 is not
+    // permission.
     if (!res.ok) {
-      return { body: null, fetched: new Date().toISOString() };
+      return {
+        body: null,
+        fetched: new Date().toISOString(),
+        error: `HTTP ${res.status}`,
+      };
     }
     const reader = res.body?.getReader();
     if (!reader) {
-      return { body: null, fetched: new Date().toISOString() };
+      return {
+        body: null,
+        fetched: new Date().toISOString(),
+        error: "response carried no body",
+      };
     }
     const chunks: Uint8Array[] = [];
     let total = 0;
@@ -63,8 +97,12 @@ async function fetchRobotsTxt(origin: string): Promise<CachedRobots> {
       .toString("utf-8")
       .slice(0, ROBOTS_MAX_BYTES);
     return { body, fetched: new Date().toISOString() };
-  } catch {
-    return { body: null, fetched: new Date().toISOString() };
+  } catch (err) {
+    return {
+      body: null,
+      fetched: new Date().toISOString(),
+      error: describeTransportFailure(err, "robots.txt"),
+    };
   }
 }
 
@@ -81,7 +119,14 @@ export async function getRobotsForOrigin(
     }
   }
   const fresh = await fetchRobotsTxt(origin);
-  await cacheSet(key, JSON.stringify(fresh), ROBOTS_TTL_SECONDS);
+  // A non-answer gets a short TTL, not a day's. Caching a transport failure
+  // for 24h is what turned one bad five-second window into a day of asserting
+  // that a site had no crawl rules.
+  await cacheSet(
+    key,
+    JSON.stringify(fresh),
+    fresh.error ? ROBOTS_ERROR_TTL_SECONDS : ROBOTS_TTL_SECONDS,
+  );
   return fresh;
 }
 
@@ -93,10 +138,25 @@ export async function checkRobots(
   try {
     parsedUrl = new URL(url);
   } catch {
+    // Reviewed (vikunja#687 class sweep): a URL we cannot parse is one we will
+    // never fetch, so there is nothing to be permitted or refused.
     return { allowed: true };
   }
   const origin = parsedUrl.origin;
   const robots = await getRobotsForOrigin(origin);
+
+  // We could not read robots.txt. Still permissive — failing closed here would
+  // stop crawling on every transient blip, and that posture is deliberate — but
+  // say which of the two happened, and DO NOT record a capability. Writing
+  // "this origin has no robots.txt" into the domain database off the back of a
+  // timeout is recording a fabricated fact about a third party's site.
+  if (robots.error) {
+    console.error(
+      `[searxng-mcp] robots.txt unreadable for ${origin}: ${robots.error} — proceeding as allowed, which is NOT the same as the site permitting it`,
+    );
+    return { allowed: true, reason: "robots_unreachable" };
+  }
+
   if (!robots.body) {
     recordRobotsProbe(origin, false, true).catch(() => {});
     return { allowed: true, reason: "no_robots_txt" };
@@ -111,6 +171,8 @@ export async function checkRobots(
     recordRobotsProbe(origin, true, true).catch(() => {});
     return { allowed: true };
   } catch {
-    return { allowed: true, reason: "fetch_failed" };
+    // robots-parser threw on a body we DID successfully fetch. Was labelled
+    // "fetch_failed", which sent anyone investigating to the network layer.
+    return { allowed: true, reason: "parse_failed" };
   }
 }

--- a/src/tiers/crawl4ai.ts
+++ b/src/tiers/crawl4ai.ts
@@ -8,6 +8,7 @@ import {
   readBoundedText,
   type TierResult,
 } from "../fetch-utils.js";
+import { describeTransportFailure } from "../transport-failure.js";
 
 /**
  * The crawl4ai version this tier is written against.
@@ -171,34 +172,6 @@ export function crawl4aiErrorReason(label: string, body: string): string {
   // corr goes before the prose for the same reason netErr does: it has to
   // survive a downstream truncation, and it is the actionable half.
   return [label, netErr, corr, prose].filter(Boolean).join(" ");
-}
-
-/**
- * Name a transport failure well enough to act on.
- *
- * Node's fetch reports every one of these as the bare string "fetch failed"
- * and hides the useful part on `cause.code`. The distinction is the whole
- * point of the Phase 7 negative control: a crawl4ai 0.9.x server started
- * without CRAWL4AI_API_TOKEN binds the container's loopback and answers with
- * ECONNRESET while its healthcheck stays green, and "fetch failed" would leave
- * an investigator no way to tell that from a DNS typo.
- */
-function describeTransportFailure(err: unknown): string {
-  const base = err instanceof Error ? err.message : String(err);
-  const cause = (err as { cause?: { code?: unknown; message?: unknown } })
-    ?.cause;
-  // `code` is present for the network failures (ECONNRESET, ECONNREFUSED,
-  // ENOTFOUND, …). Some causes carry only a message — Node rejects a request
-  // to a blocked port that way — so fall back to it rather than to nothing.
-  const detail =
-    typeof cause?.code === "string"
-      ? cause.code
-      : typeof cause?.message === "string"
-        ? cause.message
-        : undefined;
-  return detail
-    ? `Crawl4AI unreachable: ${detail} (${base})`
-    : `Crawl4AI: ${base}`;
 }
 
 /**
@@ -457,7 +430,7 @@ export async function crawl4aiFetch(
     if (err instanceof Error && err.name === "AbortError") {
       throw new Crawl4aiError("Crawl4AI timeout after 45s");
     }
-    const described = describeTransportFailure(err);
+    const described = describeTransportFailure(err, "Crawl4AI");
     // A connection reset with no token configured is the other face of the
     // same misconfiguration as a 401 — the server bound container-loopback.
     if (/ECONNRESET|ECONNREFUSED/.test(described)) {

--- a/src/tiers/crawl4ai.ts
+++ b/src/tiers/crawl4ai.ts
@@ -415,7 +415,24 @@ export async function crawl4aiFetch(
       );
     }
 
-    return null;
+    // An empty `results` array IS an answer: the backend ran the crawl and
+    // found nothing. That is a real empty result and must stay `null`, or this
+    // tier starts erroring on pages that are genuinely blank.
+    //
+    // Note the branch above tests `.length > 0`, so it does NOT cover this —
+    // an early version of this guard threw here and converted every genuine
+    // empty crawl into a tier error. The test named "still treats an empty
+    // results array as a genuine empty answer" is what caught it.
+    if (Array.isArray(data.results)) return null;
+
+    // Neither `results` in any form nor a `task_id`: the backend is speaking a
+    // protocol we do not recognise — a version skew, or something else
+    // answering in its place (a proxy error page, an auth portal). Not an
+    // empty page. `null` here would be booked by runTier as `empty_result`,
+    // the exact conflation #690 existed to remove.
+    throw new Crawl4aiError(
+      "Crawl4AI returned 200 with neither results nor a task_id — unrecognised response shape",
+    );
   } catch (err) {
     // Transport failures reach here: connection refused, connection reset, DNS
     // failure, TLS rejection — and our own 45s abort. None of them mean the

--- a/src/tiers/raw.ts
+++ b/src/tiers/raw.ts
@@ -16,6 +16,7 @@ import {
   USER_AGENT,
 } from "../fetch-utils.js";
 import { firecrawlSupportsPdf } from "../firecrawl-api.js";
+import { warnDependencyFailure } from "../transport-failure.js";
 
 // Create a ProxyAgent once at module init when ADBLOCK_PROXY_URL is configured.
 // Passed as `dispatcher` to undici-backed fetch calls (Node.js 18+ global fetch).
@@ -171,7 +172,15 @@ export async function fetchRawHtmlForMetadata(
     });
     if (!res.ok) return null;
     return await readBoundedText(res);
-  } catch {
+  } catch (err) {
+    // This is a side-channel enrichment fetch running in parallel with the
+    // tier cascade, and a probe must not turn a fetchable URL into a hard
+    // failure — so null stays the return value. What was wrong was doing it
+    // silently: a metadata fetch failing for every URL (a DNS or egress
+    // problem) looked exactly like every page happening to lack JSON-LD, and
+    // `capabilities.metadata_fetch` was populated on 0 of 572 live records
+    // with no indication of why (vikunja#687's class).
+    warnDependencyFailure(err, "raw metadata fetch");
     return null;
   }
 }

--- a/src/tiers/solver.ts
+++ b/src/tiers/solver.ts
@@ -26,6 +26,7 @@ import {
   type TierResult,
 } from "../fetch-utils.js";
 import { assertResolvedPublic } from "../ssrf-guard.js";
+import { warnDependencyFailure } from "../transport-failure.js";
 import { type RawFetchHeaders, rawFetch } from "./raw.js";
 
 interface SolverCookie {
@@ -140,10 +141,21 @@ export async function solverFetch(
       // its deadline still gets to answer, but never hang unbounded.
       signal: AbortSignal.timeout(SOLVER_MAX_TIMEOUT_MS + 10_000),
     });
-  } catch {
+  } catch (err) {
+    // A solver that is down, misaddressed or past its deadline produced the
+    // same `null` as a solver that ran and could not solve the challenge. The
+    // first is an outage of the whole tier; the second is the common case it
+    // exists to handle. Returning null is still right — the cascade must carry
+    // on — but the two have to be tellable apart in a log (vikunja#687).
+    warnDependencyFailure(err, "solver");
     return null;
   }
-  if (!res.ok) return null;
+  if (!res.ok) {
+    console.error(
+      `[searxng-mcp] solver returned HTTP ${res.status} — the tier is not solving, which is not the same as failing to solve`,
+    );
+    return null;
+  }
 
   let solution: SolverSolution;
   try {
@@ -155,7 +167,12 @@ export async function solverFetch(
     const data = JSON.parse(body) as { solution?: SolverSolution };
     if (!data.solution || typeof data.solution !== "object") return null;
     solution = data.solution;
-  } catch {
+  } catch (err) {
+    // An unreadable or unparseable body is the solver answering in a shape we
+    // do not speak — a backend fault, not a failed solve.
+    console.error(
+      `[searxng-mcp] solver response unusable: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return null;
   }
 
@@ -190,6 +207,9 @@ export async function solverFetch(
   try {
     solvedHost = new URL(solvedUrl).hostname;
   } catch {
+    // Reviewed (vikunja#687 class sweep): the solver handed back a URL that
+    // will not parse. Refusing it is the safe answer and the SSRF guard above
+    // already logged the interesting version of this case.
     return null;
   }
 
@@ -213,6 +233,11 @@ export async function solverFetch(
     return await rawFetch(solvedUrl, maxChars, tuning, headers);
   } catch (err) {
     if (err instanceof ChallengeDetectedError) throw err;
+    // The solve succeeded and the REPLAY failed. Null is still right — the
+    // cascade continues — but a transport failure here was indistinguishable
+    // from the solver having produced nothing useful, which sends an
+    // investigator to the solver rather than to the network.
+    warnDependencyFailure(err, "solver replay fetch");
     return null;
   }
 }

--- a/src/tiers/wayback.ts
+++ b/src/tiers/wayback.ts
@@ -1,4 +1,5 @@
 import { readBoundedText, safeFetch, type TierResult } from "../fetch-utils.js";
+import { warnDependencyFailure } from "../transport-failure.js";
 import { rawFetch } from "./raw.js";
 
 const CDX_URL = "https://archive.org/wayback/available";
@@ -44,7 +45,10 @@ export async function waybackFetch(
       title: `[Archived] ${result.title}`,
       text: provenance + result.text,
     };
-  } catch {
+  } catch (err) {
+    // web.archive.org being unreachable or rate-limiting is not the same as a
+    // URL having no archived snapshot, which is this tier's normal miss.
+    warnDependencyFailure(err, "wayback");
     return null;
   }
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -702,6 +702,12 @@ export const DomainStatsOutputSchema = z.object({
   found: z.boolean(),
   record: SingleDomainOutputSchema.nullable(),
   aggregate: AggregateOutputSchema.nullable(),
+  // Set when the corpus could not be read. Declared here deliberately: the SDK
+  // validates structuredContent against this schema before it leaves the
+  // server, so an undeclared field is one the caller never receives however
+  // faithfully the handler sets it — and this is precisely the field a caller
+  // needs to not read `domains_tracked: 0` as a measurement (vikunja#688).
+  unavailable: z.string().nullable().optional(),
 });
 
 export async function handleDomainStats({ hostname }: { hostname?: string }) {
@@ -738,7 +744,35 @@ export async function handleDomainStats({ hostname }: { hostname?: string }) {
     }
 
     // Aggregate mode — operator-triggered, bounded off-hot-path scan.
-    const { records, truncated } = await enumerateDomains();
+    const { records, truncated, unavailable } = await enumerateDomains();
+
+    // "Could not read the database" and "the database is empty" produced the
+    // same answer here, and the second is the one a reader believes. Research
+    // hit exactly this while measuring for the plan that fixes it: a `0` that
+    // was an auth failure. Say so instead of reporting a count (vikunja#688).
+    if (unavailable) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text:
+              `Could not read the domain database: ${unavailable}\n\n` +
+              "This is not a report that the database is empty — no count was " +
+              "obtained. Check the cache backend is reachable and that " +
+              "VALKEY_URL's credentials are correct.",
+          },
+        ],
+        structuredContent: {
+          mode: "aggregate" as const,
+          hostname: null,
+          found: false,
+          record: null,
+          aggregate: null,
+          unavailable,
+        },
+      };
+    }
+
     const aggregate = aggregateDomainStats(records, truncated);
     return {
       content: [

--- a/src/transport-failure.ts
+++ b/src/transport-failure.ts
@@ -1,0 +1,98 @@
+/**
+ * Telling a transport failure apart from a data answer.
+ *
+ * This module exists because the same defect keeps shipping: a backend that is
+ * unreachable, unauthenticated or misconfigured produces the *same* value as a
+ * backend that answered correctly and had nothing to say. `null` for "the page
+ * was empty" and `null` for "the connection was refused" are indistinguishable
+ * to every caller, so a total outage reads as a quiet day.
+ *
+ * Recorded instances, all in this repo, three of them shipped in one week:
+ *   #690  runTier booked tier-2 null as empty_result
+ *   #691  crawl4ai 0.9.x reports healthy and refuses every connection
+ *   #695  capabilities said reranker=on through a 4.5h reranker outage
+ *   #688  enumerateDomains returned an empty corpus for an unreachable Valkey
+ *   #687  raw.ts / solver.ts bare `catch { return null }`
+ *
+ * The rule this encodes: **a catch block may return a benign value only when
+ * the exception genuinely means the data is absent.** If the exception means
+ * "we could not find out", that has to reach the operator.
+ */
+
+/**
+ * Name a transport failure well enough to act on.
+ *
+ * Node's fetch reports every one of these as the bare string "fetch failed"
+ * and hides the useful part on `cause.code`. The distinction is not cosmetic:
+ * a crawl4ai 0.9.x server started without CRAWL4AI_API_TOKEN binds the
+ * container's loopback and answers published ports with ECONNRESET *while its
+ * healthcheck stays green*, and "fetch failed" would leave an investigator no
+ * way to tell that from a DNS typo.
+ *
+ * @param err   the caught value
+ * @param label the backend's name, used as the message prefix so a log line
+ *              says which dependency failed without the reader needing the
+ *              stack
+ */
+export function describeTransportFailure(err: unknown, label: string): string {
+  const base = err instanceof Error ? err.message : String(err);
+  const detail = transportErrorCode(err);
+  return detail
+    ? `${label} unreachable: ${detail} (${base})`
+    : `${label}: ${base}`;
+}
+
+/**
+ * The `cause.code` behind a Node fetch rejection, if there is one.
+ *
+ * `code` is present for the network failures (ECONNRESET, ECONNREFUSED,
+ * ENOTFOUND, EAI_AGAIN, …). Some causes carry only a message — Node rejects a
+ * request to a blocked port that way — so fall back to it rather than to
+ * nothing.
+ */
+export function transportErrorCode(err: unknown): string | undefined {
+  const cause = (err as { cause?: { code?: unknown; message?: unknown } })
+    ?.cause;
+  if (typeof cause?.code === "string") return cause.code;
+  if (typeof cause?.message === "string") return cause.message;
+  return undefined;
+}
+
+/**
+ * Does this exception mean "we could not reach the dependency", as opposed to
+ * "the dependency answered and the answer was unusable"?
+ *
+ * Deliberately conservative: an AbortError (our own timeout) counts, because a
+ * dependency that did not answer inside its budget has not told us anything
+ * about the data. A JSON.parse failure does not — that is a reply we could not
+ * use, which is a different report to make.
+ */
+export function isTransportFailure(err: unknown): boolean {
+  if (err instanceof Error && err.name === "AbortError") return true;
+  if (err instanceof Error && err.name === "TimeoutError") return true;
+  if (transportErrorCode(err) !== undefined) return true;
+  // Node's undici surfaces the generic case with this exact message and puts
+  // everything useful on `cause` — which the check above already covered. A
+  // bare "fetch failed" with no cause is still a transport failure.
+  return err instanceof Error && err.message === "fetch failed";
+}
+
+/**
+ * Log a swallowed dependency failure on a path whose return type genuinely
+ * cannot carry the error.
+ *
+ * Some call sites are optional enrichment inside a cascade — a Kiwix miss, a
+ * Wayback miss — where throwing would convert a degraded result into no result
+ * at all. Returning the benign value is correct there; returning it *silently*
+ * is what makes an outage invisible. Use this so the failure is at least on
+ * stderr with the dependency named.
+ *
+ * Do NOT use it as a way to keep a bare catch: if the caller can carry the
+ * error, give it the error.
+ */
+export function warnDependencyFailure(err: unknown, label: string): void {
+  if (!isTransportFailure(err)) return;
+  console.error(
+    `[searxng-mcp] ${describeTransportFailure(err, label)} — returning no result for this source; it is unavailable, not empty`,
+  );
+}

--- a/src/youtube.ts
+++ b/src/youtube.ts
@@ -6,6 +6,7 @@ import {
   USER_AGENT,
 } from "./fetch-utils.js";
 import { checkRobots } from "./robots.js";
+import { warnDependencyFailure } from "./transport-failure.js";
 
 const YOUTUBE_HOSTS = new Set([
   "youtube.com",
@@ -32,6 +33,7 @@ export function extractVideoId(url: string): string | null {
   try {
     parsed = new URL(url);
   } catch {
+    // Reviewed (vikunja#687 class sweep): local parse of caller input.
     return null;
   }
   if (parsed.hostname === "youtu.be") {
@@ -187,7 +189,10 @@ export async function youtubeFetch(
       url,
       text: `Transcript:\n\n${transcript}`.slice(0, maxChars),
     };
-  } catch {
+  } catch (err) {
+    // Being unable to reach YouTube is not the same as a video having no
+    // transcript, which is the common and expected case here.
+    warnDependencyFailure(err, "youtube transcript");
     return null;
   }
 }

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -32,10 +32,10 @@ beforeEach(() => {
 afterEach(clearCapEnv);
 
 describe("capabilityLine", () => {
-  it("reports a bare deployment as tier3 + cache + reranker only", async () => {
+  it("reports a bare deployment as tier3 on, the rest unverified or off", async () => {
     const { capabilityLine } = await import("../src/capabilities.js");
     expect(capabilityLine()).toBe(
-      "capabilities on=tier1,tier3,cache,reranker " +
+      "capabilities on=tier3 unverified=tier1,cache,reranker " +
         "off=tier2,llm,kiwix,hister,solver,wayback,otel,nats",
     );
   });
@@ -43,7 +43,7 @@ describe("capabilityLine", () => {
   it("moves tier1 to off when Firecrawl is switched off", async () => {
     process.env.FIRECRAWL_ENABLED = "false";
     const { capabilityLine } = await import("../src/capabilities.js");
-    expect(capabilityLine()).toContain("on=tier3,cache,reranker");
+    expect(capabilityLine()).toContain("on=tier3 unverified=cache,reranker");
     expect(capabilityLine()).toMatch(/off=tier1,tier2,/);
   });
 
@@ -105,6 +105,60 @@ describe("capabilityLine", () => {
       "user:pw",
     ]) {
       expect(line).not.toContain(leak);
+    }
+  });
+
+  // vikunja#695. The line said `reranker` was on for the whole of a 4.5h
+  // reranker outage, because a URL was set the entire time. `Boolean(URL)` is
+  // a statement about configuration and was being rendered as a statement
+  // about health. These two assertions are the ones that would have caught it.
+  it("never reports a configured-but-uncontacted backend as on", async () => {
+    process.env.KIWIX_URL = "http://kiwix:8080";
+    process.env.LLM_BASE_URL = "http://llm:8000/v1";
+    process.env.SOLVER_URL = "http://byparr:8191";
+    process.env.SOLVER_ENABLED = "true";
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://otel:4318";
+    process.env.NATS_URL = "nats://nats:4222";
+    const { capabilityStates } = await import("../src/capabilities.js");
+    const states = capabilityStates();
+    for (const backed of [
+      "tier1",
+      "cache",
+      "reranker",
+      "llm",
+      "kiwix",
+      "solver",
+      "otel",
+      "nats",
+    ]) {
+      expect(states[backed], `${backed} is backed by a remote dependency`).toBe(
+        "unverified",
+      );
+    }
+  });
+
+  it("reports only the capabilities that need no backend as on", async () => {
+    process.env.WAYBACK_ENABLED = "true";
+    const { capabilityStates } = await import("../src/capabilities.js");
+    const states = capabilityStates();
+    const on = Object.keys(states).filter((k) => states[k] === "on");
+    // tier3 is in-process; wayback is a plain feature flag. Anything else
+    // appearing here is claiming health it has not established.
+    expect(on.sort()).toEqual(["tier3", "wayback"]);
+  });
+
+  // The fix has to apply to every capability derived from a URL, not just the
+  // one whose outage prompted it — fixing `reranker` and leaving `cache` is
+  // exactly how this class has survived three releases.
+  it("applies the distinction to every capability, not just reranker", async () => {
+    const { capabilities, capabilityStates } = await import(
+      "../src/capabilities.js"
+    );
+    const configured = capabilities();
+    const states = capabilityStates();
+    expect(Object.keys(states).sort()).toEqual(Object.keys(configured).sort());
+    for (const [name, isConfigured] of Object.entries(configured)) {
+      expect(states[name] === "off").toBe(!isConfigured);
     }
   });
 

--- a/tests/cli/domain-db-maintenance.test.ts
+++ b/tests/cli/domain-db-maintenance.test.ts
@@ -251,3 +251,192 @@ describe("runMaintenance refuses to snapshot a corpus it could not read", () => 
     expect((await loadLatestSnapshot(dir))?.count).toBe(0);
   });
 });
+
+/**
+ * The stale-schema reaper (vikunja#688).
+ *
+ * These records are already unreachable — every read goes through
+ * parseDomainRecord, which gates on schema_version — so deleting them changes
+ * no observable behaviour. The plan's verification is the second test here:
+ * the tracked-domain count must be unchanged, because a change means the
+ * reaper deleted something live.
+ */
+describe("runMaintenance reaps stale-schema keys", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    getValkeyMock.mockReset();
+    dir = await mkdtemp(join(tmpdir(), "dbm-reap-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  // mget is called twice: once during enumeration, once by the reaper's
+  // re-check immediately before deleting. Serving it by key keeps the two
+  // consistent, which is what the non-racing case looks like.
+  function mockCorpus(keys: string[], raws: (string | null)[], del = vi.fn()) {
+    del.mockResolvedValue(1);
+    const byKey = new Map(keys.map((k, i) => [k, raws[i] ?? null]));
+    getValkeyMock.mockResolvedValue({
+      scan: vi.fn().mockResolvedValue(["0", keys]),
+      mget: vi
+        .fn()
+        .mockImplementation(async (...ks: string[]) =>
+          (ks.length === 1 && Array.isArray(ks[0]) ? ks[0] : ks).map(
+            (k: string) => byKey.get(k) ?? null,
+          ),
+        ),
+      del,
+    } as unknown as NonNullable<Awaited<ReturnType<typeof getValkey>>>);
+    return del;
+  }
+
+  it("deletes superseded keys and reports how many", async () => {
+    const staleJson = JSON.stringify({
+      ...JSON.parse(recordJson("old.com")),
+      schema_version: 2,
+    });
+    const del = mockCorpus(
+      ["domain:live.com", "domain:old.com"],
+      [recordJson("live.com"), staleJson],
+    );
+
+    const r = await runMaintenance({ snapshotDir: dir, retention: 14 });
+
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(del).toHaveBeenCalledWith("domain:old.com");
+    expect(r.reaped).toBe(1);
+  });
+
+  it("leaves the tracked-domain count unchanged — the plan's own check", async () => {
+    // "A change in tracked domains means the reaper deleted something live."
+    const staleJson = JSON.stringify({
+      ...JSON.parse(recordJson("old.com")),
+      schema_version: 4,
+    });
+    const keys = ["domain:live.com", "domain:old.com"];
+    const raws = [recordJson("live.com"), staleJson];
+
+    mockCorpus(keys, raws);
+    const before = await runMaintenance({
+      snapshotDir: dir,
+      retention: 14,
+      reap: false,
+    });
+
+    mockCorpus(keys, raws);
+    const after = await runMaintenance({ snapshotDir: dir, retention: 14 });
+
+    expect(before.aggregate.domains_tracked).toBe(1);
+    expect(after.aggregate.domains_tracked).toBe(
+      before.aggregate.domains_tracked,
+    );
+    expect(after.reaped).toBe(1);
+    // And the snapshot still holds the live record, not the reaped one.
+    expect(
+      (await loadLatestSnapshot(dir))?.records.map((x) => x.domain),
+    ).toEqual(["live.com"]);
+  });
+
+  it("never issues a delete when there is nothing superseded", async () => {
+    const del = mockCorpus(["domain:live.com"], [recordJson("live.com")]);
+    const r = await runMaintenance({ snapshotDir: dir, retention: 14 });
+    expect(del).not.toHaveBeenCalled();
+    expect(r.reaped).toBe(0);
+  });
+
+  it("reaps nothing when the corpus could not be read", async () => {
+    const del = vi.fn();
+    getValkeyMock.mockResolvedValue({
+      scan: vi.fn().mockRejectedValue(
+        Object.assign(new Error("fetch failed"), {
+          cause: { code: "ECONNREFUSED" },
+        }),
+      ),
+      mget: vi.fn(),
+      del,
+    } as unknown as NonNullable<Awaited<ReturnType<typeof getValkey>>>);
+
+    const r = await runMaintenance({ snapshotDir: dir, retention: 14 });
+
+    expect(r.skipped).toBeDefined();
+    expect(del).not.toHaveBeenCalled();
+    expect(r.reaped).toBe(0);
+  });
+});
+
+/**
+ * The reap re-checks each key immediately before deleting it.
+ *
+ * This is the race it closes: the key list is built during the scan, and the
+ * delete happens after the snapshot and prune. In between, the fetch path may
+ * rewrite a domain record under the same key at the CURRENT schema. Deleting
+ * it on the strength of the earlier read destroys a live record.
+ *
+ * It is also where "never delete a live record" becomes testable. Before the
+ * re-check, that property was an artefact of statement ordering in
+ * enumerateDomains — a mutation making isStaleSchema return true for every
+ * parseable record passed all 42 tests, because parseDomainRecord
+ * short-circuits first and isStaleSchema is never consulted for the records
+ * that matter.
+ */
+describe("the reaper re-checks before deleting", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    getValkeyMock.mockReset();
+    dir = await mkdtemp(join(tmpdir(), "dbm-recheck-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("does not delete a key rewritten at the current schema after the scan", async () => {
+    const staleJson = JSON.stringify({
+      ...JSON.parse(recordJson("racy.com")),
+      schema_version: 2,
+    });
+    const del = vi.fn().mockResolvedValue(1);
+    let mgetCalls = 0;
+    getValkeyMock.mockResolvedValue({
+      scan: vi.fn().mockResolvedValue(["0", ["domain:racy.com"]]),
+      mget: vi.fn().mockImplementation(async () => {
+        mgetCalls += 1;
+        // First read (enumeration): stale. Second read (reap re-check): the
+        // fetch path has rewritten it at the current schema.
+        return mgetCalls === 1 ? [staleJson] : [recordJson("racy.com")];
+      }),
+      del,
+    } as unknown as NonNullable<Awaited<ReturnType<typeof getValkey>>>);
+
+    const r = await runMaintenance({ snapshotDir: dir, retention: 14 });
+
+    expect(del).not.toHaveBeenCalled();
+    expect(r.reaped).toBe(0);
+  });
+
+  it("does not delete a key that became unreadable after the scan", async () => {
+    const staleJson = JSON.stringify({
+      ...JSON.parse(recordJson("corrupt.com")),
+      schema_version: 4,
+    });
+    const del = vi.fn().mockResolvedValue(1);
+    let mgetCalls = 0;
+    getValkeyMock.mockResolvedValue({
+      scan: vi.fn().mockResolvedValue(["0", ["domain:corrupt.com"]]),
+      mget: vi.fn().mockImplementation(async () => {
+        mgetCalls += 1;
+        return mgetCalls === 1 ? [staleJson] : ["{ not json"];
+      }),
+      del,
+    } as unknown as NonNullable<Awaited<ReturnType<typeof getValkey>>>);
+
+    const r = await runMaintenance({ snapshotDir: dir, retention: 14 });
+
+    expect(del).not.toHaveBeenCalled();
+    expect(r.reaped).toBe(0);
+  });
+});

--- a/tests/cli/domain-db-maintenance.test.ts
+++ b/tests/cli/domain-db-maintenance.test.ts
@@ -163,3 +163,91 @@ describe("runMaintenance", () => {
     expect(loaded?.count).toBe(0);
   });
 });
+
+// vikunja#688. The reporting half of this ticket ("domains tracked: 0") is
+// cosmetic. This half is not: the maintenance job wrote whatever
+// enumerateDomains returned, and a failed scan returned an empty array. That
+// made an empty file the NEWEST snapshot — the one loadLatestSnapshot returns
+// and restore-domain-db restores from — while pruneSnapshots aged out a real
+// one. At the default retention of 14, fourteen consecutive failed runs leave
+// nothing but empty snapshots, each indistinguishable from a genuine backup of
+// an empty database.
+//
+// The assertion that matters is the third one: a pre-existing good snapshot is
+// still the newest after a failed run.
+describe("runMaintenance refuses to snapshot a corpus it could not read", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    getValkeyMock.mockReset();
+    dir = await mkdtemp(join(tmpdir(), "dbm-unavailable-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function runWithScan(scan: ReturnType<typeof vi.fn>) {
+    getValkeyMock.mockResolvedValue({
+      scan,
+      mget: vi.fn(),
+    } as unknown as NonNullable<Awaited<ReturnType<typeof getValkey>>>);
+    return runMaintenance({ snapshotDir: dir, retention: 14 });
+  }
+
+  it("writes nothing and reports why when the scan fails", async () => {
+    const err = Object.assign(new Error("fetch failed"), {
+      cause: { code: "ECONNREFUSED" },
+    });
+    const r = await runWithScan(vi.fn().mockRejectedValue(err));
+
+    expect(r.skipped).toBeDefined();
+    expect(r.skipped).toContain("ECONNREFUSED");
+    expect(r.snapshotPath).toBe("");
+    expect(r.pruned).toBe(0);
+    expect(r.gaugesEmitted).toBe(false);
+    expect(await loadLatestSnapshot(dir)).toBeNull();
+  });
+
+  it("does not overwrite the newest good snapshot with an empty one", async () => {
+    // A healthy run first.
+    const good = await runWithScan(
+      vi.fn().mockResolvedValueOnce(["0", ["domain:a.com", "domain:b.com"]]),
+    );
+    getValkeyMock.mockResolvedValue({
+      scan: vi
+        .fn()
+        .mockResolvedValueOnce(["0", ["domain:a.com", "domain:b.com"]]),
+      mget: vi
+        .fn()
+        .mockResolvedValueOnce([recordJson("a.com"), recordJson("b.com")]),
+    } as unknown as NonNullable<Awaited<ReturnType<typeof getValkey>>>);
+    await runMaintenance({ snapshotDir: dir, retention: 14 });
+    const before = await loadLatestSnapshot(dir);
+    expect(before?.records.length).toBeGreaterThan(0);
+    void good;
+
+    // Now Valkey goes away.
+    const err = Object.assign(new Error("fetch failed"), {
+      cause: { code: "ECONNRESET" },
+    });
+    const r = await runWithScan(vi.fn().mockRejectedValue(err));
+    expect(r.skipped).toBeDefined();
+
+    // The restore point must be untouched — this is the whole point.
+    const after = await loadLatestSnapshot(dir);
+    expect(after?.records.map((x) => x.domain)).toEqual(
+      before?.records.map((x) => x.domain),
+    );
+    expect(after?.count).toBe(before?.count);
+  });
+
+  it("still snapshots a genuinely empty corpus", async () => {
+    // The negative control: empty is a real state and must still be recorded,
+    // or this fix would just be a different way of losing data.
+    const r = await runWithScan(vi.fn().mockResolvedValueOnce(["0", []]));
+    expect(r.skipped).toBeUndefined();
+    expect(r.snapshotPath).not.toBe("");
+    expect((await loadLatestSnapshot(dir))?.count).toBe(0);
+  });
+});

--- a/tests/domain-snapshot.test.ts
+++ b/tests/domain-snapshot.test.ts
@@ -1,8 +1,12 @@
 import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { DomainRecord } from "../src/domain-db.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type DomainRecord,
+  SCHEMA_VERSION,
+  TIER_SLOT_KEYS,
+} from "../src/domain-db.js";
 import {
   applyRestore,
   listSnapshots,
@@ -281,5 +285,85 @@ describe("applyRestore", () => {
       mkRecord("b.com", "2026-06-01T00:00:00Z"),
     ]);
     expect(result).toEqual({ total: 2, restored: 0, skipped: 2 });
+  });
+});
+
+/**
+ * `applyRestore` counted a transport failure as a per-record skip.
+ *
+ * The loop is deliberately best-effort — a single malformed or unwritable
+ * record should not abort a restore. But a dead connection is not one bad
+ * record: every record after it fails too, so a Valkey that died after record
+ * four counted the remaining 1,287 as "skipped" and restore-domain-db printed
+ * "restored 4, skipped 1287 of 1291" and exited 0.
+ *
+ * An operator reads that as a finished restore from a mostly-stale snapshot.
+ * It is a failed restore, and this is the path the domain-db is supposed to be
+ * recoverable through.
+ */
+describe("applyRestore abandons rather than reporting a dead datastore as skips", () => {
+  const rec = (domain: string, lastFetch = "2026-06-01T00:00:00Z") =>
+    ({
+      schema_version: SCHEMA_VERSION,
+      domain,
+      first_seen: "2026-05-01T00:00:00Z",
+      last_fetch: lastFetch,
+      capabilities: {},
+      tier_stats_30d: Object.fromEntries(
+        TIER_SLOT_KEYS.map((k) => [
+          k,
+          { attempts: 0, ok: 0, fail: 0, window_start_ms: Date.now() },
+        ]),
+      ),
+    }) as unknown as DomainRecord;
+
+  it("stops and reports when the connection dies mid-restore", async () => {
+    let calls = 0;
+    const client = {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockImplementation(async () => {
+        calls += 1;
+        if (calls > 2) {
+          throw Object.assign(new Error("fetch failed"), {
+            cause: { code: "ECONNRESET" },
+          });
+        }
+        return "OK";
+      }),
+    };
+    const records = Array.from({ length: 10 }, (_, i) => rec(`d${i}.com`));
+
+    const r = await applyRestore(client, records);
+
+    expect(r.failed).toBeDefined();
+    expect(r.failed).toContain("ECONNRESET");
+    expect(r.restored).toBe(2);
+    // The remaining records were NOT attempted, so they must not be counted as
+    // skipped — that is the miscount the whole fix is about.
+    expect(r.skipped).toBe(0);
+    expect(r.restored + r.skipped).toBeLessThan(r.total);
+  });
+
+  it("still counts ordinary per-record failures as skips", async () => {
+    // The negative control. If the guard treated every error as fatal, a
+    // single unwritable record would abort an otherwise fine restore — trading
+    // one failure mode for another.
+    let calls = 0;
+    const client = {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockImplementation(async () => {
+        calls += 1;
+        if (calls === 2) throw new Error("WRONGTYPE against a key");
+        return "OK";
+      }),
+    };
+    const records = Array.from({ length: 4 }, (_, i) => rec(`d${i}.com`));
+
+    const r = await applyRestore(client, records);
+
+    expect(r.failed).toBeUndefined();
+    expect(r.restored).toBe(3);
+    expect(r.skipped).toBe(1);
+    expect(r.restored + r.skipped).toBe(r.total);
   });
 });

--- a/tests/domain-stats-output-contract.test.ts
+++ b/tests/domain-stats-output-contract.test.ts
@@ -402,4 +402,40 @@ describe("domain_stats advertised output schema", () => {
     const live = await validateAsClient(result.structuredContent);
     expect(live.valid, JSON.stringify(live.errors ?? live.error)).toBe(true);
   });
+
+  /**
+   * vikunja#688. The unavailable payload has to survive the SAME path the
+   * `solver` slot did not: the advertised JSON Schema emits
+   * `additionalProperties: false`, so a field the handler sets but the zod
+   * schema does not declare is stripped by the client's validator and the
+   * caller sees nothing. A server-side `.parse()` test would pass regardless —
+   * zod's z.object() strips rather than rejects — which is the whole reason
+   * this file validates as a client instead.
+   *
+   * Without `unavailable` declared on DomainStatsOutputSchema, the operator
+   * gets a payload with `aggregate: null` and no stated reason, which reads as
+   * a failure of the tool rather than of the database.
+   */
+  it("advertises `unavailable`, so an unreadable corpus reaches the caller", async () => {
+    const err = Object.assign(new Error("fetch failed"), {
+      cause: { code: "ECONNREFUSED" },
+    });
+    vi.mocked(getValkey).mockResolvedValueOnce({
+      scan: vi.fn().mockRejectedValue(err),
+      mget: vi.fn(),
+    } as unknown as NonNullable<Awaited<ReturnType<typeof getValkey>>>);
+
+    const result = await handleDomainStats({});
+
+    expect(result.structuredContent.unavailable).toContain("ECONNREFUSED");
+    expect(result.structuredContent.aggregate).toBeNull();
+    // And it is not reported as a zero-domain corpus.
+    expect(result.content[0].text).not.toMatch(/domains tracked: 0/);
+    expect(result.content[0].text).toMatch(
+      /not a report that the database is empty/i,
+    );
+
+    const r = await validateAsClient(result.structuredContent);
+    expect(r.valid, JSON.stringify(r.errors ?? r.error)).toBe(true);
+  });
 });

--- a/tests/domain-stats.test.ts
+++ b/tests/domain-stats.test.ts
@@ -423,3 +423,69 @@ describe("enumerateDomains reports unreachability rather than emptiness", () => 
     expect(result.unavailable).toMatch(/not configured/i);
   });
 });
+
+/**
+ * vikunja#688 — collecting the stale-schema keys the reaper deletes.
+ *
+ * Measured on the live corpus 2026-09-06 (the ticket's numbers, which research
+ * could not independently confirm, re-measured through the configured
+ * VALKEY_URL): 1,295 keys, of which 1,196 (92.4%) carry a superseded schema —
+ * 122 at schema 2, 475 at 4, 436 at 5, 163 at 6 — against 99 current.
+ *
+ * The distinction that matters here is stale vs corrupt. A record we
+ * deliberately superseded is safe to delete; a record we cannot read is a
+ * different decision and is left alone.
+ */
+describe("enumerateDomains collects stale-schema keys for reaping", () => {
+  beforeEach(() => {
+    getValkeyMock.mockReset();
+  });
+
+  function withRaws(keys: string[], raws: (string | null)[]) {
+    const scan = vi.fn().mockResolvedValueOnce(["0", keys]);
+    const mget = vi.fn().mockResolvedValueOnce(raws);
+    getValkeyMock.mockResolvedValue(fakeClient({ scan, mget }));
+  }
+
+  it("lists superseded records and keeps current ones out of the list", async () => {
+    const current = mkRecord("current.com");
+    const stale = { ...mkRecord("stale.com"), schema_version: 2 };
+    withRaws(
+      ["domain:current.com", "domain:stale.com"],
+      [JSON.stringify(current), JSON.stringify(stale)],
+    );
+
+    const r = await enumerateDomains();
+
+    expect(r.records.map((x) => x.domain)).toEqual(["current.com"]);
+    expect(r.staleKeys).toEqual(["domain:stale.com"]);
+    // The assertion that matters: a live key must never reach the delete list.
+    expect(r.staleKeys).not.toContain("domain:current.com");
+  });
+
+  it("does not mark an unreadable record as stale", async () => {
+    // Corrupt is not superseded. Deleting data we cannot read is a different
+    // decision from deleting data we replaced, and this reaper does not make
+    // it.
+    withRaws(["domain:corrupt.com"], ["{ this is not json"]);
+
+    const r = await enumerateDomains();
+
+    expect(r.records).toEqual([]);
+    expect(r.staleKeys).toEqual([]);
+  });
+
+  it("returns no delete list when the corpus could not be read", async () => {
+    const scan = vi.fn().mockRejectedValue(
+      Object.assign(new Error("fetch failed"), {
+        cause: { code: "ECONNREFUSED" },
+      }),
+    );
+    getValkeyMock.mockResolvedValue(fakeClient({ scan }));
+
+    const r = await enumerateDomains();
+
+    expect(r.unavailable).toBeDefined();
+    expect(r.staleKeys).toEqual([]);
+  });
+});

--- a/tests/domain-stats.test.ts
+++ b/tests/domain-stats.test.ts
@@ -149,13 +149,18 @@ describe("enumerateDomains", () => {
     expect(truncated).toBe(false);
   });
 
-  it("is best-effort: returns empty on a scan error rather than throwing", async () => {
+  // Retargeted, not removed. The "best-effort" contract still holds — callers
+  // are a reporting tool and a scheduled job, and neither is improved by an
+  // exception. What this used to assert as well, via toEqual on the whole
+  // object, was that a scan error is INDISTINGUISHABLE from an empty corpus.
+  // That was the defect (vikunja#688), pinned as an invariant.
+  it("is best-effort: does not throw on a scan error, but says it failed", async () => {
     const scan = vi.fn().mockRejectedValue(new Error("connection reset"));
     getValkeyMock.mockResolvedValue(fakeClient({ scan }));
-    await expect(enumerateDomains()).resolves.toEqual({
-      records: [],
-      truncated: false,
-    });
+    const result = await enumerateDomains();
+    expect(result.records).toEqual([]);
+    expect(result.truncated).toBe(false);
+    expect(result.unavailable).toContain("connection reset");
   });
 
   it("returns empty (no mget) when the scan yields no keys", async () => {
@@ -364,5 +369,57 @@ describe("formatDomainRecord renders every tier slot", () => {
     TIER_SLOT_KEYS.forEach((slot, i) => {
       expect(block[i].trim().startsWith(slot)).toBe(true);
     });
+  });
+});
+
+// vikunja#688 sub-finding, and the more serious consequence of it.
+//
+// `enumerateDomains` caught every failure and returned `{records: [], truncated}`
+// — the exact shape of a healthy scan over an empty corpus. Two things then
+// read that as fact:
+//
+//   1. `domain_stats` reported "domains tracked: 0"
+//   2. `domain-db-maintenance` wrote a snapshot containing zero records, made
+//      it the NEWEST snapshot, and pruned by retention
+//
+// (2) is the one that does damage. `loadLatestSnapshot` returns the newest, so
+// a single maintenance run during a Valkey outage leaves `restore-domain-db`
+// restoring nothing; fourteen consecutive ones (the default retention) prune
+// every good snapshot away. A transport failure silently destroys the restore
+// path, and the artefact it leaves behind is indistinguishable from a
+// legitimate backup of an empty database.
+describe("enumerateDomains reports unreachability rather than emptiness", () => {
+  beforeEach(() => {
+    getValkeyMock.mockReset();
+  });
+
+  it("flags a scan that failed mid-flight instead of returning an empty corpus", async () => {
+    const err = Object.assign(new Error("fetch failed"), {
+      cause: { code: "ECONNREFUSED" },
+    });
+    const scan = vi.fn().mockRejectedValue(err);
+    getValkeyMock.mockResolvedValue(fakeClient({ scan }));
+
+    const result = await enumerateDomains();
+    expect(result.records).toEqual([]);
+    expect(result.unavailable).toBeDefined();
+    expect(result.unavailable).toContain("ECONNREFUSED");
+  });
+
+  it("distinguishes a genuinely empty corpus from an unreachable one", async () => {
+    const scan = vi.fn().mockResolvedValueOnce(["0", []]);
+    getValkeyMock.mockResolvedValue(fakeClient({ scan }));
+
+    const result = await enumerateDomains();
+    expect(result.records).toEqual([]);
+    expect(result.unavailable).toBeUndefined();
+  });
+
+  it("flags a domain database that is not configured at all", async () => {
+    getValkeyMock.mockResolvedValue(null);
+
+    const result = await enumerateDomains();
+    expect(result.unavailable).toBeDefined();
+    expect(result.unavailable).toMatch(/not configured/i);
   });
 });

--- a/tests/robots.test.ts
+++ b/tests/robots.test.ts
@@ -5,11 +5,17 @@ vi.mock("../src/cache.js", () => ({
   cacheSet: vi.fn(),
 }));
 
+vi.mock("../src/domain-db.js", () => ({
+  recordRobotsProbe: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { cacheGet, cacheSet } from "../src/cache.js";
+import { recordRobotsProbe } from "../src/domain-db.js";
 import { checkRobots } from "../src/robots.js";
 
 const cacheGetMock = vi.mocked(cacheGet);
 const cacheSetMock = vi.mocked(cacheSet);
+const recordRobotsProbeMock = vi.mocked(recordRobotsProbe);
 
 describe("checkRobots", () => {
   beforeEach(() => {
@@ -82,5 +88,97 @@ describe("checkRobots", () => {
     expect(cacheSetMock).toHaveBeenCalled();
     const [, _value, ttl] = cacheSetMock.mock.calls[0];
     expect(ttl).toBe(24 * 60 * 60);
+  });
+});
+
+/**
+ * `fetchRobotsTxt` returned `{body: null}` for four different situations — a
+ * 404, a 5xx, a missing response body, and a transport failure — and
+ * `checkRobots` turned all four into `allowed: true, reason: "no_robots_txt"`.
+ *
+ * Three consequences, in increasing order of seriousness:
+ *   1. an investigator cannot tell a permissive site from an unreachable one
+ *   2. the answer was cached for 24 HOURS, so one bad five-second window
+ *      asserted for a day that a site had no crawl rules
+ *   3. `recordRobotsProbe(origin, false, true)` wrote that into the domain
+ *      database as a fact about a third party's site
+ *
+ * The permissive default is deliberate and unchanged: failing closed would
+ * stop crawling on every transient blip. What changes is that it is no longer
+ * indistinguishable from consent.
+ */
+describe("checkRobots distinguishes unreachable from permissive", () => {
+  beforeEach(() => {
+    cacheGetMock.mockReset();
+    cacheSetMock.mockReset();
+    recordRobotsProbeMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports a transport failure as unreachable, not as an absent robots.txt", async () => {
+    cacheGetMock.mockResolvedValue(null);
+    vi.spyOn(global, "fetch").mockRejectedValue(
+      Object.assign(new Error("fetch failed"), {
+        cause: { code: "ECONNREFUSED" },
+      }),
+    );
+    const result = await checkRobots("https://example.com/page", "searxng-mcp");
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe("robots_unreachable");
+    expect(result.reason).not.toBe("no_robots_txt");
+  });
+
+  it("reports a 5xx as unreachable — a 503 is not permission", async () => {
+    cacheGetMock.mockResolvedValue(null);
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response("", { status: 503 }) as Response,
+    );
+    const result = await checkRobots("https://example.com/page", "searxng-mcp");
+    expect(result.reason).toBe("robots_unreachable");
+  });
+
+  it("does not record a domain-db capability from a failure", async () => {
+    cacheGetMock.mockResolvedValue(null);
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("fetch failed"));
+    await checkRobots("https://example.com/page", "searxng-mcp");
+    expect(recordRobotsProbeMock).not.toHaveBeenCalled();
+  });
+
+  it("still records the capability for a genuine 404", async () => {
+    // The negative control. If the guard above were simply suppressing every
+    // probe, this would fail — and the fix would have replaced one wrong
+    // record with no records at all.
+    cacheGetMock.mockResolvedValue(null);
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response("", { status: 404 }) as Response,
+    );
+    const result = await checkRobots("https://example.com/page", "searxng-mcp");
+    expect(result.reason).toBe("no_robots_txt");
+    expect(recordRobotsProbeMock).toHaveBeenCalledWith(
+      "https://example.com",
+      false,
+      true,
+    );
+  });
+
+  it("caches a failure briefly and a real answer for a day", async () => {
+    cacheGetMock.mockResolvedValue(null);
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("fetch failed"));
+    await checkRobots("https://example.com/page", "searxng-mcp");
+    const failureTtl = cacheSetMock.mock.calls[0]?.[2];
+
+    cacheSetMock.mockClear();
+    cacheGetMock.mockResolvedValue(null);
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response("", { status: 404 }) as Response,
+    );
+    await checkRobots("https://other.example.com/page", "searxng-mcp");
+    const answerTtl = cacheSetMock.mock.calls[0]?.[2];
+
+    expect(answerTtl).toBe(24 * 60 * 60);
+    expect(failureTtl).toBeLessThan(answerTtl as number);
   });
 });

--- a/tests/tiers/crawl4ai.test.ts
+++ b/tests/tiers/crawl4ai.test.ts
@@ -238,3 +238,46 @@ describe("pollCrawl4aiTask", () => {
     vi.useRealTimers();
   });
 });
+
+/**
+ * The fallthrough at the end of crawl4aiFetch's try block.
+ *
+ * v3.25.0 fixed the tier's transport handling for vikunja#690/#687, but this
+ * path survived: a 200 carrying neither `results` nor a `task_id` returned
+ * `null`, and runTier books null as `empty_result` — the exact conflation that
+ * ticket existed to remove, one branch below the code that removed it.
+ *
+ * A backend answering 200 in a shape we do not recognise is a version skew or
+ * something else replying in its place (a proxy error page, an auth portal).
+ * It is not an empty page.
+ */
+describe("crawl4aiFetch on an unrecognised 200", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws rather than reporting the page as empty", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: "ok", detail: "nothing here" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    await expect(crawl4aiFetch(URL)).rejects.toThrow(
+      /unrecognised response shape/i,
+    );
+  });
+
+  it("still treats an empty results array as a genuine empty answer", async () => {
+    // The negative control. `results: []` IS the backend telling us it found
+    // nothing, and must keep returning null — otherwise this fix converts a
+    // real empty result into a tier error.
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    await expect(crawl4aiFetch(URL)).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
Phases 2–5 of `searxng-mcp-observability-hygiene-2026-09`. Phase 1 shipped separately as v3.25.1 (#36). **Phases 6 and 7 will follow in their own PR** — they both edit `docker-compose.full.yml` and the publish workflow, so splitting them apart would only manufacture conflicts.

Three of the four tickets in here turned out to be wrong about their own premises. Each is corrected with evidence rather than worked around.

---

## Phase 2 — the defect class (#695, #688, #687's survivors)

One change with fourteen sites, not fourteen changes. `src/transport-failure.ts` generalises the reference implementation that already existed as a private helper in `crawl4ai.ts`, written for #690. `crawl4ai.ts` is rewired to it with **no behaviour change: 962 tests before, 962 after.**

The plan named 5 sites. A first triage found 26. Looking 8 lines past each `catch` instead of 4 found **38**. All 38 are now decided — fixed, or annotated as reviewed so the next sweep can tell a decision from an oversight.

**`capabilities.ts`** gains a third state. The module header already said it reports configuration and never health, then rendered a configured backend as `on=` — which reads as "working", and which said `reranker` was on through the entire 4.5h outage because a URL was set the whole time. Now:

```
capabilities on=tier3 unverified=tier1,cache,reranker off=tier2,llm,kiwix,...
```

Applied to all ten URL-derived capabilities. Fixing `reranker` and leaving `cache` is how this class survived three releases.

**`enumerateDomains`** sets `unavailable` instead of returning an empty corpus. Research hit the reporting half of this *while measuring for the plan that fixes it* — a `0` that was an auth failure.

**Two findings that were in no ticket:**

| Finding | Consequence |
|---|---|
| `domain-db-maintenance` wrote an **empty snapshot** on a failed scan, made it the newest, then pruned by retention | At the default retention of 14, fourteen consecutive failed runs destroy every restore point. The artefact left behind is indistinguishable from a real backup of an empty database |
| `applyRestore` counted a **dead connection as skipped records** | `restored 4, skipped 1287 of 1291`, exit 0 — a failed restore reported as a finished one, on the path the domain-db is meant to be recoverable through |

**`robots.txt`** was the one with teeth. A 404, a 5xx, a missing body and a transport failure all became `allowed: true, reason: "no_robots_txt"` — cached for **24 hours** and written into the domain database via `recordRobotsProbe` as a fact about a third party's site. One bad five-second window asserted for a day that a site had no crawl rules. The permissive default is deliberate and unchanged (failing closed would stop crawling on every blip), but it now reports `robots_unreachable`, caches a non-answer for 5 minutes, and records no capability.

**#687 is closed, not built.** Its premise died in v3.25.0 — `648b60e` replaced the exact bare `catch { return null }` at `crawl4ai.ts:197` the ticket describes. But research's claim that only the not-configured path survived in that file was wrong: there were three `return null`s, and line 445 was a live instance of the class one branch below the code that fixed #690.

## Phase 3 — reap stale-schema records (#688)

The ticket's numbers were the developer's own and research could not confirm them. Re-measured through the configured `VALKEY_URL`; they hold:

```
total 1295   schema 2: 122   4: 475   5: 436   6: 163   7 (current): 99
stale 1196 (92.4%)
```

Checked the snapshot path first as the plan requires — nothing depends on stale records surviving.

**The reap re-reads every key immediately before deleting it.** That is not padding. The key list is built during the scan and the delete happens after the snapshot and prune, in a process whose fetch path writes domain records throughout; a domain fetched in that window is rewritten at the current schema under the same key, and deleting it on the earlier read destroys live data.

It is also where the safety property became testable. **A mutation making `isStaleSchema` return true for every parseable record — which would delete the entire live corpus — passed all 42 tests**, because `parseDomainRecord` short-circuits above it. The protection was an artefact of statement ordering. Mutating the re-check is now caught.

Dry-run against forge before shipping, twice — once hand-written, once with the **actual built code** in a scratch container, because a reimplementation agreeing with itself proves nothing:

```
live (schema 7, KEPT):      99
stale candidates:         1196
  confirmed at re-check:  1196
live keys also in staleKeys: 0   OK
```

Key count after the dry run: still 1,295. Nothing deleted.

## Phase 4 — provenance was never missing (#689)

The ticket reported `referrers=0` and the plan said to **drop `push-to-registry: true`**. Diagnosed first, as the plan required. Neither hypothesised cause holds.

**GHCR does not implement the OCI referrers API.** `GET /v2/<name>/referrers/<digest>` returns `404 MANIFEST_UNKNOWN` *for a digest that exists and carries an attestation*. GHCR uses the spec's fallback tag scheme, publishing the index under `sha256-<digest>`:

```
artifactType:  application/vnd.dev.sigstore.bundle.v0.3+json
predicateType: https://slsa.dev/provenance/v1
```

Verified across both images and both releases — 3 fallback tags on `searxng-mcp`, 2 on `searxng-mcp-reranker`. So dropping the line would have **deleted a working supply-chain feature to make a false measurement consistent**. No workflow change; docs and a comment explaining why it must not be removed on the strength of a 404. Fleet sweep filed as vikunja#699.

## Phase 5 — compose hardening (#693)

0 → 51 directives on `full.yml`, 0 → 7 on `example.yml`. `read_only` only where running the service proved it works. Four results a diff read would have got wrong:

| service | finding |
|---|---|
| `cache`, `firecrawl-redis` | `cap_drop: [ALL]` **kills them** — both drop privileges via `setpriv`. Need `SETUID`+`SETGID` back |
| `crawl4ai` | No `read_only`. Three configs run, three different failures — see the comment at the service |
| `ollama` | No `read_only`, verified failing with and without a tmpfs |
| `nats` | `read_only` needs a writable `/tmp`; alone it exits 1 |

`kiwix`, `firecrawl-api` and `firecrawl-puppeteer` carry `cap_drop` and limits but no `read_only` — they could not be started here, so that is recorded as unverified rather than assumed safe.

Also fixed by running it: the reference `cache` command line **cannot start on a large host**. Dragonfly sizes io threads to the core count and refuses to boot below 256MiB per thread — `--maxmemory=2gb` exits with "There are 32 threads, so 8.00GiB are required" on a 32-core machine, hardening or not. `--proactor_threads=4` now pinned.

### Three of my own probes were wrong before I caught them

Worth stating, because each nearly went in as fact:

1. **Red baseline.** The first pass concluded "`cap_drop: ALL` breaks dragonfly" from a comparison whose control was already failing — dragonfly couldn't start on this host at all. Every row of that matrix was meaningless.
2. **Wrong image.** `firecrawl-redis` was recorded as verified against `redis:alpine` (redis 8, different entrypoint) while the file declares `redis:7-alpine`. The one tested passed; the one that ships did not.
3. **"Running" isn't "working".** crawl4ai reports `running` for ~30s while gunicorn retries a worker that cannot write, then goes FATAL. A 12-second probe called it verified.

## Verification

- **990 tests** (was 962), tsc clean, lint clean
- Coverage **85.63 / 78.92 / 84.63 / 87.91** against an 84/77/83/86 floor
- Every new guard proven capable of failing: snapshot-destruction pair red without the guard, schema field red when undeclared, robots 4-of-11 red pre-fix, restore guard red when removed
- Every guard has a **negative control that stays green in both directions**, so none can pass by suppressing everything
- Seven services brought up from the shipped compose file, hardening confirmed applied per-container rather than silently dropped; production untouched throughout

## Also filed

- vikunja#698 — `~/docker/reranker/` is still an unpinned `reranker` project (deployment side of #694)
- vikunja#699 — fleet sweep: don't remove `push-to-registry` on the strength of a referrers 404
- vikunja#700 — rotate `searxng-dragonfly` requirepass; it is passed as a container argument, so `docker inspect` exposes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)