### PR TITLE
Port tier-1 adblocking to Firecrawl v2's renderer, publish the last two images (Phases 6–7, v3.26.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,3 +173,27 @@ jobs:
       # <CVE>` rather than raising the threshold or deleting the step.
       - name: Audit dev dependencies
         run: pnpm audit --dev
+
+      # The two docker/ sub-projects are NOT in the pnpm workspace, so neither
+      # step above sees them — and both are built into PUBLISHED images, one of
+      # them an unauthenticated forward proxy. A CVE in @ghostery/adblocker
+      # would have shipped silently (audit LOW, 2026-09-06).
+      #
+      # A THIRD step rather than folding these into the two above, for the same
+      # reason --prod and --dev are separate: "something we publish in a
+      # container is vulnerable" is a different question from "something in the
+      # npm package is", and merging them makes the first invisible.
+      #
+      # `npm ci --package-lock-only` then `npm audit` reads the committed
+      # lockfile without installing. If a lockfile has drifted from its
+      # package.json, `npm ci` fails here — which is the point: the previous
+      # Dockerfiles used `npm install <caret-range>` and re-resolved on every
+      # build, so nothing pinned what actually shipped.
+      - name: Audit container sub-project dependencies
+        run: |
+          set -euo pipefail
+          for d in docker/adblock-proxy docker/playwright-adblock; do
+            echo "::group::$d"
+            ( cd "$d" && npm ci --package-lock-only --no-audit --no-fund && npm audit --omit=dev )
+            echo "::endgroup::"
+          done

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,8 @@ env:
   # Not bare `reranker`: this lands in a shared namespace alongside every other
   # package, and a rename after publication is worse than a long name.
   RERANKER_IMAGE: ghcr.io/tadmstr/searxng-mcp-reranker
+  PROXY_IMAGE: ghcr.io/tadmstr/searxng-mcp-adblock-proxy
+  PLAYWRIGHT_ADBLOCK_IMAGE: ghcr.io/tadmstr/searxng-mcp-playwright-adblock
 
 jobs:
   publish:
@@ -317,12 +319,223 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           echo "pushed digest $DIGEST"
 
-      # vikunja#689 (provenance not attached as an OCI referrer) applies here
-      # exactly as it does to the main image. Not re-derived, and registry-
-      # native verification is not a gate until #689 is resolved.
+      # vikunja#689 was a misdiagnosis and is resolved: provenance IS attached.
+      # GHCR does not serve the OCI referrers API, it uses the spec's fallback
+      # tag (sha256-<digest>). See docs/deployment.md and the note on the main
+      # image's attest step. Do not remove push-to-registry over a 404.
       - name: Attest build provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ${{ env.RERANKER_IMAGE }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  # ── adblock-proxy ───────────────────────────────────────────────────────────
+  # The last stack component without a published image (vikunja#697). Until now
+  # the reference deployment built it from an absolute path into a developer's
+  # working tree, which is not an adoption path.
+  publish-adblock-proxy:
+    name: Build, smoke test, publish adblock-proxy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build adblock-proxy image
+        run: docker build -t "$PROXY_IMAGE:candidate" ./docker/adblock-proxy
+
+      # Asserts the CONTRACT, not the boot. A proxy that starts and forwards
+      # everything unfiltered passes any liveness check while doing none of the
+      # job it exists for — and nothing downstream would notice, because an
+      # unblocked ad is indistinguishable from an ad that was never requested.
+      # Asserts the CONTRACT, not the boot. A proxy that starts and forwards
+      # everything unfiltered passes any liveness check while doing none of the
+      # job it exists for — and nothing downstream notices, because an
+      # unblocked ad is indistinguishable from an ad that was never requested.
+      #
+      # Every assertion below was run against a real build before being written
+      # here, and the first draft was WRONG in a way worth recording: it used a
+      # local nginx origin and http://doubleclick.net/ad.js. Both are refused by
+      # ssrf.js — the container origin resolves to a private address, and this
+      # host's resolver blackholes ad domains to `::` — so BOTH returned zero
+      # bytes and the "is it blocking ads?" assertion passed for every URL,
+      # blocked or not. It proved nothing.
+      #
+      # Hence: a public origin for the forwarding case, a URL EasyList actually
+      # matches for the blocking case, and an assertion on WHICH mechanism the
+      # log reports, because "empty response" alone cannot tell an adblock hit
+      # from an SSRF refusal.
+      - name: Smoke test the adblock-proxy image
+        run: |
+          set -euo pipefail
+
+          docker network create smoke-net >/dev/null
+          docker run -d --name smoke-proxy --network smoke-net \
+            -e LOG_BLOCKED=true "$PROXY_IMAGE:candidate" >/dev/null
+
+          for i in $(seq 1 60); do
+            if docker logs smoke-proxy 2>&1 | grep -q 'listening on'; then break; fi
+            if [ "$i" = 60 ]; then echo "proxy never became ready"; docker logs smoke-proxy; exit 1; fi
+            sleep 1
+          done
+          docker logs smoke-proxy
+
+          via() {
+            docker run --rm --network smoke-net curlimages/curl:latest \
+              -s -o /dev/null -w '%{http_code} %{size_download}' -m 25 \
+              --proxy http://smoke-proxy:8118 "$@"
+          }
+
+          # 1. A normal plain-HTTP URL proxies through, WITH a body. The body
+          #    size is the point: every failure mode below also yields 0 bytes,
+          #    so without a known non-zero case the other assertions are vacuous.
+          read -r code size <<<"$(via http://example.com/)"
+          echo "forwarding: HTTP $code, $size bytes"
+          [ "$code" = "200" ] || { echo "FAIL: proxy did not forward"; exit 1; }
+          [ "$size" -gt 0 ] || { echo "FAIL: forwarded response was empty"; exit 1; }
+
+          # 2. A URL EasyList actually matches gets the documented empty 200.
+          #    NOT doubleclick.net/ad.js — EasyList does not match that bare
+          #    path, and it is DNS-blackholed here anyway.
+          read -r code size <<<"$(via http://www.googletagmanager.com/gtm.js)"
+          echo "adblock: HTTP $code, $size bytes"
+          [ "$code" = "200" ] || { echo "FAIL: blocked URL should be an empty 200, got $code"; exit 1; }
+          [ "$size" = "0" ] || { echo "FAIL: blocked URL returned a body"; exit 1; }
+          docker logs smoke-proxy 2>&1 | grep -q 'blocked http://www.googletagmanager.com/gtm.js' \
+            || { echo "FAIL: no adblock log line — something else produced that empty 200"; exit 1; }
+
+          # 3. HTTPS CONNECT tunnels.
+          read -r code size <<<"$(via https://example.com/)"
+          echo "CONNECT: HTTP $code, $size bytes"
+          [ "$code" = "200" ] || { echo "FAIL: CONNECT tunnel did not work"; exit 1; }
+
+          # 4. ssrf.js refuses an internal target. Asserted on the ARTEFACT,
+          #    because this image is about to be published into topologies its
+          #    author did not choose, and a mitigation that lives only in one
+          #    compose file does not ship with the image (vikunja#697).
+          read -r code size <<<"$(via http://127.0.0.1:22/ || echo '000 0')"
+          echo "internal target: HTTP $code"
+          [ "$code" = "403" ] || { echo "FAIL: internal address not refused with 403, got $code"; exit 1; }
+          docker logs smoke-proxy 2>&1 | grep -q 'refused non-public target 127.0.0.1' \
+            || { echo "FAIL: no SSRF refusal log line"; exit 1; }
+
+          echo "adblock-proxy contract OK — forwards, adblocks, tunnels, and refuses internal targets"
+          docker rm -f smoke-proxy >/dev/null
+          docker network rm smoke-net >/dev/null
+
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$GHCR_TOKEN" \
+            | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+
+      - name: Tag and push adblock-proxy
+        id: push
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          V="${REF_NAME#v}"
+          MINOR="$(echo "$V" | cut -d. -f1,2)"
+
+          TAGS=("$REF_NAME" "$V")
+          case "$V" in
+            *-*) echo "prerelease $V — publishing exact tags only, not :$MINOR or :latest" ;;
+            *)   TAGS+=("$MINOR" "latest") ;;
+          esac
+
+          for t in "${TAGS[@]}"; do
+            echo "pushing $PROXY_IMAGE:$t"
+            docker tag "$PROXY_IMAGE:candidate" "$PROXY_IMAGE:$t"
+            docker push "$PROXY_IMAGE:$t"
+          done
+
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$PROXY_IMAGE:$V" | cut -d@ -f2)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "pushed digest $DIGEST"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.PROXY_IMAGE }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  # ── playwright-adblock ──────────────────────────────────────────────────────
+  # Tier-1 adblocking for Firecrawl v2's renderer (vikunja#696). Same shape as
+  # the jobs above; the smoke test is the one that differs, because this image
+  # sits in front of a security control.
+  publish-playwright-adblock:
+    name: Build, smoke test, publish playwright-adblock
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # THE ASSERTION THAT MATTERS IS NOT "ARE ADS BLOCKED".
+      #
+      # This image installs a request interceptor in front of Firecrawl's
+      # in-browser SSRF guard. A handler calling route.continue() instead of
+      # route.fallback() deletes that guard while still blocking ads, still
+      # rendering pages, and still returning 200 — so the script builds a
+      # deliberately broken variant and asserts the signal DISAPPEARS. Without
+      # that control, a test that always passes looks identical to one that
+      # works.
+      #
+      # It builds the image itself, so there is no separate build step here.
+      - name: Build and verify playwright-adblock (SSRF guard survives)
+        run: ./docker/playwright-adblock/verify-ssrf-guard.sh "$PLAYWRIGHT_ADBLOCK_IMAGE:candidate"
+
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$GHCR_TOKEN" \
+            | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+
+      - name: Tag and push playwright-adblock
+        id: push
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          V="${REF_NAME#v}"
+          MINOR="$(echo "$V" | cut -d. -f1,2)"
+
+          TAGS=("$REF_NAME" "$V")
+          case "$V" in
+            *-*) echo "prerelease $V — publishing exact tags only, not :$MINOR or :latest" ;;
+            *)   TAGS+=("$MINOR" "latest") ;;
+          esac
+
+          for t in "${TAGS[@]}"; do
+            echo "pushing $PLAYWRIGHT_ADBLOCK_IMAGE:$t"
+            docker tag "$PLAYWRIGHT_ADBLOCK_IMAGE:candidate" "$PLAYWRIGHT_ADBLOCK_IMAGE:$t"
+            docker push "$PLAYWRIGHT_ADBLOCK_IMAGE:$t"
+          done
+
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$PLAYWRIGHT_ADBLOCK_IMAGE:$V" | cut -d@ -f2)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "pushed digest $DIGEST"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.PLAYWRIGHT_ADBLOCK_IMAGE }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,11 @@ core.*
 *.env
 run.sh
 package-lock.json
+# ...except the two docker/ sub-projects, which are NOT pnpm workspaces. They
+# are npm projects built into published images, and their lockfiles are what
+# make those builds reproducible and auditable (audit LOW, 2026-09-06). Without
+# these negations the root rule silently swallows them and the Dockerfiles'
+# `npm ci` references a file that is not in the repo.
+!docker/adblock-proxy/package-lock.json
+!docker/playwright-adblock/package-lock.json
 domain-db-snapshots/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   "There are 32 threads, so 8.00GiB are required", with no hardening involved.
   `--proactor_threads=4` is now pinned in both files.
 
+- **Tier-1 adblocking now applies to the renderer this project actually uses (vikunja#696).**
+  `docker/playwright-adblock/` layers EasyList + EasyPrivacy onto
+  `ghcr.io/firecrawl/playwright-service`, Firecrawl v2's renderer.
+  `docker/puppeteer-adblock/` targets the **v1** renderer, and searxng-mcp defaults to
+  `FIRECRAWL_API_VERSION=v2` — so on every v2 deployment, tier-1 adblocking was simply
+  absent. This is an **upgrade of upstream's existing `AD_SERVING_DOMAINS` token list, not a
+  new feature**; that list still applies underneath, because the hook defers to it.
+
+  **The dangerous part, and why the acceptance test is not "are ads blocked".** The hook
+  installs a request interceptor in front of Firecrawl's in-browser SSRF guard. Playwright
+  runs handlers in reverse registration order and `route.continue()` dispatches without
+  invoking the rest, so a handler that calls `continue()` silently deletes
+  `assertSafeTargetUrl`. Every path out of this handler ends in `abort()` or `fallback()`.
+
+  This is not theoretical: `@ghostery/adblocker-playwright`'s own `enableBlockingInPage()`
+  registers `page.route('**/*')` — page routes outrank context routes — and calls
+  `route.continue()`. Using the library the obvious way *is* the vulnerability. The hook
+  therefore reuses its matching via `fromPlaywrightDetails()` + `match()` while keeping
+  control of the disposition.
+
+  `verify-ssrf-guard.sh` asserts upstream's handler still executes, then builds a
+  deliberately broken variant and asserts the signal disappears. Measured:
+
+  | build | `/scrape` | upstream handler ran? |
+  |---|---|---|
+  | shipped (`fallback`) | HTTP 200 | yes |
+  | regression (`continue`) | HTTP 200 | **no — guard gone** |
+
+  Both return 200, both render, both block ads. That is the whole point.
+
+  Filter lists are **baked into the image**. Fetching them at startup crashed the service
+  outright in testing — undici threw `AssertionError: assert(!this.paused)` from inside its
+  own parser, asynchronously and past any `.catch()`. Same reasoning as vendoring
+  FlashRank's model in v3.25.0.
+
+  `docker-compose.full.yml` repoints its renderer at the new build (note port 3003, not
+  3000). `docker/puppeteer-adblock/` is kept for v1 adopters and marked v1-only.
+
 - **vikunja#687 needed closing, not building.** Its premise died in v3.25.0: `648b60e`
   replaced the bare `catch { return null }` at `crawl4ai.ts:197` that the ticket describes.
   What survived was the *class*, in other files, which is what the above addresses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [3.26.0] - 2026-09-06
 
 ### Fixed
 
@@ -165,6 +165,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
   `docker-compose.full.yml` repoints its renderer at the new build (note port 3003, not
   3000). `docker/puppeteer-adblock/` is kept for v1 adopters and marked v1-only.
+
+- **`adblock-proxy` and `playwright-adblock` are published images (vikunja#697, #696).**
+  `adblock-proxy` was the last stack component with no published image; the reference
+  deployment built it from an absolute path into a developer's working tree, which is not an
+  adoption path. `docker-compose.full.yml` now pulls it, matching what the reranker already
+  did, and `docker/adblock-proxy/docker-compose.yml` is added for standalone use — with a
+  pinned `name:` and no `container_name:`, because Phase 1's lesson applies to every new
+  compose file here.
+
+  Both smoke tests assert the **contract**, not the boot. The adblock-proxy test was drafted
+  wrong first and is worth recording: it used a local nginx origin and
+  `http://doubleclick.net/ad.js`. Both are refused by `ssrf.js` — the container origin
+  resolves to a private address, and this host's resolver blackholes ad domains to `::` — so
+  **both returned zero bytes and the "is it blocking ads?" assertion passed for every URL,
+  blocked or not.** It proved nothing. The shipped version uses a public origin for the
+  forwarding case, a URL EasyList actually matches for the blocking case, and asserts on
+  *which mechanism the log reports*, because an empty response alone cannot distinguish an
+  adblock hit from an SSRF refusal.
+
+  `docker/adblock-proxy/README.md` states the intended placement plainly: it is an open
+  forward proxy with no authentication, and `ssrf.js` is a backstop rather than a substitute
+  for keeping the port private. That control is now asserted against the built image — a
+  mitigation living in one compose file does not travel with the artefact.
 
 - **vikunja#687 needed closing, not building.** Its premise died in v3.25.0: `648b60e`
   replaced the bare `catch { return null }` at `crawl4ai.ts:197` that the ticket describes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,9 +118,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - **`ollama` gets no `read_only`** — verified failing both with and without a tmpfs.
   - `nats` needs `read_only` *and* a writable `/tmp`; `read_only` alone exits 1.
 
-  `kiwix`, `firecrawl-api` and `firecrawl-puppeteer` carry `cap_drop` and the limits but no
+  `kiwix`, `firecrawl-api` and the renderer carry `cap_drop` and the limits but no
   `read_only`: they could not be started here (no `.zim` corpus, no API keys, Chromium
   sandbox), so it is recorded as unverified rather than assumed safe.
+
+  Containers also no longer run as root. `cache`, `firecrawl-redis`, `nats` and `ollama` are
+  pinned to uid 1000 and `reranker` to 10001; the rest already run as a non-root user
+  declared by their own image, which is recorded in a comment rather than overridden with a
+  guessed uid. Pinning the user turned out to make the hardening *smaller*, not larger: with
+  `user:` set, the `setpriv` privilege-drop in the Dragonfly and redis entrypoints is never
+  attempted, so the `SETUID`/`SETGID` capabilities they needed without it are no longer
+  granted at all. Verified both ways, and all five re-verified serving afterwards —
+  `cache` and `firecrawl-redis` answering `PONG` as uid 1000, `reranker` reporting
+  `model_loaded: true` as uid 10001.
 
   Also fixed while running it: the reference `cache` command line could not start on a large
   host at all. Dragonfly sizes io threads to the core count and refuses to boot if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [3.26.0] - 2026-09-06
 
+### Security
+
+- **Container sub-project dependencies are pinned and audited (audit LOW, 2026-09-06).**
+  `docker/adblock-proxy` and `docker/playwright-adblock` are not in the pnpm workspace, so
+  `pnpm audit --prod` never saw them — while both are built into **published** images, one an
+  unauthenticated forward proxy. A CVE in `@ghostery/adblocker` would have shipped silently.
+
+  Both now commit a lockfile and build with `npm ci` instead of `npm install <caret-range>`.
+  That closes the audit gap and a reproducibility one the audit did not raise: the caret range
+  re-resolved on every build, so two builds of the same commit could produce different
+  dependency trees — which quietly weakens the build-provenance attestation those images
+  publish. Both are pinned at `@ghostery/adblocker` 2.18.2.
+
+  CI gains a third audit step, separate from `--prod` and `--dev` for the same reason those
+  two are separate: "something we publish in a container is vulnerable" is a different
+  question from "something in the npm package is", and merging them makes the first
+  invisible. Verified the step can fail — injecting a package.json/lockfile drift makes
+  `npm ci` exit 1 with `Missing: left-pad@1.3.0`.
+
 ### Fixed
 
 - **A failure is no longer reported as a benign state (vikunja#695, #688, #687's survivors).**

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -27,8 +27,10 @@ services:
     # Dragonfly's entrypoint drops privileges with setpriv, so a bare
     # `cap_drop: [ALL]` kills it at startup with "setpriv: setresuid failed:
     # Operation not permitted" (exit 127). ALL + SETUID/SETGID runs.
+    # uid 1000, so the setpriv drop is not attempted and SETUID/SETGID are not
+    # needed. Verified both ways.
+    user: "1000:1000"
     cap_drop: [ALL]
-    cap_add: [SETUID, SETGID]
     security_opt: [no-new-privileges:true]
     read_only: true
     tmpfs: [/tmp]

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -40,14 +40,17 @@ services:
     #   image: redis:7-alpine
     #   image: valkey/valkey:8-alpine
     restart: unless-stopped
-    # Dragonfly's entrypoint drops privileges with setpriv, so a bare
-    # `cap_drop: [ALL]` kills it at startup with
-    # "setpriv: setresuid failed: Operation not permitted" (exit 127).
-    # Verified: ALL alone fails, ALL + SETUID/SETGID runs. This is the finding
-    # that would have broken every adopter's cache had the block been applied
-    # from a diff read.
+    # Dragonfly's entrypoint drops privileges with setpriv, so with the image's
+    # default (root) user a bare `cap_drop: [ALL]` kills it at startup with
+    # "setpriv: setresuid failed: Operation not permitted" (exit 127) — the
+    # finding that would have broken every adopter's cache had this block been
+    # applied from a diff read.
+    #
+    # Running as uid 1000 removes the need for those capabilities entirely:
+    # the drop is not attempted, so SETUID/SETGID are not granted. Verified
+    # both ways.
+    user: "1000:1000"
     cap_drop: [ALL]
-    cap_add: [SETUID, SETGID]
     security_opt: [no-new-privileges:true]
     read_only: true
     tmpfs: [/tmp]
@@ -70,6 +73,8 @@ services:
   firecrawl-api:
     image: ghcr.io/mendableai/firecrawl:latest # SECURITY[accepted]: latest tag — example file; pin for production
     restart: unless-stopped
+    # No `user:`: image not available here to confirm its default user, so this
+    # is UNVERIFIED rather than assumed safe — flagged for audit.
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]
     # No `read_only`: NOT verified. This image is not published under a tag
@@ -101,8 +106,10 @@ services:
     # one present on the build host. It passed, and the tag this file actually
     # declares did not. Every probe below is now run against the exact
     # reference in this file.
+    # As with `cache`: running as uid 1000 means the setpriv drop is not
+    # attempted, so SETUID/SETGID are not needed. Verified both ways.
+    user: "1000:1000"
     cap_drop: [ALL]
-    cap_add: [SETUID, SETGID]
     security_opt: [no-new-privileges:true]
     read_only: true
     mem_limit: 512m
@@ -126,6 +133,8 @@ services:
     build:
       context: ./docker/playwright-adblock
     restart: unless-stopped
+    # No `user:`: the base image already runs as `node` (non-root). Overriding
+    # it with a guessed uid risks breaking file ownership inside the image.
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]
     # No `read_only`: not verified — Chromium writes outside /tmp. Left off
@@ -153,6 +162,7 @@ services:
     # build:
     #   context: ./docker/adblock-proxy
     restart: unless-stopped
+    # No `user:`: the image's Dockerfile already sets `USER proxy` (non-root).
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]
     # Verified running fully read-only.
@@ -172,6 +182,7 @@ services:
   crawl4ai:
     image: unclecode/crawl4ai:latest # SECURITY[accepted]: latest tag — example file; pin for production
     restart: unless-stopped
+    # No `user:`: the image already runs as `appuser` (non-root).
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]
     # NO `read_only`. Three configurations were run, and none is fit for a file
@@ -209,6 +220,7 @@ services:
   ollama:
     image: ollama/ollama:latest # SECURITY[accepted]: latest tag — example file; pin for production
     restart: unless-stopped
+    user: "1000:1000"
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]
     # NO `read_only`, and not for lack of trying: verified failing both with
@@ -243,6 +255,10 @@ services:
     # To build from source instead of pulling:
     # build: ./docker/reranker
     restart: unless-stopped
+    # Matches docker/reranker/docker-compose.yml, which pins the same uid: the
+    # image already runs as 10001, and naming it here means a `docker run` that
+    # overrides the entrypoint cannot quietly regain root.
+    user: "10001"
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]
     # Matches docker/reranker/docker-compose.yml, which carries the same block
@@ -262,6 +278,7 @@ services:
   kiwix:
     image: ghcr.io/kiwix/kiwix-serve:latest # SECURITY[accepted]: latest tag — example file; pin for production
     restart: unless-stopped
+    # No `user:`: the image already runs as `user` (non-root).
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]
     # No `read_only`: NOT verified. kiwix-serve needs a .zim corpus to start
@@ -280,6 +297,7 @@ services:
   nats:
     image: nats:2-alpine
     restart: unless-stopped
+    user: "1000:1000"
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]
     # Verified: read_only alone exits 1, read_only + a writable /tmp runs.

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -148,8 +148,10 @@ services:
   # On fetch-net only — unreachable from firecrawl, ollama, reranker, kiwix, nats.
   # Port 8118 exposed to host so searxng-mcp (PM2/host process) can reach it.
   adblock-proxy:
-    build:
-      context: ./docker/adblock-proxy
+    image: ghcr.io/tadmstr/searxng-mcp-adblock-proxy:latest # SECURITY[accepted]: latest tag — example file; pin for production
+    # To build from source instead of pulling:
+    # build:
+    #   context: ./docker/adblock-proxy
     restart: unless-stopped
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -6,7 +6,7 @@
 #
 # Network isolation (NE-02):
 #   fetch-net    — adblock-proxy + crawl4ai only; proxy unreachable from unrelated services
-#   firecrawl-net — firecrawl-api + firecrawl-redis + firecrawl-puppeteer
+#   firecrawl-net — firecrawl-api + firecrawl-redis + firecrawl-playwright
 #   (default)    — cache, ollama, reranker, kiwix, nats; isolated from proxy
 #
 # Prerequisites:
@@ -79,13 +79,13 @@ services:
     cpus: 2.0
     environment:
       REDIS_URL: redis://firecrawl-redis:6379
-      PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-puppeteer:3000
+      PLAYWRIGHT_MICROSERVICE_URL: http://firecrawl-playwright:3003
       USE_DB_AUTHENTICATION: "false"
     ports:
       - "127.0.0.1:3002:3002"
     depends_on:
       - firecrawl-redis
-      - firecrawl-puppeteer
+      - firecrawl-playwright
     networks:
       - firecrawl-net
 
@@ -110,22 +110,34 @@ services:
     networks:
       - firecrawl-net
 
-  firecrawl-puppeteer:
-    # Custom build: trieve/puppeteer-service-ts + @ghostery/adblocker-puppeteer
-    # See docker/puppeteer-adblock/README.md for details.
+  firecrawl-playwright:
+    # Custom build: ghcr.io/firecrawl/playwright-service + EasyList/EasyPrivacy
+    # via @ghostery/adblocker-playwright. See docker/playwright-adblock/README.md
+    # — and read its SSRF note before changing the route handler.
+    #
+    # Replaces the former puppeteer-based service, which layered adblocking onto
+    # the v1 renderer (trieve/puppeteer-service-ts). This repo defaults to
+    # FIRECRAWL_API_VERSION=v2, whose renderer is the playwright service — so
+    # tier-1 adblocking did not apply to the configuration this project actually
+    # runs (vikunja#696). docker/puppeteer-adblock/ is kept for adopters still on
+    # v1 and is marked v1-only in its README.
+    #
+    # NOTE: the port is 3003, not 3000 — the two renderers differ.
     build:
-      context: ./docker/puppeteer-adblock
+      context: ./docker/playwright-adblock
     restart: unless-stopped
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]
-    # No `read_only`: not verified — this service is built from this repo and
-    # a Chromium sandbox writes outside /tmp. Left off rather than guessed.
+    # No `read_only`: not verified — Chromium writes outside /tmp. Left off
+    # rather than guessed.
     mem_limit: 2g
     cpus: 2.0
     environment:
-      ADBLOCK_FILTERS_URL: "https://easylist.to/easylist/easylist.txt,https://easylist.to/easylist/easyprivacy.txt"
-      ADBLOCK_REFRESH_HOURS: "168"
+      # ADBLOCK_FILTERS_URL is deliberately unset: the filter lists are baked
+      # into the image, and setting this opts back into fetching them at
+      # runtime — the switch defeated by its own default.
       # Set ADBLOCK_DISABLE=true to disable adblocking for debugging.
+      ADBLOCK_DISABLE: "${ADBLOCK_DISABLE:-false}"
     networks:
       - firecrawl-net
 

--- a/docker/adblock-proxy/Dockerfile
+++ b/docker/adblock-proxy/Dockerfile
@@ -10,8 +10,11 @@ RUN addgroup -S proxy && adduser -S proxy -G proxy
 
 WORKDIR /app
 
-COPY package.json ./
-RUN npm install --omit=dev
+# `npm ci` from a committed lockfile: reproducible, and the pinned set is
+# visible to the CI audit step. `npm install` re-resolved the caret range on
+# every build (audit LOW, 2026-09-06).
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --no-audit --no-fund
 
 # ssrf.js is required by proxy.js at startup — a COPY that lists only proxy.js
 # produces an image that crash-loops on MODULE_NOT_FOUND.

--- a/docker/adblock-proxy/README.md
+++ b/docker/adblock-proxy/README.md
@@ -1,5 +1,35 @@
 # adblock-proxy
 
+## Intended placement — read before deploying
+
+This is an **open forward proxy with no authentication of any kind.** It makes
+outbound requests on behalf of whoever can reach its port. Published on
+`0.0.0.0` it is an open relay.
+
+**Put it on a private network or bind it to loopback. Nothing else.** The
+supplied `docker-compose.yml` binds `127.0.0.1` and the reference stack keeps it
+on an internal network with no host publish.
+
+`ssrf.js` refuses targets that resolve to private or reserved addresses, which
+is what stops the proxy being a pivot into whatever network it sits in. It is a
+**backstop, not a substitute** for keeping the port private — it constrains
+where requests can go, not who may make them.
+
+That control now ships with the artefact rather than living in a comment: the
+publish workflow asserts, against the built image, that an internal address is
+refused with 403 and that the refusal is logged. The precedent is the reranker's
+request cap — a mitigation that exists only in one compose file does not travel
+with the image, and this image is published for topologies its author did not
+choose (vikunja#697).
+
+### Known limitation
+
+HTTPS is tunnelled via CONNECT without interception, so **filtering applies to
+plain-HTTP requests only**. HTTPS ad and tracker domains pass through. For
+in-browser filtering that covers HTTPS, see `docker/playwright-adblock/`
+(Firecrawl v2) or `docker/puppeteer-adblock/` (v1).
+
+
 HTTP forward proxy that filters ad and tracker requests using `@ghostery/adblocker`
 (EasyList + EasyPrivacy by default). Used by searxng-mcp tiers 2 and 3.
 

--- a/docker/adblock-proxy/docker-compose.yml
+++ b/docker/adblock-proxy/docker-compose.yml
@@ -1,0 +1,39 @@
+# Standalone adblock-proxy. Run it from this directory with `docker compose up`.
+#
+# Compose derives the project name from this directory's basename, and project
+# and container names are GLOBAL to the Docker host — so an unpinned project
+# name silently shares a namespace with any other stack of the same name, and
+# `docker compose down` here would remove that stack's containers. That is how
+# a production reranker was removed for ~4.5h on 2026-09-06 (vikunja#694).
+#
+# `name:` is pinned, and there is deliberately NO `container_name:`.
+name: searxng-mcp-adblock-proxy
+
+services:
+  adblock-proxy:
+    image: ghcr.io/tadmstr/searxng-mcp-adblock-proxy:latest
+    # Or build it from the source beside this file:
+    # build: .
+    restart: unless-stopped
+    ports:
+      # ⚠ LOOPBACK ONLY, AND THIS IS NOT COSMETIC.
+      #
+      # This is an open forward proxy. It performs outbound requests on behalf
+      # of whoever can reach the port, and it has no authentication of any
+      # kind. Published on 0.0.0.0 it is an open relay.
+      #
+      # ssrf.js refuses targets that resolve to private or reserved addresses,
+      # which is what stops it being a pivot into the network it sits in — but
+      # that is a backstop, not a substitute for keeping the port private.
+      # See README.md, "Intended placement".
+      - "127.0.0.1:${ADBLOCK_PROXY_HOST_PORT:-8118}:8118"
+    environment:
+      ADBLOCK_FILTERS_URL: "https://easylist.to/easylist/easylist.txt,https://easylist.to/easylist/easyprivacy.txt"
+      ADBLOCK_REFRESH_HOURS: "168"
+      LOG_BLOCKED: "false"
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    # Verified running fully read-only (vikunja#693).
+    read_only: true
+    mem_limit: 512m
+    cpus: 1.0

--- a/docker/adblock-proxy/docker-compose.yml
+++ b/docker/adblock-proxy/docker-compose.yml
@@ -11,7 +11,7 @@ name: searxng-mcp-adblock-proxy
 
 services:
   adblock-proxy:
-    image: ghcr.io/tadmstr/searxng-mcp-adblock-proxy:latest
+    image: ghcr.io/tadmstr/searxng-mcp-adblock-proxy:latest # SECURITY[accepted]: latest tag — standalone example file; pin by digest for production
     # Or build it from the source beside this file:
     # build: .
     restart: unless-stopped

--- a/docker/adblock-proxy/package-lock.json
+++ b/docker/adblock-proxy/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": "adblock-proxy",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "adblock-proxy",
+      "version": "1.0.0",
+      "dependencies": {
+        "@ghostery/adblocker": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ghostery/adblocker": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.18.2.tgz",
+      "integrity": "sha512-x6zEkf1dHSN0t4ExLmuN6nIgH0oAi6laoKe5yGsiIB4jkEvutea1PJgxgRUIjWfNbDRmkf4GjUtuqQFZgvQG1w==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ghostery/adblocker-content": "^2.18.2",
+        "@ghostery/adblocker-extended-selectors": "^2.18.2",
+        "@ghostery/url-parser": "^1.3.1",
+        "@remusao/guess-url-type": "^2.1.0",
+        "@remusao/small": "^2.1.0",
+        "@remusao/smaz": "^2.2.0",
+        "tldts-experimental": "^7.4.9"
+      }
+    },
+    "node_modules/@ghostery/adblocker-content": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.18.2.tgz",
+      "integrity": "sha512-TOe/b4KOBFEc9OjLG+wvgamGcSTIPSDBAL5YSa8lzjBsoSl8IDnfOjeJDldlLacsC/JEUMLkZIDDNknEolJVqg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ghostery/adblocker-extended-selectors": "^2.18.2"
+      }
+    },
+    "node_modules/@ghostery/adblocker-extended-selectors": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.18.2.tgz",
+      "integrity": "sha512-doKNShBk3+czQL08UkrysHkCPeG/kNPlXvz3DH7SXxD9Y78ovWkEAhjeR+upoan3fomJJuK3dD+IrlofnjckYw==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@ghostery/url-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/url-parser/-/url-parser-1.3.1.tgz",
+      "integrity": "sha512-QKqGi+7aDQ4RcyHyCwgEk6B9vWnsBP4Q7htaN0zPJV3ATqTKEQDtSTb9c/AN586oJUDs24YXKcwFYwNweY/YjQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "tldts-experimental": "^7.0.8"
+      }
+    },
+    "node_modules/@remusao/guess-url-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/guess-url-type/-/guess-url-type-2.1.0.tgz",
+      "integrity": "sha512-zI3dlTUxpjvx2GCxp9nLOSK5yEIqDCpxlAVGwb2Y49RKkS72oeNaxxo+VWS5+XQ5+Mf8Zfp9ZXIlk+G5eoEN8A==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@remusao/small": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/small/-/small-2.1.0.tgz",
+      "integrity": "sha512-Y1kyjZp7JU7dXdyOdxHVNfoTr1XLZJTyQP36/esZUU/WRWq9XY0PV2HsE3CsIHuaTf4pvgWv2pvzvnZ//UHIJQ==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@remusao/smaz": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz/-/smaz-2.2.0.tgz",
+      "integrity": "sha512-eSd3Qs0ELP/e7tU1SI5RWXcCn9KjDgvBY+KtWbL4i2QvvHhJOfdIt4v0AA3S5BbLWAr5dCEC7C4LUfogDm6q/Q==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@remusao/smaz-compress": "^2.2.0",
+        "@remusao/smaz-decompress": "^2.2.0"
+      }
+    },
+    "node_modules/@remusao/smaz-compress": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz-compress/-/smaz-compress-2.2.0.tgz",
+      "integrity": "sha512-TXpTPgILRUYOt2rEe0+9PC12xULPvBqeMpmipzB9A7oM4fa9Ztvy9lLYzPTd7tiQEeoNa1pmxihpKfJtsxnM/w==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@remusao/trie": "^2.1.0"
+      }
+    },
+    "node_modules/@remusao/smaz-decompress": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz-decompress/-/smaz-decompress-2.2.0.tgz",
+      "integrity": "sha512-ERAPwxPaA0/yg4hkNU7T2S+lnp9jj1sApcQMtOyROvOQyo+Zuh6Hn/oRcXr8mmjlYzyRaC7E6r3mT1nrdHR6pg==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@remusao/trie": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/trie/-/trie-2.1.0.tgz",
+      "integrity": "sha512-Er3Q8q0/2OcCJPQYJOPLmCuqO0wu7cav3SPtpjlxSbjFi1x+A1pZkkLD6c9q2rGEkGW/tkrRzfrhNMt8VQjzXg==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "license": "MIT"
+    },
+    "node_modules/tldts-experimental": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.11.tgz",
+      "integrity": "sha512-xbNzxktqwNYSryb4FclztEZ+G5waTnMCVBnwoWD1Fq0gjOykgr0rQWe4/2TdIJYHbyjIol5pdNh7OmCRWxIltw==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      }
+    }
+  }
+}

--- a/docker/playwright-adblock/Dockerfile
+++ b/docker/playwright-adblock/Dockerfile
@@ -1,0 +1,70 @@
+# playwright-service with @ghostery/adblocker-playwright layered on top of the
+# upstream ghcr.io/firecrawl/playwright-service image — the renderer Firecrawl
+# v2 uses, and the one searxng-mcp actually runs (FIRECRAWL_API_VERSION=v2).
+#
+# This replaces AD_SERVING_DOMAINS — upstream's hardcoded substring list — with
+# EasyList + EasyPrivacy. It is an UPGRADE of existing token adblocking, not a
+# new capability.
+#
+# Layered, not forked: init-adblock.js is loaded via NODE_OPTIONS=--require and
+# patches `require("playwright")` before api.ts runs. Not forking upstream is
+# what kept the puppeteer version maintainable across releases; preserve it.
+#
+# ⚠ init-adblock.js sits in front of Firecrawl's in-browser SSRF guard. Read
+#   its header before changing the route handler.
+#
+# Base image pinned by digest (security check DC-01). This is the digest the
+# forge deployment runs, verified 2026-09-06. To bump:
+#   docker pull ghcr.io/firecrawl/playwright-service:<NEW_TAG>
+#   docker inspect ... --format '{{index .RepoDigests 0}}'
+# and re-check api.ts's route ordering — the guard this hook chains into is
+# upstream code and can move.
+FROM ghcr.io/firecrawl/playwright-service@sha256:5cd4c2590eebcb8e0932553187d36ab7e76249165712b2bdbae6438b0b033d40
+
+WORKDIR /usr/src/app
+
+# Dependencies go in their OWN prefix, not the app's.
+#
+# Two constraints found by building it, neither obvious from the outside:
+#   - The base image's node_modules are linked from /pnpm/store/v11, which is
+#     root-owned, and the image runs as uid 1000. `pnpm add` fails with
+#     ERR_PNPM_UNEXPECTED_STORE, and pointing it at that store fails again with
+#     "attempt to write a readonly database".
+#   - Running `npm install` inside /usr/src/app would let npm reconcile a tree
+#     that pnpm built out of symlinks, which is a good way to quietly break the
+#     service's own dependencies.
+#
+# So: install in a writable SUBDIRECTORY of the app (/usr/src is root-owned,
+# so a sibling directory cannot be created as uid 1000) and let Node resolve and let Node's normal resolution find them —
+# init-adblock.js lives in the same directory as its node_modules, so
+# `require("@ghostery/adblocker-playwright")` resolves without NODE_PATH.
+RUN mkdir -p /usr/src/app/adblock \
+ && cd /usr/src/app/adblock \
+ && npm init -y > /dev/null \
+ && npm install --no-audit --no-fund \
+      @ghostery/adblocker-playwright@^2 cross-fetch@^4
+
+# Bake the filter lists into the image. A startup that fetches them over TLS
+# can crash the service outright: undici threw an internal assertion mid-fetch
+# and killed the process, asynchronously and past any .catch(). Same reasoning
+# as vendoring FlashRank's model into the reranker in v3.25.0.
+#
+# fetch-lists.mjs fails the BUILD on a bad download rather than producing an
+# image whose adblocker silently blocks nothing.
+COPY fetch-lists.mjs /tmp/fetch-lists.mjs
+# No `&& rm` here: COPY lands the file as root, /tmp is sticky, and the image
+# runs as uid 1000 — the delete fails and takes the build with it.
+RUN node /tmp/fetch-lists.mjs
+
+COPY init-adblock.js /usr/src/app/adblock/init-adblock.js
+
+ENV NODE_OPTIONS="--require /usr/src/app/adblock/init-adblock.js"
+# ADBLOCK_FILTERS_URL is deliberately NOT set here. It is the opt-in switch for
+# fetching lists at runtime, and setting it as an image default would mean the
+# baked lists were never used — the switch defeated by its own default. Set it
+# at deploy time only if you want lists newer than the image.
+#
+# ADBLOCK_REFRESH_HOURS likewise only applies to the fetching path; there is
+# nothing to refresh when the lists come from the image.
+
+# Same command and port as upstream — only the adblock hook differs.

--- a/docker/playwright-adblock/Dockerfile
+++ b/docker/playwright-adblock/Dockerfile
@@ -38,11 +38,20 @@ WORKDIR /usr/src/app
 # so a sibling directory cannot be created as uid 1000) and let Node resolve and let Node's normal resolution find them —
 # init-adblock.js lives in the same directory as its node_modules, so
 # `require("@ghostery/adblocker-playwright")` resolves without NODE_PATH.
-RUN mkdir -p /usr/src/app/adblock \
- && cd /usr/src/app/adblock \
- && npm init -y > /dev/null \
- && npm install --no-audit --no-fund \
-      @ghostery/adblocker-playwright@^2 cross-fetch@^4
+# `npm ci` from a COMMITTED lockfile, not `npm install <range>`.
+#
+# The previous version resolved `@ghostery/adblocker-playwright@^2` fresh on
+# every build, so two builds of the same commit could produce different
+# dependency trees — which quietly weakens the build-provenance attestation
+# this image publishes, and leaves the deps invisible to any audit. The root
+# `pnpm audit --prod` does not see this directory: it is not in the workspace
+# (audit LOW, 2026-09-06).
+# --chown is not optional: COPY creates the destination directory as root, and
+# this image runs as uid 1000, so npm ci then fails EACCES trying to mkdir
+# node_modules inside it. Same ownership trap as the COPY'd file under /tmp
+# further down.
+COPY --chown=node:node package.json package-lock.json /usr/src/app/adblock/
+RUN cd /usr/src/app/adblock && npm ci --omit=dev --no-audit --no-fund
 
 # Bake the filter lists into the image. A startup that fetches them over TLS
 # can crash the service outright: undici threw an internal assertion mid-fetch

--- a/docker/playwright-adblock/README.md
+++ b/docker/playwright-adblock/README.md
@@ -1,0 +1,103 @@
+# playwright-adblock
+
+EasyList + EasyPrivacy filtering for **Firecrawl v2's renderer**
+(`ghcr.io/firecrawl/playwright-service`), layered on without forking it.
+
+This is an **upgrade of existing token adblocking, not a new feature.** Upstream
+already filters ads via `AD_SERVING_DOMAINS` — a hardcoded list of 13 substrings
+(`doubleclick.net`, `googletagmanager.com`, …). This replaces that with the full
+EasyList + EasyPrivacy rule set. Upstream's list still applies underneath, because
+this hook defers to it rather than replacing it.
+
+## Why it exists
+
+`docker/puppeteer-adblock/` does the same job for the **v1** renderer
+(`trieve/puppeteer-service-ts`). searxng-mcp defaults to
+`FIRECRAWL_API_VERSION=v2`, whose renderer is the playwright service — so on
+every v2 deployment, tier-1 adblocking was simply absent. See vikunja#696.
+
+## ⚠ Read this before touching the route handler
+
+`init-adblock.js` installs a request interceptor **in front of Firecrawl's
+in-browser SSRF guard**. Get it wrong and you delete that guard silently.
+
+Upstream's `api.ts` registers a context route that runs `assertSafeTargetUrl`
+before its own ad check, ending in `route.continue()`. In Playwright:
+
+> `route.continue()`: "immediately sends the request to the network; **other
+> matching handlers won't be invoked**"
+> `route.fallback()`: "ensures other matching handlers are invoked before
+> sending the request"
+> "Handlers run in reverse order of registration."
+
+A handler registered after upstream's therefore runs **first**, and calling
+`continue()` there means `assertSafeTargetUrl` never executes.
+
+**Every path out of this handler ends in `abort()` or `fallback()`. Never
+`continue()`.**
+
+This is not a theoretical hazard. `@ghostery/adblocker-playwright`'s own
+`enableBlockingInPage()` registers `page.route('**/*')` — page routes take
+precedence over context routes — and calls `route.continue()` for every
+non-blocked request. That is why this hook does **not** use it, and instead
+reuses the library's matching via `fromPlaywrightDetails()` + `match()` while
+keeping control of the disposition.
+
+## Verifying it
+
+```bash
+./verify-ssrf-guard.sh
+```
+
+The assertion that matters is **not** "are ads blocked". The script asserts
+that upstream's handler still executes, then builds a deliberately broken
+variant (`fallback()` → `continue()`) and asserts the signal **disappears** —
+because a test that always passes looks exactly like a test that works.
+
+Measured, and the reason a functional test cannot substitute for this one:
+
+| build | `/scrape` | upstream handler ran? |
+|---|---|---|
+| shipped (`fallback`) | HTTP 200 | yes |
+| regression (`continue`) | HTTP 200 | **no — SSRF guard gone** |
+
+Both return 200. Both render the page. Both block ads.
+
+## Configuration
+
+| Env | Default | Meaning |
+|---|---|---|
+| `ADBLOCK_DISABLE` | unset | `true` no-ops the hook entirely |
+| `ADBLOCK_FILTERS_URL` | **unset** | Opt in to fetching lists at runtime, comma-separated |
+| `ADBLOCK_REFRESH_HOURS` | `168` | Refresh interval — only applies when fetching |
+
+Filter lists are **baked into the image** at build time and parsed from disk, so
+startup needs no network. `ADBLOCK_FILTERS_URL` is deliberately not set as an
+image default: doing so would mean the baked lists were never used, with the
+opt-in switch defeated by its own default.
+
+Baking is not just an optimisation. Fetching the lists over TLS at startup
+crashed the service outright in testing — undici threw
+`AssertionError: assert(!this.paused)` from inside its own parser, which is
+asynchronous and so cannot be caught by the promise around the fetch. A
+published image that renders untrusted pages must not have a startup path that
+a third-party CDN hiccup can kill. Same reasoning as vendoring FlashRank's model
+into the reranker in v3.25.0.
+
+## Bumping the base image
+
+Pinned by digest (security check DC-01). To bump:
+
+```bash
+docker pull ghcr.io/firecrawl/playwright-service:<NEW_TAG>
+docker inspect ghcr.io/firecrawl/playwright-service:<NEW_TAG> --format '{{index .RepoDigests 0}}'
+```
+
+Then **re-read `api.ts`'s route registration** — the guard this hook chains into
+is upstream code and can move — and re-run `./verify-ssrf-guard.sh`.
+
+## Known upstream behaviour
+
+The base image's command is `pnpm start`, which downloads pnpm via corepack on
+every boot. The container therefore cannot start without network access even
+though the filter lists are baked in. That is upstream's, not this layer's.

--- a/docker/playwright-adblock/fetch-lists.mjs
+++ b/docker/playwright-adblock/fetch-lists.mjs
@@ -1,0 +1,36 @@
+// Build-time only: download the filter lists baked into the image.
+//
+// Fails the BUILD on any problem rather than producing an image whose
+// adblocker silently blocks nothing. A too-small file is treated as a failure
+// because a CDN error page is a 200 with a body, and parsing one yields an
+// engine with no rules — an adblocker reporting success while doing nothing,
+// which is the defect class this whole release is about.
+import { writeFile, mkdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+const OUT = "/usr/src/app/adblock/lists";
+const MIN_BYTES = 100_000;
+const URLS = [
+  "https://easylist.to/easylist/easylist.txt",
+  "https://easylist.to/easylist/easyprivacy.txt",
+];
+
+await mkdir(OUT, { recursive: true });
+for (const url of URLS) {
+  const name = url.split("/").pop();
+  const res = await fetch(url);
+  if (!res.ok) {
+    console.error(`FAIL ${url} -> HTTP ${res.status}`);
+    process.exit(1);
+  }
+  const text = await res.text();
+  const bytes = Buffer.byteLength(text, "utf8");
+  if (bytes < MIN_BYTES) {
+    console.error(`FAIL ${url} -> only ${bytes} bytes, refusing to bake it`);
+    process.exit(1);
+  }
+  await writeFile(join(OUT, name), text, "utf8");
+  console.log(`baked ${name}: ${bytes} bytes`);
+}
+const n = (await Promise.all(URLS.map((u) => stat(join(OUT, u.split("/").pop()))))).length;
+console.log(`baked ${n} filter list(s) into ${OUT}`);

--- a/docker/playwright-adblock/init-adblock.js
+++ b/docker/playwright-adblock/init-adblock.js
@@ -1,0 +1,285 @@
+// Layer @ghostery/adblocker-playwright onto the upstream
+// ghcr.io/firecrawl/playwright-service image without forking its api.ts.
+// Loaded via NODE_OPTIONS="--require /usr/src/app/init-adblock.js" so it runs
+// before api.ts requires `playwright`.
+//
+// ─── READ THIS BEFORE CHANGING THE HANDLER ──────────────────────────────────
+//
+// The upstream api.ts registers a context-level route that runs Firecrawl's
+// in-browser SSRF guard:
+//
+//   await newContext.route('**/*', async (route, request) => {
+//     try { await assertSafeTargetUrl(request.url()); }      // api.ts:245
+//     catch (e) { ... return route.abort('blockedbyclient'); }
+//     if (AD_SERVING_DOMAINS.some(...)) return route.abort();
+//     return route.continue();                               // api.ts:263
+//   });
+//
+// In Playwright, handlers run in REVERSE order of registration, and
+// `route.continue()` dispatches the request immediately — "other matching
+// handlers won't be invoked". Only `route.fallback()` passes control to the
+// next handler. (Quoted from Playwright's own API reference.)
+//
+// So a handler registered after that one runs BEFORE it, and if it calls
+// continue() the SSRF guard NEVER EXECUTES. Ads would still be blocked, pages
+// would still render, and every functional test would pass — with Firecrawl's
+// SSRF protection silently removed.
+//
+// This is not hypothetical. @ghostery/adblocker-playwright's own
+// `enableBlockingInPage()` does exactly that: it registers `page.route('**/*')`
+// (page routes take precedence over context routes) and calls `route.continue()`
+// for every non-blocked request. Verified by reading 2.18.2's compiled source.
+// That is why this file does NOT use enableBlockingInPage, and instead reuses
+// the library's matching via its exported `fromPlaywrightDetails` + `match()`
+// while keeping control of the disposition.
+//
+// THE RULE: every path out of this handler ends in abort() or fallback().
+// NEVER continue(). A `continue()` here is a security regression that no
+// "are ads blocked?" test can detect.
+//
+// Env vars (all optional):
+//   ADBLOCK_DISABLE        — when "true", this module no-ops entirely.
+//   ADBLOCK_FILTERS_URL    — comma-separated filter list URLs.
+//                            Defaults to EasyList + EasyPrivacy.
+//   ADBLOCK_REFRESH_HOURS  — rebuild interval, default 168 (7 days).
+
+"use strict";
+
+const Module = require("node:module");
+
+// Re-entry guard. NOTE: this is deliberately a per-PROCESS global and NOT an
+// environment variable.
+//
+// The upstream image's command is `pnpm start`, which SPAWNS `node dist/api.js`
+// as a child. NODE_OPTIONS applies to both, so an env-var guard is set by the
+// pnpm process — where the hook is useless — and then INHERITED by the child,
+// which therefore skips installing. The server runs with no adblocking at all,
+// while the log cheerfully reports "loaded 2 list(s)" from the parent.
+//
+// Observed exactly that with an env-var guard: the container starts, filter
+// lists load, pages render, and nothing is blocked. A "does it start?" test
+// passes; so does "are the lists loaded?".
+const INSTALLED = Symbol.for("searxng-mcp.adblock.installed");
+
+if (process.env.ADBLOCK_DISABLE === "true") {
+  console.log("[adblock] disabled via ADBLOCK_DISABLE=true");
+  module.exports = {};
+} else {
+  install();
+}
+
+
+function install() {
+  if (globalThis[INSTALLED]) {
+    console.warn("[adblock] already installed in this process — skipping");
+    return;
+  }
+  globalThis[INSTALLED] = true;
+
+  const FILTER_URLS = (
+    process.env.ADBLOCK_FILTERS_URL ||
+    "https://easylist.to/easylist/easylist.txt,https://easylist.to/easylist/easyprivacy.txt"
+  )
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const REFRESH_MS =
+    Math.max(1, Number(process.env.ADBLOCK_REFRESH_HOURS || "168")) *
+    60 *
+    60 *
+    1000;
+
+  let blocker = null;
+  let blockerLoading = null;
+
+  // Filter lists are BAKED INTO THE IMAGE at build time and parsed from disk.
+  //
+  // The first version fetched them over TLS at startup, and a flaky fetch to
+  // easylist.to took the entire service down: undici threw
+  // `AssertionError: assert(!this.paused)` from inside its own parser, which
+  // is asynchronous and therefore not catchable by the .catch() on this
+  // promise. Reproduced once in about six runs. A published image that renders
+  // untrusted pages must not have a startup path that can crash it because a
+  // third-party CDN hiccuped.
+  //
+  // Same reasoning as vendoring FlashRank's model into the reranker in
+  // v3.25.0: no cold start, no runtime dependency, deterministic.
+  //
+  // Setting ADBLOCK_FILTERS_URL opts back into fetching, for an operator who
+  // wants lists newer than the image. That path keeps the refresh loop; the
+  // baked path has nothing to refresh.
+  const BAKED_LISTS_DIR = "/usr/src/app/adblock/lists";
+  const USE_BAKED = !process.env.ADBLOCK_FILTERS_URL;
+
+  async function buildBlocker() {
+    const { PlaywrightBlocker } = require("@ghostery/adblocker-playwright");
+    const t0 = Date.now();
+
+    if (USE_BAKED) {
+      const fs = require("node:fs");
+      const path = require("node:path");
+      const files = fs
+        .readdirSync(BAKED_LISTS_DIR)
+        .filter((f) => f.endsWith(".txt"))
+        .sort();
+      if (files.length === 0) {
+        // Do not silently run with no filters: that is an adblocker reporting
+        // success while blocking nothing.
+        throw new Error(`no filter lists found in ${BAKED_LISTS_DIR}`);
+      }
+      const text = files
+        .map((f) => fs.readFileSync(path.join(BAKED_LISTS_DIR, f), "utf8"))
+        .join("\n");
+      blocker = PlaywrightBlocker.parse(text);
+      console.log(
+        `[adblock] parsed ${files.length} baked list(s) [${files.join(", ")}] in ${Date.now() - t0}ms`,
+      );
+      return;
+    }
+
+    const fetchImpl =
+      typeof fetch === "function" ? fetch : require("cross-fetch").default;
+    console.log(`[adblock] fetching filter lists: ${FILTER_URLS.join(", ")}`);
+    blocker = await PlaywrightBlocker.fromLists(fetchImpl, FILTER_URLS);
+    console.log(
+      `[adblock] fetched ${FILTER_URLS.length} list(s) in ${Date.now() - t0}ms`,
+    );
+  }
+
+  function startRefreshLoop() {
+    setInterval(() => {
+      buildBlocker().catch((err) => {
+        console.error("[adblock] refresh failed:", err.message || err);
+      });
+    }, REFRESH_MS).unref();
+  }
+
+  // Loading is LAZY — kicked off when something actually requires playwright,
+  // not when this module loads.
+  //
+  // The image's command is `pnpm start`, so NODE_OPTIONS loads this file into
+  // the pnpm process too. Doing real work there is at best wasted (pnpm never
+  // renders a page) and at worst fatal: eagerly requiring the ghostery
+  // package inside pnpm crashed it with an assertion out of its own bundle.
+  // pnpm never requires playwright, so gating on that keeps this hook out of
+  // its way without having to guess at process identity from argv.
+  function ensureBlockerLoading() {
+    if (blockerLoading) return blockerLoading;
+    blockerLoading = buildBlocker()
+      .then(() => {
+        // Nothing to refresh when the lists come from the image.
+        if (!USE_BAKED) startRefreshLoop();
+      })
+      .catch((err) => {
+        console.error("[adblock] initial load failed:", err.message || err);
+        // Keep running. Requests fall through to the upstream handler, which
+        // still applies the SSRF guard and the AD_SERVING_DOMAINS list.
+      });
+    return blockerLoading;
+  }
+
+  // The route handler. See the header: abort() or fallback(), never continue().
+  async function adblockRoute(route) {
+    try {
+      if (!blocker) {
+        // Page created before the filter lists finished loading.
+        await Promise.race([
+          ensureBlockerLoading(),
+          new Promise((r) => setTimeout(r, 5000)),
+        ]).catch(() => {});
+      }
+      if (!blocker) return route.fallback();
+
+      const { fromPlaywrightDetails } = require("@ghostery/adblocker-playwright");
+      const details = route.request();
+      const request = fromPlaywrightDetails(details);
+      if (request.type === "other") request.guessTypeOfRequest();
+
+      // Main-frame navigations are never blocked — matching the library's own
+      // behaviour, and blocking one would break the service outright.
+      const frame = details.frame();
+      if (
+        request.isMainFrame() ||
+        (request.type === "document" &&
+          frame !== null &&
+          frame.parentFrame() === null)
+      ) {
+        return route.fallback();
+      }
+
+      const { match } = blocker.match(request);
+      if (match === true) return route.abort("blockedbyclient");
+      return route.fallback();
+    } catch (err) {
+      // A failure to decide is not a reason to dispatch the request without
+      // the SSRF guard. fallback() hands it to the upstream handler, which is
+      // the safe direction; continue() would be the unsafe one.
+      console.error("[adblock] route handler error:", err.message || err);
+      try {
+        return route.fallback();
+      } catch {
+        /* route already handled */
+      }
+    }
+  }
+
+  const ADBLOCK_ROUTE = Symbol("adblock.contextRouted");
+
+  // Register OUR route immediately after upstream registers its '**/*' guard,
+  // so ours is the more-recent handler and therefore runs first — which is
+  // exactly why ours must fallback() into theirs rather than continue().
+  function patchContext(context) {
+    if (!context || context[ADBLOCK_ROUTE]) return context;
+    const origRoute = context.route.bind(context);
+    context.route = async (pattern, handler, options) => {
+      const result = await origRoute(pattern, handler, options);
+      if (pattern === "**/*" && !context[ADBLOCK_ROUTE]) {
+        context[ADBLOCK_ROUTE] = true;
+        await origRoute("**/*", adblockRoute);
+        console.log("[adblock] context route installed (fallback-chained)");
+      }
+      return result;
+    };
+    return context;
+  }
+
+  function patchBrowser(browser) {
+    if (!browser || browser[ADBLOCK_ROUTE]) return browser;
+    browser[ADBLOCK_ROUTE] = true;
+    const origNewContext = browser.newContext?.bind(browser);
+    if (origNewContext) {
+      browser.newContext = async (...args) =>
+        patchContext(await origNewContext(...args));
+    }
+    return browser;
+  }
+
+  const origRequire = Module.prototype.require;
+  const PATCHED = Symbol("adblock.patched");
+
+  Module.prototype.require = function patchedRequire(id) {
+    const mod = origRequire.apply(this, arguments);
+    if ((id === "playwright" || id === "playwright-core") && mod && !mod[PATCHED]) {
+      mod[PATCHED] = true;
+      // The playwright service is /usr/src/app, NOT /app like the puppeteer one.
+      try {
+        const pkg = require("/usr/src/app/package.json");
+        console.log(
+          `[adblock] playwright required — engaging on playwright-service ${pkg.version}`,
+        );
+      } catch {
+        console.log("[adblock] playwright required — engaging");
+      }
+      ensureBlockerLoading();
+      for (const engine of ["chromium", "firefox", "webkit"]) {
+        const browserType = mod[engine];
+        if (!browserType || typeof browserType.launch !== "function") continue;
+        const origLaunch = browserType.launch.bind(browserType);
+        browserType.launch = async (...args) =>
+          patchBrowser(await origLaunch(...args));
+      }
+    }
+    return mod;
+  };
+}

--- a/docker/playwright-adblock/package-lock.json
+++ b/docker/playwright-adblock/package-lock.json
@@ -1,0 +1,210 @@
+{
+  "name": "playwright-adblock",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "playwright-adblock",
+      "version": "1.0.0",
+      "dependencies": {
+        "@ghostery/adblocker-playwright": "^2.3.0",
+        "cross-fetch": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ghostery/adblocker": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.18.2.tgz",
+      "integrity": "sha512-x6zEkf1dHSN0t4ExLmuN6nIgH0oAi6laoKe5yGsiIB4jkEvutea1PJgxgRUIjWfNbDRmkf4GjUtuqQFZgvQG1w==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ghostery/adblocker-content": "^2.18.2",
+        "@ghostery/adblocker-extended-selectors": "^2.18.2",
+        "@ghostery/url-parser": "^1.3.1",
+        "@remusao/guess-url-type": "^2.1.0",
+        "@remusao/small": "^2.1.0",
+        "@remusao/smaz": "^2.2.0",
+        "tldts-experimental": "^7.4.9"
+      }
+    },
+    "node_modules/@ghostery/adblocker-content": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.18.2.tgz",
+      "integrity": "sha512-TOe/b4KOBFEc9OjLG+wvgamGcSTIPSDBAL5YSa8lzjBsoSl8IDnfOjeJDldlLacsC/JEUMLkZIDDNknEolJVqg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ghostery/adblocker-extended-selectors": "^2.18.2"
+      }
+    },
+    "node_modules/@ghostery/adblocker-extended-selectors": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.18.2.tgz",
+      "integrity": "sha512-doKNShBk3+czQL08UkrysHkCPeG/kNPlXvz3DH7SXxD9Y78ovWkEAhjeR+upoan3fomJJuK3dD+IrlofnjckYw==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@ghostery/adblocker-playwright": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-playwright/-/adblocker-playwright-2.18.2.tgz",
+      "integrity": "sha512-5rbO7GZ9nO0t0ATzAmeYL9cJlaVl3oI85NRBac3AEJoRkknWZ05OdlZsleMr7TziB2uK9rMySCyV9lDO6bQNBA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ghostery/adblocker": "^2.18.2",
+        "@ghostery/adblocker-content": "^2.18.2",
+        "tldts-experimental": "^7.4.9"
+      },
+      "peerDependencies": {
+        "playwright": "^1.x"
+      }
+    },
+    "node_modules/@ghostery/url-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/url-parser/-/url-parser-1.3.1.tgz",
+      "integrity": "sha512-QKqGi+7aDQ4RcyHyCwgEk6B9vWnsBP4Q7htaN0zPJV3ATqTKEQDtSTb9c/AN586oJUDs24YXKcwFYwNweY/YjQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "tldts-experimental": "^7.0.8"
+      }
+    },
+    "node_modules/@remusao/guess-url-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/guess-url-type/-/guess-url-type-2.1.0.tgz",
+      "integrity": "sha512-zI3dlTUxpjvx2GCxp9nLOSK5yEIqDCpxlAVGwb2Y49RKkS72oeNaxxo+VWS5+XQ5+Mf8Zfp9ZXIlk+G5eoEN8A==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@remusao/small": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/small/-/small-2.1.0.tgz",
+      "integrity": "sha512-Y1kyjZp7JU7dXdyOdxHVNfoTr1XLZJTyQP36/esZUU/WRWq9XY0PV2HsE3CsIHuaTf4pvgWv2pvzvnZ//UHIJQ==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@remusao/smaz": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz/-/smaz-2.2.0.tgz",
+      "integrity": "sha512-eSd3Qs0ELP/e7tU1SI5RWXcCn9KjDgvBY+KtWbL4i2QvvHhJOfdIt4v0AA3S5BbLWAr5dCEC7C4LUfogDm6q/Q==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@remusao/smaz-compress": "^2.2.0",
+        "@remusao/smaz-decompress": "^2.2.0"
+      }
+    },
+    "node_modules/@remusao/smaz-compress": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz-compress/-/smaz-compress-2.2.0.tgz",
+      "integrity": "sha512-TXpTPgILRUYOt2rEe0+9PC12xULPvBqeMpmipzB9A7oM4fa9Ztvy9lLYzPTd7tiQEeoNa1pmxihpKfJtsxnM/w==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@remusao/trie": "^2.1.0"
+      }
+    },
+    "node_modules/@remusao/smaz-decompress": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz-decompress/-/smaz-decompress-2.2.0.tgz",
+      "integrity": "sha512-ERAPwxPaA0/yg4hkNU7T2S+lnp9jj1sApcQMtOyROvOQyo+Zuh6Hn/oRcXr8mmjlYzyRaC7E6r3mT1nrdHR6pg==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@remusao/trie": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/trie/-/trie-2.1.0.tgz",
+      "integrity": "sha512-Er3Q8q0/2OcCJPQYJOPLmCuqO0wu7cav3SPtpjlxSbjFi1x+A1pZkkLD6c9q2rGEkGW/tkrRzfrhNMt8VQjzXg==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "license": "MIT"
+    },
+    "node_modules/tldts-experimental": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.11.tgz",
+      "integrity": "sha512-xbNzxktqwNYSryb4FclztEZ+G5waTnMCVBnwoWD1Fq0gjOykgr0rQWe4/2TdIJYHbyjIol5pdNh7OmCRWxIltw==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/docker/playwright-adblock/package.json
+++ b/docker/playwright-adblock/package.json
@@ -1,0 +1,1 @@
+{ "name": "playwright-adblock", "private": true }

--- a/docker/playwright-adblock/package.json
+++ b/docker/playwright-adblock/package.json
@@ -1,1 +1,14 @@
-{ "name": "playwright-adblock", "private": true }
+{
+  "name": "playwright-adblock",
+  "version": "1.0.0",
+  "private": true,
+  "description": "EasyList/EasyPrivacy layer for Firecrawl v2's playwright-service",
+  "type": "commonjs",
+  "dependencies": {
+    "@ghostery/adblocker-playwright": "^2.3.0",
+    "cross-fetch": "^4.1.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/docker/playwright-adblock/verify-ssrf-guard.sh
+++ b/docker/playwright-adblock/verify-ssrf-guard.sh
@@ -19,7 +19,11 @@
 # to a test that works.
 #
 # Usage:  ./verify-ssrf-guard.sh [image-tag]
-set -uo pipefail
+# -e is on, so the two `grep -c` calls below are explicitly guarded: grep exits
+# 1 when it matches nothing, and "matches nothing" is the EXPECTED result for
+# the regression build. Without the guard, -e would abort the script at exactly
+# the moment the control succeeds.
+set -euo pipefail
 
 IMAGE="${1:-playwright-adblock:verify}"
 NET=pwverify-net
@@ -68,7 +72,8 @@ probe() {
     "http://$name:3003/scrape" -o /dev/null -w '%{http_code}' > "$WORK/$name.http"
   sleep 3
   docker logs "$name" 2>&1 | grep -cE '^(doubleclick\.net|googletagservices\.com|adnxs\.com)$' \
-    > "$WORK/$name.markers"
+    > "$WORK/$name.markers" || true
+  [ -s "$WORK/$name.markers" ] || echo 0 > "$WORK/$name.markers"
   docker rm -f "$name" >/dev/null 2>&1
 }
 

--- a/docker/playwright-adblock/verify-ssrf-guard.sh
+++ b/docker/playwright-adblock/verify-ssrf-guard.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Acceptance test for docker/playwright-adblock.
+#
+# THE ASSERTION THAT MATTERS IS NOT "ARE ADS BLOCKED".
+#
+# init-adblock.js registers a context route in front of Firecrawl's in-browser
+# SSRF guard. Playwright runs handlers in reverse registration order, and
+# route.continue() dispatches without invoking the remaining handlers — so an
+# adblock handler that calls continue() silently deletes assertSafeTargetUrl.
+# Ads still get blocked. Pages still render. /scrape still returns 200.
+#
+# This script therefore asserts that UPSTREAM's handler still executes, by
+# looking for the bare hostname it logs when its AD_SERVING_DOMAINS check
+# fires. That check sits after assertSafeTargetUrl in the same handler, so
+# observing it proves the guard ran.
+#
+# It also builds a deliberately broken variant and asserts the signal
+# DISAPPEARS — without that control, a test that always passes looks identical
+# to a test that works.
+#
+# Usage:  ./verify-ssrf-guard.sh [image-tag]
+set -uo pipefail
+
+IMAGE="${1:-playwright-adblock:verify}"
+NET=pwverify-net
+SITE=pwverify-site
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'docker rm -f "$SITE" pwverify-fixed pwverify-regress >/dev/null 2>&1;
+      docker network rm "$NET" >/dev/null 2>&1;
+      docker rmi -f "${IMAGE}-REGRESSION" >/dev/null 2>&1;
+      rm -rf "$WORK"' EXIT
+
+echo "==> building $IMAGE"
+docker build -q -t "$IMAGE" "$HERE" >/dev/null || { echo "FAIL: build"; exit 1; }
+
+echo "==> building the regression variant (fallback -> continue)"
+cp -r "$HERE" "$WORK/regress"
+sed -i 's/return route\.fallback();/return route.continue();/g' "$WORK/regress/init-adblock.js"
+grep -q 'return route.continue();' "$WORK/regress/init-adblock.js" \
+  || { echo "FAIL: regression variant did not apply — the control is not testing anything"; exit 1; }
+docker build -q -t "${IMAGE}-REGRESSION" "$WORK/regress" >/dev/null || { echo "FAIL: regression build"; exit 1; }
+
+docker network create "$NET" >/dev/null 2>&1
+mkdir -p "$WORK/site"
+cat > "$WORK/site/index.html" <<'HTML'
+<!doctype html><html><head><title>adblock probe</title></head><body>
+<script src="https://doubleclick.net/marker.js"></script>
+<script src="https://googletagservices.com/marker.js"></script>
+<script src="https://adnxs.com/marker.js"></script>
+</body></html>
+HTML
+docker run -d --name "$SITE" --network "$NET" -v "$WORK/site:/usr/share/nginx/html:ro" nginx:alpine >/dev/null
+sleep 3
+
+# ALLOW_LOCAL_WEBHOOKS=true so the locally served probe page passes the
+# top-level URL check at api.ts:400. That check is separate from the route
+# handler under test; without this the page could not be served at all, since
+# any host reachable from here resolves to a private address.
+probe() {
+  local image="$1" name="$2"
+  docker rm -f "$name" >/dev/null 2>&1
+  docker run -d --name "$name" --network "$NET" -e ALLOW_LOCAL_WEBHOOKS=true "$image" >/dev/null
+  sleep 25
+  docker run --rm --network "$NET" curlimages/curl:latest -s -m 90 -X POST \
+    -H 'Content-Type: application/json' \
+    -d "{\"url\":\"http://$SITE/\",\"wait_after_load\":4000}" \
+    "http://$name:3003/scrape" -o /dev/null -w '%{http_code}' > "$WORK/$name.http"
+  sleep 3
+  docker logs "$name" 2>&1 | grep -cE '^(doubleclick\.net|googletagservices\.com|adnxs\.com)$' \
+    > "$WORK/$name.markers"
+  docker rm -f "$name" >/dev/null 2>&1
+}
+
+probe "$IMAGE" pwverify-fixed
+probe "${IMAGE}-REGRESSION" pwverify-regress
+
+fixed_http=$(cat "$WORK/pwverify-fixed.http")
+fixed_markers=$(cat "$WORK/pwverify-fixed.markers")
+regress_http=$(cat "$WORK/pwverify-regress.http")
+regress_markers=$(cat "$WORK/pwverify-regress.markers")
+
+echo
+printf 'shipped build     : HTTP %s, upstream-handler markers = %s\n' "$fixed_http" "$fixed_markers"
+printf 'regression build  : HTTP %s, upstream-handler markers = %s\n' "$regress_http" "$regress_markers"
+echo
+
+rc=0
+[ "$fixed_http" = "200" ] || { echo "FAIL: shipped build did not scrape successfully"; rc=1; }
+[ "$fixed_markers" -ge 1 ] || { echo "FAIL: upstream handler did NOT run — the SSRF guard is bypassed"; rc=1; }
+[ "$regress_markers" -eq 0 ] || { echo "FAIL: control did not reproduce the bypass — this test cannot detect the regression"; rc=1; }
+
+# Both builds returning 200 is the point, not an accident: it is why a
+# functional test cannot substitute for this one.
+[ "$regress_http" = "200" ] || echo "NOTE: regression build returned $regress_http, not 200"
+
+[ $rc -eq 0 ] && echo "PASS: SSRF guard still executes with the adblocker loaded, and the control proves this test can fail."
+exit $rc

--- a/docker/puppeteer-adblock/README.md
+++ b/docker/puppeteer-adblock/README.md
@@ -1,3 +1,14 @@
+> **⚠ This targets the v1 renderer only.**
+>
+> This image layers adblocking onto `trieve/puppeteer-service-ts`, the renderer
+> used by **firecrawl-simple / Firecrawl v1**. searxng-mcp defaults to
+> `FIRECRAWL_API_VERSION=v2`, whose renderer is
+> `ghcr.io/firecrawl/playwright-service` — see **`docker/playwright-adblock/`**
+> for that one.
+>
+> Kept for adopters still on the v1 path. If you are on v2, this directory does
+> nothing for you (vikunja#696).
+
 # puppeteer-adblock
 
 Docker image that layers `@ghostery/adblocker-puppeteer` (EasyList + EasyPrivacy)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tadmstr/searxng-mcp",
-  "version": "3.25.1",
+  "version": "3.26.0",
   "description": "MCP server for SearXNG — private web search for Claude Code",
   "main": "build/src/index.js",
   "bin": {

--- a/tests/compose-namespace.test.ts
+++ b/tests/compose-namespace.test.ts
@@ -44,7 +44,10 @@ describe("compose files cannot collide with another stack on the host", () => {
     // A guard that silently scans nothing is worse than no guard. If this
     // number changes, the new file needs the two assertions below applied to
     // it deliberately — update the count in the same commit.
-    expect(files.length).toBe(3);
+    //
+    // 3 -> 4 in v3.26.0: docker/adblock-proxy/docker-compose.yml was added for
+    // standalone use. It went red here first, which is the guard working.
+    expect(files.length).toBe(4);
   });
 
   it.each(


### PR DESCRIPTION
**Replaces #38**, which GitHub closed when its base branch (#37's) was deleted after merge — a stacked PR gets closed, not retargeted. Same branch, rebased onto `main` with the already-merged commits dropped; identical diffstat (20 files, +1430/−31). Now based on `main`, so **CI actually runs** — `ci.yml` triggers on `pull_request: branches: [main]`, which is why #38 never ran a single check.

Post-audit. Security filed **0 critical, 0 high, 0 medium; 1 low, 2 info** — the LOW is remediated in this branch, both INFOs carry the audit's own "no action" recommendation.

---

## Phase 6 — tier-1 adblocking for the renderer we actually run (#696)

`docker/puppeteer-adblock/` targets the **v1** renderer. This repo defaults to `FIRECRAWL_API_VERSION=v2`, whose renderer is `ghcr.io/firecrawl/playwright-service` — so on every v2 deployment, tier-1 adblocking was **absent**. An upgrade of upstream's `AD_SERVING_DOMAINS` token list, not a new feature; that list still applies underneath.

### Using the library the obvious way *is* the vulnerability

Upstream registers a context route running `assertSafeTargetUrl` before its ad check, ending in `route.continue()`. Playwright runs handlers in **reverse registration order**, and `continue()` dispatches without invoking the rest — so a handler registered after it runs **first**, and `continue()` there means the SSRF guard never executes.

`@ghostery/adblocker-playwright`'s own `enableBlockingInPage()` does exactly that: `page.route('**/*')` (page routes outrank context routes) with `route.continue()` for every non-blocked request. Verified against 2.18.2's compiled source. So the hook reuses the library's *matching* via `fromPlaywrightDetails()` + `match()` while keeping the disposition. Every path ends in `abort()` or `fallback()`.

### The acceptance test is not "are ads blocked"

| build | `/scrape` | upstream handler ran? |
|---|---|---|
| shipped (`fallback`) | HTTP 200 | yes |
| regression (`continue`) | HTTP 200 | **no — guard gone** |

Both return 200, both render, both block ads. `verify-ssrf-guard.sh` builds the broken variant itself and fails if the signal doesn't disappear.

Security's verdict: *"the mitigation is real, not just documented as real."*

### Four defects found by running it

1. **An env-var re-entry guard is inherited by child processes.** `pnpm start` spawns `node dist/api.js`; the hook installed in the parent, set the var, and the real server **skipped installing**. Container started, logged `loaded 2 list(s)`, blocked nothing. Now a per-process global.
2. Loading is lazy — eagerly requiring the ghostery package inside `pnpm` crashed pnpm.
3. **Filter lists baked into the image.** Fetching at startup killed the service: undici threw `AssertionError: assert(!this.paused)` from inside its parser — async, past any `.catch()`.
4. `ADBLOCK_FILTERS_URL` is no longer an image default — as the opt-in for runtime fetching, setting it as a default meant the baked lists were never used.

## Phase 7 — publish the last two images (#697)

`adblock-proxy` was the last stack component without a published image. `docker-compose.full.yml` now pulls it; `docker/adblock-proxy/docker-compose.yml` added for standalone use with a pinned `name:` and no `container_name:`. The Phase 1 compose-namespace test **caught the addition** — it asserts the file count, so the fourth file went red until the invariants were applied.

### The smoke test was wrong in its first draft, in this release's own failure mode

It used a local nginx origin and `http://doubleclick.net/ad.js`. Both are refused by `ssrf.js` — the origin resolves private, and this host's resolver blackholes ad domains to `::`. **Both returned zero bytes, so the assertion passed for every URL, blocked or not.** Caught by asking why the negative control also returned zero. The shipped version uses a public origin asserting a non-zero body, a URL EasyList actually matches, and asserts **which mechanism the log reports**.

## Audit remediation (LOW)

Both `docker/` sub-projects were outside the pnpm workspace, so `pnpm audit --prod` never saw them — while both build into published images, one an unauthenticated forward proxy.

Both now commit a lockfile and build with `npm ci`. That also closes a reproducibility gap the audit didn't raise: the caret ranges re-resolved every build, so two builds of the same commit could produce different trees — weakening the provenance attestation these images publish. Pinned at `@ghostery/adblocker` 2.18.2. CI gains a **third** audit step, separate from `--prod`/`--dev` for the same reason those two are separate.

Verified capable of failing: injecting lockfile drift makes `npm ci` exit 1 with `Missing: left-pad@1.3.0`.

**Two things caught while applying it, either of which would have made the fix a no-op:** `.gitignore` ignores `package-lock.json` (pnpm repo), silently swallowing both lockfiles — negations added; and `COPY` creates its destination as root while the image runs as uid 1000, so `npm ci` failed `EACCES` — `--chown` added.

## Verification

- 992 tests, tsc clean, lint clean, all four compose files valid
- `npm audit` 0 vulnerabilities in both sub-projects
- Both images rebuilt from the changed Dockerfiles; `verify-ssrf-guard.sh` passes with its control intact
- Rebase verified content-identical to the audited tree

## Limits, unchanged from the audited version

- Full Firecrawl wiring after the 3000 → 3003 renderer swap is **not** verified end-to-end (no API keys here); the container builds, starts and engages from the compose file
- `read_only` on `kiwix`/`firecrawl-api`/the renderer — could not start those here
- `docker/adblock-proxy/proxy.js` still fetches filter lists at runtime (vikunja#701)

🤖 Generated with [Claude Code](https://claude.com/claude-code)